### PR TITLE
Create dedicated plugin UI

### DIFF
--- a/packages/core/components/Puck/components/Header/styles.module.css
+++ b/packages/core/components/Puck/components/Header/styles.module.css
@@ -7,6 +7,12 @@
   max-width: 100vw;
 }
 
+@media (min-width: 638px) {
+  .PuckHeader {
+    padding-left: 67px;
+  }
+}
+
 .PuckHeader-inner {
   align-items: end;
   display: grid;
@@ -14,7 +20,14 @@
   grid-template-areas: "left middle right";
   grid-template-columns: 1fr auto 1fr;
   grid-template-rows: auto;
+  border-left: 1px solid var(--puck-color-grey-09);
   padding: var(--puck-space-px);
+}
+
+@media (min-width: 638px) {
+  .PuckHeader-inner {
+    border-left: 1px solid var(--puck-color-grey-09);
+  }
 }
 
 .PuckHeader-toggle {

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -1,0 +1,156 @@
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { getClassNameFactory } from "../../../../lib";
+import { IframeConfig, UiState } from "../../../../types";
+import { usePropsContext } from "../..";
+import styles from "./styles.module.css";
+import { useInjectGlobalCss } from "../../../../lib/use-inject-css";
+import { useAppStore } from "../../../../store";
+import { DefaultOverride } from "../../../DefaultOverride";
+import { monitorHotkeys, useMonitorHotkeys } from "../../../../lib/use-hotkey";
+import { getFrame } from "../../../../lib/get-frame";
+import { usePreviewModeHotkeys } from "../../../../lib/use-preview-mode-hotkeys";
+import { DragDropContext } from "../../../DragDropContext";
+import { Header } from "../Header";
+import { SidebarSection } from "../../../SidebarSection";
+import { Components } from "../Components";
+import { Outline } from "../Outline";
+import { Canvas } from "../Canvas";
+import { Fields } from "../Fields";
+
+const getClassName = getClassNameFactory("Puck", styles);
+const getLayoutClassName = getClassNameFactory("PuckLayout", styles);
+
+const FieldSideBar = () => {
+  const title = useAppStore((s) =>
+    s.selectedItem
+      ? s.config.components[s.selectedItem.type]?.["label"] ??
+        s.selectedItem.type.toString()
+      : "Page"
+  );
+
+  return (
+    <SidebarSection noPadding noBorderTop showBreadcrumbs title={title}>
+      <Fields />
+    </SidebarSection>
+  );
+};
+
+export const Layout = ({ children }: { children: ReactNode }) => {
+  const {
+    iframe: _iframe,
+    dnd,
+    initialHistory: _initialHistory,
+  } = usePropsContext();
+
+  const iframe: IframeConfig = useMemo(
+    () => ({
+      enabled: true,
+      waitForStyles: true,
+      ..._iframe,
+    }),
+    [_iframe]
+  );
+
+  useInjectGlobalCss(iframe.enabled);
+
+  const leftSideBarVisible = useAppStore((s) => s.state.ui.leftSideBarVisible);
+  const rightSideBarVisible = useAppStore(
+    (s) => s.state.ui.rightSideBarVisible
+  );
+
+  const dispatch = useAppStore((s) => s.dispatch);
+
+  useEffect(() => {
+    if (!window.matchMedia("(min-width: 638px)").matches) {
+      dispatch({
+        type: "setUi",
+        ui: {
+          leftSideBarVisible: false,
+          rightSideBarVisible: false,
+        },
+      });
+    }
+
+    const handleResize = () => {
+      if (!window.matchMedia("(min-width: 638px)").matches) {
+        dispatch({
+          type: "setUi",
+          ui: (ui: UiState) => ({
+            ...ui,
+            ...(ui.rightSideBarVisible ? { leftSideBarVisible: false } : {}),
+          }),
+        });
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const overrides = useAppStore((s) => s.overrides);
+
+  const CustomPuck = useMemo(
+    () => overrides.puck || DefaultOverride,
+    [overrides]
+  );
+
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const ready = useAppStore((s) => s.status === "READY");
+
+  useMonitorHotkeys();
+
+  useEffect(() => {
+    if (ready && iframe.enabled) {
+      const frameDoc = getFrame();
+
+      if (frameDoc) {
+        return monitorHotkeys(frameDoc);
+      }
+    }
+  }, [ready, iframe.enabled]);
+
+  usePreviewModeHotkeys();
+
+  return (
+    <div className={`Puck ${getClassName()}`}>
+      <DragDropContext disableAutoScroll={dnd?.disableAutoScroll}>
+        <CustomPuck>
+          {children || (
+            <div
+              className={getLayoutClassName({
+                leftSideBarVisible,
+                mounted,
+                rightSideBarVisible,
+              })}
+            >
+              <div className={getLayoutClassName("inner")}>
+                <Header />
+                <div className={getLayoutClassName("leftSideBar")}>
+                  <SidebarSection title="Components" noBorderTop>
+                    <Components />
+                  </SidebarSection>
+                  <SidebarSection title="Outline">
+                    <Outline />
+                  </SidebarSection>
+                </div>
+                <Canvas />
+                <div className={getLayoutClassName("rightSideBar")}>
+                  <FieldSideBar />
+                </div>
+              </div>
+            </div>
+          )}
+        </CustomPuck>
+      </DragDropContext>
+      <div id="puck-portal-root" className={getClassName("portal")} />
+    </div>
+  );
+};

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -16,6 +16,8 @@ import { Components } from "../Components";
 import { Outline } from "../Outline";
 import { Canvas } from "../Canvas";
 import { Fields } from "../Fields";
+import { Nav } from "../Nav";
+import { Hammer, Heading1, Layers } from "lucide-react";
 
 const getClassName = getClassNameFactory("Puck", styles);
 const getLayoutClassName = getClassNameFactory("PuckLayout", styles);
@@ -119,6 +121,8 @@ export const Layout = ({ children }: { children: ReactNode }) => {
 
   usePreviewModeHotkeys();
 
+  const [view, setView] = useState<"blocks" | "outline" | "headings">("blocks");
+
   return (
     <div className={`Puck ${getClassName()}`}>
       <DragDropContext disableAutoScroll={dnd?.disableAutoScroll}>
@@ -133,13 +137,49 @@ export const Layout = ({ children }: { children: ReactNode }) => {
             >
               <div className={getLayoutClassName("inner")}>
                 <Header />
+
+                <div className={getLayoutClassName("nav")}>
+                  <Nav
+                    slim
+                    navigation={{
+                      main: {
+                        items: {
+                          build: {
+                            label: "Blocks",
+                            icon: <Hammer />,
+                            onClick: () => {
+                              setView("blocks");
+                            },
+                            isActive: view === "blocks",
+                          },
+                          outline: {
+                            label: "Outline",
+                            icon: <Layers />,
+                            onClick: () => {
+                              setView("outline");
+                            },
+                            isActive: view === "outline",
+                          },
+                          headings: {
+                            label: "Headings",
+                            icon: <Heading1 />,
+                            onClick: () => {
+                              setView("headings");
+                            },
+                            isActive: view === "headings",
+                          },
+                        },
+                      },
+                    }}
+                  />
+                </div>
                 <div className={getLayoutClassName("leftSideBar")}>
-                  <SidebarSection title="Components" noBorderTop>
-                    <Components />
-                  </SidebarSection>
-                  <SidebarSection title="Outline">
-                    <Outline />
-                  </SidebarSection>
+                  {leftSideBarVisible && (
+                    <>
+                      {view === "blocks" && <Components />}
+                      {view === "outline" && <Outline />}
+                    </>
+                  )}
                 </div>
                 <Canvas />
                 <div className={getLayoutClassName("rightSideBar")}>

--- a/packages/core/components/Puck/components/Layout/styles.module.css
+++ b/packages/core/components/Puck/components/Layout/styles.module.css
@@ -33,8 +33,6 @@
   z-index: 2;
 }
 
-/* Puck Layout */
-
 .PuckLayout-inner {
   --puck-frame-width: auto;
   --puck-side-bar-width: 0px;

--- a/packages/core/components/Puck/components/Layout/styles.module.css
+++ b/packages/core/components/Puck/components/Layout/styles.module.css
@@ -37,8 +37,8 @@
   --puck-frame-width: auto;
   --puck-side-bar-width: 0px;
   display: grid;
-  grid-template-areas: "header header header" "left editor right";
-  grid-template-columns: 0 var(--puck-frame-width) 0;
+  grid-template-areas: "header header header header" "sidenav left editor right";
+  grid-template-columns: var(--puck-side-nav-width) 0 var(--puck-frame-width) 0;
   grid-template-rows: min-content auto;
   height: 100dvh;
   position: relative;
@@ -47,24 +47,29 @@
 
 .PuckLayout--mounted .PuckLayout-inner {
   --puck-side-bar-width: 186px;
+  --puck-side-nav-width: 68px;
 }
 
 .PuckLayout--leftSideBarVisible .PuckLayout-inner {
   grid-template-columns:
-    var(--puck-side-bar-width) var(--puck-frame-width)
+    var(--puck-side-nav-width) var(--puck-side-bar-width) var(
+      --puck-frame-width
+    )
     0;
 }
 
 .PuckLayout--rightSideBarVisible .PuckLayout-inner {
   grid-template-columns:
-    0 var(--puck-frame-width)
+    var(--puck-side-nav-width) 0 var(--puck-frame-width)
     var(--puck-side-bar-width);
 }
 
 .PuckLayout--leftSideBarVisible.PuckLayout--rightSideBarVisible
   .PuckLayout-inner {
   grid-template-columns:
-    var(--puck-side-bar-width) var(--puck-frame-width)
+    var(--puck-side-nav-width) var(--puck-side-bar-width) var(
+      --puck-frame-width
+    )
     var(--puck-side-bar-width);
 }
 
@@ -116,6 +121,7 @@
   display: flex;
   flex-direction: column;
   grid-area: left;
+  padding: 16px;
   overflow-y: auto;
 }
 
@@ -126,4 +132,9 @@
   flex-direction: column;
   grid-area: right;
   overflow-y: auto;
+}
+
+.PuckLayout-nav {
+  border-right: 1px solid var(--puck-color-grey-09);
+  background-color: var(--puck-color-grey-12);
 }

--- a/packages/core/components/Puck/components/Nav/index.tsx
+++ b/packages/core/components/Puck/components/Nav/index.tsx
@@ -1,0 +1,81 @@
+import styles from "./styles.module.css";
+import { ReactNode } from "react";
+import { getClassNameFactory } from "../../../../lib";
+
+const getClassName = getClassNameFactory("Nav", styles);
+const getClassNameSection = getClassNameFactory("NavSection", styles);
+const getClassNameItem = getClassNameFactory("NavItem", styles);
+
+export type MenuItem = {
+  label: string;
+  onClick?: () => void;
+  icon?: ReactNode;
+  items?: Record<string, MenuItem>;
+  isActive?: boolean;
+};
+
+export type NavSection = {
+  title?: string;
+  items: Record<string, MenuItem>;
+};
+
+export const MenuItem = ({
+  label,
+  icon,
+  items,
+  onClick,
+  isActive,
+}: MenuItem) => {
+  const showChildren = isActive;
+
+  return (
+    <li className={getClassNameItem({ active: isActive })}>
+      {onClick && (
+        <div className={getClassNameItem("link")} onClick={onClick}>
+          {icon && <span className={getClassNameItem("linkIcon")}>{icon}</span>}
+          <span className={getClassNameItem("linkLabel")}>{label}</span>
+        </div>
+      )}
+      {items && showChildren && (
+        <ul className={getClassNameItem("list")}>
+          {Object.entries(items).map(([key, item]) => (
+            <MenuItem key={key} {...item} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+};
+
+export const NavSection = ({ title, items }: NavSection) => {
+  return (
+    <li className={getClassNameSection()}>
+      {title && <div className={getClassNameSection("title")}>{title}</div>}
+      <ul className={getClassNameSection("list")}>
+        {Object.entries(items).map(([key, item]) => (
+          <MenuItem key={key} {...item} />
+        ))}
+      </ul>
+    </li>
+  );
+};
+
+export const Nav = ({
+  navigation,
+  slim,
+}: {
+  navigation: Record<string, NavSection>;
+  slim?: boolean;
+}) => {
+  return (
+    <nav className={getClassName({ slim })}>
+      <ul className={getClassName("list")}>
+        {Object.entries(navigation).map(([key, section]) => {
+          return (
+            <NavSection key={key} title={section.title} items={section.items} />
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};

--- a/packages/core/components/Puck/components/Nav/styles.module.css
+++ b/packages/core/components/Puck/components/Nav/styles.module.css
@@ -1,0 +1,106 @@
+.Nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.NavSection {
+  padding: 16px;
+}
+
+.NavSection:first-of-type {
+  padding-top: 32px;
+}
+
+.Nav--slim .NavSection {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.Nav--slim .NavSection + .NavSection {
+  border-top: 1px solid var(--puck-color-grey-09);
+}
+
+.NavSection-list {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.Nav--slim .NavSection-list {
+  gap: 16px;
+}
+
+.NavSection-title {
+  font-weight: 700;
+  margin-bottom: 8px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.Nav--slim .NavSection-title {
+  opacity: 0;
+}
+
+.NavItem-link {
+  align-items: center;
+  color: var(--puck-color-grey-03);
+  display: flex;
+  gap: 8px;
+  text-decoration: none;
+  cursor: pointer;
+
+  border-radius: 4px;
+  padding: 8px 4px;
+}
+
+.Nav--slim .NavItem-link {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-radius: 0;
+  flex-direction: column;
+  font-size: var(--puck-font-size-xxxs);
+}
+
+.NavItem-linkIcon {
+  height: 24px;
+  width: 24px;
+}
+
+.NavItem--active > .NavItem-link {
+  background-color: var(--puck-color-azure-10);
+  color: var(--puck-color-azure-04);
+  font-weight: 600;
+}
+
+.Nav--slim .NavItem--active > .NavItem-link {
+  background-color: transparent;
+  border-right-color: var(--puck-color-azure-04);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  font-weight: 600;
+}
+
+.NavItem:not(.NavItem--active) > .NavItem-link:hover {
+  background-color: var(--puck-color-azure-11);
+  color: var(--puck-color-azure-04);
+}
+
+.NavItem-list {
+  border-left: 1px solid var(--puck-color-grey-09);
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin-top: 8px;
+  margin-left: 4px;
+  padding: 0;
+  padding-left: 8px;
+}
+
+.Nav--slim .NavItem-list {
+  border-left: 0;
+  padding-left: 0;
+  margin-left: 0;
+}

--- a/packages/core/lib/load-overrides.ts
+++ b/packages/core/lib/load-overrides.ts
@@ -10,11 +10,13 @@ export const loadOverrides = ({
   const collected: Partial<Overrides> = { ...overrides };
 
   plugins?.forEach((plugin) => {
+    if (!plugin.overrides) return;
+
     Object.keys(plugin.overrides).forEach((_overridesType) => {
-      const overridesType = _overridesType as keyof Plugin["overrides"];
+      const overridesType = _overridesType as keyof Overrides;
 
       if (overridesType === "fieldTypes") {
-        const fieldTypes = plugin.overrides.fieldTypes!;
+        const fieldTypes = plugin.overrides!.fieldTypes!;
         Object.keys(fieldTypes).forEach((fieldType) => {
           collected.fieldTypes = collected.fieldTypes || {};
 
@@ -35,7 +37,7 @@ export const loadOverrides = ({
       const childNode = collected[overridesType];
 
       const Comp = (props: any) =>
-        plugin.overrides[overridesType]!({
+        plugin.overrides![overridesType]!({
           ...props,
           children: childNode ? childNode(props) : props.children,
         });

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -1,11 +1,7 @@
 import { ReactElement, ReactNode } from "react";
 import { Field, FieldProps } from "../Fields";
 import { ItemSelector } from "../../lib/data/get-item";
-
-// Plugins can use `usePuck` instead of relying on props
-type RenderFunc<
-  Props extends { [key: string]: any } = { children: ReactNode }
-> = (props: Props) => ReactElement;
+import { RenderFunc } from "../Internal";
 
 // All direct render methods, excluding fields
 export const overrideKeys = [

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -1,3 +1,4 @@
+import { ReactElement, ReactNode } from "react";
 import { PuckAction } from "../../reducer";
 import { DefaultAllProps, WithDeepSlots } from "../Internal";
 import { DefaultComponentProps } from "../Props";
@@ -25,7 +26,11 @@ export type OnAction<UserData extends Data = Data> = (
 ) => void;
 
 export type Plugin = {
-  overrides: Partial<Overrides>;
+  name?: string;
+  label?: string;
+  icon?: ReactNode;
+  render?: () => ReactElement;
+  overrides?: Partial<Overrides>;
 };
 
 export type History<D = any> = {

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -1,3 +1,4 @@
+import { ReactElement, ReactNode } from "react";
 import { Slot } from "./API";
 import { AppState } from "./AppState";
 import { ComponentData, Data } from "./Data";
@@ -59,3 +60,8 @@ export type WithDeepSlots<T, SlotType = T> =
     T extends object
     ? { [K in keyof T]: WithDeepSlots<T[K], SlotType> }
     : T;
+
+// Plugins can use `usePuck` instead of relying on props
+export type RenderFunc<
+  Props extends { [key: string]: any } = { children: ReactNode }
+> = (props: Props) => ReactElement;

--- a/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
+++ b/packages/plugin-heading-analyzer/src/HeadingAnalyzer.tsx
@@ -4,11 +4,12 @@ import styles from "./HeadingAnalyzer.module.css";
 
 import { createUsePuck } from "@measured/puck";
 import { Plugin } from "@/core/types";
-import { SidebarSection } from "@/core/components/SidebarSection";
 import { OutlineList } from "@/core/components/OutlineList";
 
 import { scrollIntoView } from "@/core/lib/scroll-into-view";
 import { getFrame } from "@/core/lib/get-frame";
+
+import { Heading1 } from "lucide-react";
 
 import { getClassNameFactory } from "@/core/lib";
 
@@ -243,18 +244,10 @@ export const HeadingAnalyzer = () => {
 };
 
 const headingAnalyzer: Plugin = {
-  overrides: {
-    fields: ({ children, itemSelector }) => (
-      <>
-        {children}
-        <div style={{ display: itemSelector ? "none" : "block" }}>
-          <SidebarSection title="Heading Outline">
-            <HeadingAnalyzer />
-          </SidebarSection>
-        </div>
-      </>
-    ),
-  },
+  name: "heading-analyzer",
+  label: "Audit",
+  render: HeadingAnalyzer,
+  icon: <Heading1 />,
 };
 
 export default headingAnalyzer;


### PR DESCRIPTION
Work-in-progress.

* Adds a new side menu
* Adds new APIs to add dedicated plugin UI

## Usage

```tsx
import { Puck } from "@measured/puck";
 
const MyPlugin = {
  name: "plugin", // globally unique name
  label: "Plugin", // Side nav friendly name
  icon: <svg />, // Icon node. Best to use lucide.
  render: () => <div>Hello, world</div>
  overrides: {} // Optional overrides
};
 
export function Editor() {
  return (
    <Puck
      // ...
      plugins={[MyPlugin]}
    />
  );
}
```


## Tasks

* [ ] Migrate Blocks and Outline to use plugin API