### PR TITLE
Add support for slots with resolveFields

### DIFF
--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -232,6 +232,10 @@ function AutoFieldInternal<
     );
   }
 
+  if (!defaultFields[field.type]) {
+    throw new Error(`Unsupported field type: ${field.type}`);
+  }
+
   const children = defaultFields[field.type](mergedProps);
 
   const Render = render[field.type] as (props: FieldProps) => ReactElement;

--- a/packages/core/lib/__tests__/resolve-component-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-component-data.spec.tsx
@@ -1,4 +1,4 @@
-import { resolveComponentData } from "../resolve-component-data";
+import { resolveComponentData, cache } from "../resolve-component-data";
 import { createAppStore } from "../../store";
 import { Config, Fields } from "../../types";
 import { toComponent } from "../data/to-component";
@@ -93,6 +93,7 @@ const config: Config = {
 describe("resolveComponentData", () => {
   beforeEach(() => {
     appStore.setState({ ...appStore.getInitialState(), config }, true);
+    cache.lastChange = {};
   });
 
   it("should run resolvers for every node in the tree", async () => {

--- a/packages/core/lib/__tests__/resolve-fields.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-fields.spec.tsx
@@ -1,0 +1,244 @@
+import { resolveFields, cache } from "../resolve-fields";
+import { Config, Fields } from "../../types";
+import { defaultAppState } from "../../store";
+import { walkAppState } from "../data/walk-app-state";
+
+const myComponentFields: Fields = {
+  prop: { type: "text" },
+  slot: {
+    type: "slot",
+  },
+  object: {
+    type: "object",
+    objectFields: {
+      slot: {
+        type: "slot",
+      },
+    },
+  },
+};
+
+const rootResolverMock = jest.fn((...args) => null);
+const componentResolverMock = jest.fn((...args) => null);
+
+const config: Config = {
+  root: {
+    fields: {
+      title: { type: "text" },
+      object: { type: "object", objectFields: { slot: { type: "slot" } } },
+      slot: { type: "slot" },
+      array: {
+        type: "array",
+        arrayFields: {
+          slot: {
+            type: "slot",
+          },
+        },
+      },
+    },
+    resolveFields: (...args) => {
+      rootResolverMock(...args);
+
+      return {
+        resolved: { type: "text" },
+      };
+    },
+  },
+  components: {
+    MyComponentWithResolver: {
+      fields: myComponentFields,
+      resolveFields: (...args) => {
+        componentResolverMock(...args);
+
+        return {
+          resolved: { type: "text" },
+        };
+      },
+      render: () => <div />,
+    },
+    MyComponentWithoutResolver: {
+      fields: myComponentFields,
+      render: () => <div />,
+    },
+  },
+};
+
+describe("resolveFields", () => {
+  afterEach(() => {
+    rootResolverMock.mockClear();
+    componentResolverMock.mockClear();
+    cache.lastChange = {};
+  });
+
+  it("returns default fields if no resolver is defined", async () => {
+    const config: Config = {
+      components: {
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: () => <div />,
+        },
+      },
+    };
+
+    const fields = await resolveFields(
+      { type: "Heading", props: { id: "Heading-1" } },
+      config,
+      defaultAppState
+    );
+
+    expect(fields).toEqual({
+      data: { title: { type: "text" } },
+      didChange: true,
+    });
+  });
+
+  it("should run resolvers for every node in the tree", async () => {
+    const onResolveStart = jest.fn(() => null);
+    const onResolveEnd = jest.fn(() => null);
+
+    const componentItem = {
+      type: "MyComponentWithResolver",
+      props: { id: "slotted" },
+    };
+
+    const rootItem = {
+      type: "root",
+      props: {
+        id: "root",
+        slot: [componentItem],
+      },
+    };
+    await resolveFields(
+      rootItem,
+      config,
+      defaultAppState,
+      {},
+      onResolveStart,
+      onResolveEnd
+    );
+
+    expect(rootResolverMock).toHaveBeenCalled();
+    expect(componentResolverMock).toHaveBeenCalled();
+
+    expect(onResolveStart).toHaveBeenCalledWith(rootItem);
+    expect(onResolveStart).toHaveBeenCalledWith(componentItem);
+
+    expect(onResolveEnd).toHaveBeenCalledWith(rootItem, {
+      data: {
+        resolved: { type: "text" },
+      },
+      didChange: true,
+    });
+    expect(onResolveEnd).toHaveBeenCalledWith(componentItem, {
+      data: {
+        resolved: { type: "text" },
+      },
+      didChange: true,
+    });
+  });
+
+  it("should run child resolvers even if parent doesn't have one", async () => {
+    const onResolveStart = jest.fn(() => null);
+    const onResolveEnd = jest.fn(() => null);
+
+    const componentItem = {
+      type: "MyComponentWithResolver",
+      props: { id: "slotted" },
+    };
+
+    const rootItem = {
+      type: "root",
+      props: {
+        id: "root",
+        slot: [componentItem],
+      },
+    };
+
+    const newConfig = {
+      ...config,
+      root: { ...config.root, resolveFields: undefined },
+    };
+
+    await resolveFields(
+      rootItem,
+      newConfig,
+      defaultAppState,
+      {},
+      onResolveStart,
+      onResolveEnd
+    );
+
+    expect(rootResolverMock).not.toHaveBeenCalled();
+    expect(componentResolverMock).toHaveBeenCalled();
+  });
+
+  it("should not re-run when node doesn't change", async () => {
+    const onResolveStart = jest.fn(() => null);
+    const onResolveEnd = jest.fn(() => null);
+
+    const rootItem = {
+      type: "root",
+      props: {
+        id: "root",
+        slot: [],
+      },
+    };
+
+    await resolveFields(
+      rootItem,
+      config,
+      defaultAppState,
+      {},
+      onResolveStart,
+      onResolveEnd
+    );
+
+    expect(rootResolverMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should provide the parent node", async () => {
+    const componentItem = {
+      type: "MyComponentWithResolver",
+      props: { id: "slotted" },
+    };
+
+    const root = {
+      type: "root",
+      props: {
+        id: "root",
+        slot: [componentItem],
+      },
+    };
+
+    await resolveFields(
+      root,
+      config,
+      walkAppState(
+        { ...defaultAppState, data: { ...defaultAppState.data, root } },
+        config
+      ),
+      {}
+    );
+
+    const { lastCall } = componentResolverMock.mock;
+
+    const returned = lastCall ? lastCall[1] : null;
+
+    expect(returned.parent).toMatchInlineSnapshot(`
+      {
+        "props": {
+          "id": "root",
+          "slot": [
+            {
+              "props": {
+                "id": "slotted",
+              },
+              "type": "MyComponentWithResolver",
+            },
+          ],
+        },
+        "type": "root",
+      }
+    `);
+  });
+});

--- a/packages/core/lib/get-config.ts
+++ b/packages/core/lib/get-config.ts
@@ -1,0 +1,10 @@
+import { ComponentData, Config, RootData } from "../types";
+import { toComponent } from "./data/to-component";
+
+export const getConfig = (item: ComponentData | RootData, config: Config) => {
+  const componentItem = toComponent(item);
+
+  return componentItem.type !== "root"
+    ? config.components[componentItem.type]
+    : config.root;
+};

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -2,12 +2,13 @@ import {
   ComponentData,
   Config,
   Metadata,
-  ResolveDataTrigger,
+  ResolverTrigger,
   RootDataWithProps,
 } from "../types";
 import { mapSlots } from "./data/map-slots";
 import { getChanged } from "./get-changed";
 import fdeq from "fast-deep-equal";
+import { getConfig } from "./get-config";
 
 export const cache: {
   lastChange: Record<string, any>;
@@ -21,12 +22,9 @@ export const resolveComponentData = async <
   metadata: Metadata = {},
   onResolveStart?: (item: T) => void,
   onResolveEnd?: (item: T) => void,
-  trigger: ResolveDataTrigger = "replace"
+  trigger: ResolverTrigger = "replace"
 ) => {
-  const configForItem =
-    "type" in item && item.type !== "root"
-      ? config.components[item.type]
-      : config.root;
+  const configForItem = getConfig(item, config);
 
   const resolvedItem: T = {
     ...item,

--- a/packages/core/lib/resolve-fields.ts
+++ b/packages/core/lib/resolve-fields.ts
@@ -1,0 +1,118 @@
+import {
+  AppState,
+  ComponentData,
+  Config,
+  Fields,
+  Metadata,
+  ResolverTrigger,
+  RootDataWithProps,
+} from "../types";
+import { mapSlots } from "./data/map-slots";
+import { getChanged } from "./get-changed";
+import fdeq from "fast-deep-equal";
+import { getConfig } from "./get-config";
+import { AppStore } from "../store";
+import { makeStatePublic } from "./data/make-state-public";
+import { PrivateAppState } from "../types/Internal";
+
+export const cache: {
+  lastChange: Record<string, any>;
+} = { lastChange: {} };
+
+export const resolveFields = async <
+  T extends ComponentData | RootDataWithProps,
+  ReturnType extends {
+    data: Fields<T["props"]> | undefined;
+    didChange: boolean;
+  }
+>(
+  item: T,
+  config: Config,
+  state: PrivateAppState,
+  metadata: Metadata = {},
+  onResolveStart?: (item: T) => void,
+  onResolveEnd?: (item: T, fields: ReturnType) => void,
+  trigger: ResolverTrigger = "replace"
+): Promise<ReturnType> => {
+  const parentId = state.indexes.nodes[item.props.id]?.parentId;
+  const parent = parentId ? state.indexes.nodes[parentId].data : null;
+  const configForItem = getConfig(item, config);
+
+  let newFields = configForItem?.fields;
+
+  const shouldRunResolver = configForItem?.resolveFields && item.props;
+
+  const id = "id" in item.props ? item.props.id : "root";
+
+  if (shouldRunResolver) {
+    const { item: oldItem = null, resolved = {} } = cache.lastChange[id] || {};
+
+    if (item && fdeq(item, oldItem)) {
+      return { data: resolved, didChange: false } as ReturnType;
+    }
+
+    const changed = getChanged(item, oldItem) as any;
+
+    if (onResolveStart) {
+      onResolveStart(item);
+    }
+
+    newFields = await configForItem.resolveFields!(item, {
+      changed,
+      lastData: oldItem,
+      fields: configForItem.fields ?? {},
+      lastFields: resolved,
+      appState: makeStatePublic(state),
+      parent,
+      // TODO implement for consistency
+      // metadata: { ...metadata, ...configForItem.metadata },
+      // trigger,
+    });
+  }
+
+  await mapSlots(
+    item,
+    async (content, parentId) => {
+      await Promise.all(
+        content.map(
+          async (childItem) =>
+            (
+              await resolveFields(
+                childItem as T,
+                config,
+                state,
+                metadata,
+                onResolveStart,
+                onResolveEnd,
+                trigger
+              )
+            ).data
+        )
+      );
+      return content;
+    },
+
+    config
+  );
+
+  const didChange = !fdeq(cache.lastChange[id]?.resolved, newFields);
+
+  const response = {
+    data: newFields,
+    didChange,
+  } as ReturnType;
+
+  if (shouldRunResolver && onResolveEnd) {
+    onResolveEnd(item, response);
+  }
+
+  cache.lastChange[id] = {
+    item: item,
+    resolved: newFields,
+  };
+
+  return {
+    data: newFields,
+    didChange,
+  } as ReturnType;
+};

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -11,7 +11,7 @@ import {
   Metadata,
   ComponentData,
   RootDataWithProps,
-  ResolveDataTrigger,
+  ResolverTrigger,
 } from "../types";
 import { createReducer, PuckAction } from "../reducer";
 import { getItem } from "../lib/data/get-item";
@@ -63,7 +63,7 @@ export type AppStore<
   pendingLoadTimeouts: Record<string, NodeJS.Timeout>;
   resolveComponentData: <T extends ComponentData | RootDataWithProps>(
     componentData: T,
-    trigger: ResolveDataTrigger
+    trigger: ResolverTrigger
   ) => Promise<{ node: T; didChange: boolean }>;
   resolveAndCommitData: () => void;
   plugins: Plugin[];
@@ -87,7 +87,7 @@ export type AppStore<
 
 export type AppStoreApi = StoreApi<AppStore>;
 
-const defaultPageFields: Record<string, Field> = {
+export const defaultPageFields: Record<string, Field> = {
   title: { type: "text" },
 };
 

--- a/packages/core/store/slices/fields.ts
+++ b/packages/core/store/slices/fields.ts
@@ -1,28 +1,82 @@
 import { ComponentData } from "../../types";
-import type { Fields } from "../../types";
-import { AppStore, useAppStoreApi } from "../";
+import type { Fields, ResolverTrigger, RootDataWithProps } from "../../types";
+import { AppStore, defaultPageFields, useAppStoreApi } from "../";
 import { useCallback, useEffect } from "react";
-import { getChanged } from "../../lib/get-changed";
-import { makeStatePublic } from "../../lib/data/make-state-public";
-
-type ComponentOrRootData = Omit<ComponentData<any>, "type">;
+import { resolveFields } from "../../lib/resolve-fields";
+import { getConfig } from "../../lib/get-config";
 
 export type FieldsSlice = {
-  fields: Fields | Partial<Fields>;
-  loading: boolean;
-  lastResolvedData: Partial<ComponentOrRootData>;
-  id: string | undefined;
+  resolved: Record<string, Fields>;
+  resolveFields: <T extends ComponentData | RootDataWithProps>(
+    componentData: T,
+    trigger: ResolverTrigger
+  ) => Promise<{ data: Fields; didChange: boolean }>;
+  resolveAllFields: () => void;
+  get: () => Fields;
 };
 
 export const createFieldsSlice = (
-  _set: (newState: Partial<AppStore>) => void,
-  _get: () => AppStore
+  set: (newState: Partial<AppStore>) => void,
+  get: () => AppStore
 ): FieldsSlice => {
   return {
-    fields: {},
-    loading: false,
-    lastResolvedData: {},
-    id: undefined,
+    resolved: {},
+    resolveFields: async (componentData, trigger) => {
+      const { metadata, setComponentLoading, config, state } = get();
+
+      const timeouts: Record<string, () => void> = {};
+
+      return await resolveFields(
+        componentData,
+        config,
+        state,
+        metadata,
+        (item) => {
+          const id = "id" in item.props ? item.props.id : "root";
+          timeouts[id] = setComponentLoading(id, true, 50);
+        },
+        async (item, resolvedFields) => {
+          const id = "id" in item.props ? item.props.id : "root";
+
+          const fields = get().fields;
+
+          if (resolvedFields.didChange) {
+            set({
+              fields: {
+                ...fields,
+                resolved: {
+                  ...fields.resolved,
+                  [item.props.id]: resolvedFields.data,
+                },
+              },
+            });
+          }
+
+          timeouts[id]();
+        },
+        trigger
+      );
+    },
+    resolveAllFields: () => {},
+    get: () => {
+      const s = get();
+
+      const item = s.selectedItem;
+
+      if (item) {
+        const config = s.config;
+        const componentConfig = getConfig(item, config);
+
+        const resolvedFields =
+          s.fields.resolved[item.props.id] ?? componentConfig?.fields ?? {};
+
+        return resolvedFields;
+      }
+
+      return (
+        s.fields.resolved["root"] ?? s.config.root?.fields ?? defaultPageFields
+      );
+    },
   };
 };
 
@@ -30,81 +84,16 @@ export const useRegisterFieldsSlice = (
   appStore: ReturnType<typeof useAppStoreApi>,
   id?: string
 ) => {
-  const resolveFields = useCallback(
-    async (reset?: boolean) => {
-      const { fields, lastResolvedData } = appStore.getState().fields;
-      const nodes = appStore.getState().state.indexes.nodes;
-      const node = nodes[id || "root"];
-      const componentData = node?.data;
-      const parentNode = node?.parentId ? nodes[node.parentId] : null;
-      const parent = parentNode?.data || null;
+  const resolveFields = useCallback(async () => {
+    const fields = appStore.getState().fields;
+    const nodes = appStore.getState().state.indexes.nodes;
+    const node = nodes[id || "root"];
+    const componentData = node?.data;
 
-      const { getComponentConfig, state } = appStore.getState();
-
-      const componentConfig = getComponentConfig(componentData?.type);
-
-      if (!componentData || !componentConfig) return;
-
-      const defaultFields = componentConfig.fields || {};
-      const resolver = componentConfig.resolveFields;
-      let lastFields: Fields | null = fields as Fields;
-
-      if (reset) {
-        appStore.setState((s) => ({
-          fields: { ...s.fields, fields: defaultFields, id },
-        }));
-
-        lastFields = defaultFields;
-      }
-
-      if (resolver) {
-        const timeout = setTimeout(() => {
-          appStore.setState((s) => ({
-            fields: { ...s.fields, loading: true },
-          }));
-        }, 50);
-
-        const lastData =
-          lastResolvedData.props?.id === id ? lastResolvedData : null;
-
-        const changed = getChanged(componentData, lastData);
-
-        const newFields = await resolver(componentData, {
-          changed,
-          fields: defaultFields,
-          lastFields,
-          lastData: lastData as ComponentOrRootData,
-          appState: makeStatePublic(state),
-          parent,
-        });
-
-        clearTimeout(timeout);
-
-        // Abort if item has changed during resolution (happens with history)
-        if (appStore.getState().selectedItem?.props.id !== id) {
-          return;
-        }
-
-        appStore.setState({
-          fields: {
-            fields: newFields,
-            loading: false,
-            lastResolvedData: componentData,
-            id,
-          },
-        });
-      } else {
-        appStore.setState((s) => ({
-          fields: { ...s.fields, fields: defaultFields, id },
-        }));
-      }
-    },
-    [id]
-  );
+    fields.resolveFields(componentData, "replace");
+  }, [id]);
 
   useEffect(() => {
-    resolveFields(true);
-
     return appStore.subscribe(
       (s) => s.state.indexes.nodes[id || "root"],
       () => resolveFields()

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -19,7 +19,7 @@ export type PuckComponent<Props> = (
   >
 ) => JSX.Element;
 
-export type ResolveDataTrigger = "insert" | "replace" | "load" | "force";
+export type ResolverTrigger = "insert" | "replace" | "load" | "force";
 
 type WithPartialProps<T, Props extends DefaultComponentProps> = Omit<
   T,
@@ -56,7 +56,7 @@ export type ComponentConfig<
       changed: Partial<Record<keyof FieldProps, boolean> & { id: string }>;
       lastData: DataShape | null;
       metadata: Metadata;
-      trigger: ResolveDataTrigger;
+      trigger: ResolverTrigger;
     }
   ) =>
     | Promise<WithPartialProps<DataShape, FieldProps>>


### PR DESCRIPTION
Slots are not expected to support `resolveFields` as part of 0.19, but workarounds exist for most common use-cases. This decision is to avoid delays releasing the slots API.

This is because `resolveFields` is transient, only triggering to resolve the fields for the current component. Once the component is changed, that state is lost.

Challenges:

* resolveFields state is not persistent
* rendering with `<Render>` will require first resolving all fields, via internal API or external resolveAllFields method
* `walkTree` will require first resolving all fields, via internal API or external resolveAllFields method
* `migrate` will require first resolving all fields, via internal API or external resolveAllFields method

This is a WIP PR that:

1. Migrates `resolveFields` state to be persistent
2. May (or may not) provide a solution for the other challenges listed above