### PR TITLE
fix: support user-defined fields in overrides

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Button, Puck, Render } from "@/core";
+import { AutoField, Button, FieldLabel, Puck, Render } from "@/core";
 import headingAnalyzer from "@/plugin-heading-analyzer/src/HeadingAnalyzer";
 import config from "../../config";
 import { useDemoData } from "../../lib/use-demo-data";
 import { useEffect, useState } from "react";
+import { Type } from "lucide-react";
 
 export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   const metadata = {
@@ -42,6 +43,22 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
             enabled: params.get("disableIframe") === "true" ? false : true,
           }}
           overrides={{
+            fieldTypes: {
+              // Example of user field provided via overrides
+              userField: ({ readOnly, field, name, value, onChange }) => (
+                <FieldLabel
+                  label={field.label || name}
+                  readOnly={readOnly}
+                  icon={<Type size={16} />}
+                >
+                  <AutoField
+                    field={{ type: "text" }}
+                    onChange={onChange}
+                    value={value}
+                  />
+                </FieldLabel>
+              ),
+            },
             headerActions: ({ children }) => (
               <>
                 <div>

--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -42,6 +42,9 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
           iframe={{
             enabled: params.get("disableIframe") === "true" ? false : true,
           }}
+          fieldTransforms={{
+            userField: ({ value }) => value, // Included to check types
+          }}
           overrides={{
             fieldTypes: {
               // Example of user field provided via overrides

--- a/apps/demo/app/rsc/page.tsx
+++ b/apps/demo/app/rsc/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import config from "../../config/server";
 import { initialData } from "../../config/initial-data";
-import { Props, RootProps } from "../../config/types";
+import { Components, RootProps } from "../../config/types";
 
 import { Config } from "@/core";
 import { Render, resolveAllData } from "@/core/bundle/rsc";
@@ -22,7 +22,7 @@ export default async function Page() {
     example: "Hello, world",
   };
 
-  const resolvedData = await resolveAllData<Props, RootProps>(
+  const resolvedData = await resolveAllData<Components, RootProps>(
     data,
     conf,
     metadata

--- a/apps/demo/config/blocks/Heading/index.tsx
+++ b/apps/demo/config/blocks/Heading/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentConfig } from "@/core";
+import { ComponentConfig } from "@/core/types";
 import { Heading as _Heading } from "@/core/components/Heading";
 import type { HeadingProps as _HeadingProps } from "@/core/components/Heading";
 import { Section } from "../../components/Section";

--- a/apps/demo/config/blocks/Hero/client.tsx
+++ b/apps/demo/config/blocks/Hero/client.tsx
@@ -1,13 +1,20 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfigWithExtensions } from "@/core/types";
+import { ComponentConfig } from "@/core/types";
 import { quotes } from "./quotes";
 import { AutoField, FieldLabel } from "@/core";
 import { Link2 } from "lucide-react";
 import HeroComponent, { HeroProps } from "./Hero";
-import { Extensions } from "../../types";
 
-export const Hero: ComponentConfigWithExtensions<Extensions, HeroProps> = {
+export const Hero: ComponentConfig<{
+  props: HeroProps;
+  fields: {
+    userField: {
+      type: "userField";
+      option: boolean;
+    };
+  };
+}> = {
   fields: {
     quote: {
       type: "external",

--- a/apps/demo/config/blocks/Hero/client.tsx
+++ b/apps/demo/config/blocks/Hero/client.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
-import { ComponentConfig } from "@/core/types";
+import { ComponentConfigWithExtensions } from "@/core/types";
 import { quotes } from "./quotes";
 import { AutoField, FieldLabel } from "@/core";
 import { Link2 } from "lucide-react";
 import HeroComponent, { HeroProps } from "./Hero";
+import { Extensions } from "../../types";
 
-export const Hero: ComponentConfig<HeroProps> = {
+export const Hero: ComponentConfigWithExtensions<Extensions, HeroProps> = {
   fields: {
     quote: {
       type: "external",
@@ -133,7 +134,7 @@ export const Hero: ComponentConfig<HeroProps> = {
         },
       },
     },
-    padding: { type: "text" },
+    padding: { type: "userField", option: true },
   },
   defaultProps: {
     title: "Hero",

--- a/apps/demo/config/blocks/Template/client.tsx
+++ b/apps/demo/config/blocks/Template/client.tsx
@@ -5,15 +5,15 @@ import { ComponentConfig, ComponentDataOptionalId, Slot } from "@/core/types";
 import { withLayout } from "../../components/Layout";
 import { generateId } from "@/core/lib/generate-id";
 import { componentKey } from "../../index";
-import { type Props } from "../../types";
+import { type Components } from "../../types";
 import TemplateComponent, { TemplateProps } from "./Template";
 
 const usePuck = createUsePuck();
 
-async function createComponent<T extends keyof Props>(
+async function createComponent<T extends keyof Components>(
   component: T,
-  props?: Partial<Props[T]>
-): Promise<ComponentDataOptionalId<Props[T]>> {
+  props?: Partial<Components[T]>
+): Promise<ComponentDataOptionalId<Components[T]>> {
   const { conf: config } = await import("../../index");
 
   return {
@@ -22,7 +22,7 @@ async function createComponent<T extends keyof Props>(
       ...config.components[component].defaultProps,
       ...props,
     },
-  } as ComponentDataOptionalId<Props[T]>;
+  } as ComponentDataOptionalId<Components[T]>;
 }
 
 type TemplateData = Record<string, { label: string; data: Slot }>;

--- a/apps/demo/config/blocks/Text/index.tsx
+++ b/apps/demo/config/blocks/Text/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ALargeSmall, AlignLeft } from "lucide-react";
 
-import { ComponentConfig } from "@/core";
+import { ComponentConfig } from "@/core/types";
 import { Section } from "../../components/Section";
 import { WithLayout, withLayout } from "../../components/Layout";
 

--- a/apps/demo/config/components/Layout/index.tsx
+++ b/apps/demo/config/components/Layout/index.tsx
@@ -88,12 +88,10 @@ Layout.displayName = "Layout";
 export { Layout };
 
 export function withLayout<
-  Props extends DefaultComponentProps = DefaultComponentProps
->(
-  componentConfig: ComponentConfig<Props>
-): ComponentConfig<Props & { layout?: LayoutFieldProps }> {
+  ThisComponentConfig extends ComponentConfig<any> = ComponentConfig
+>(componentConfig: ThisComponentConfig): ThisComponentConfig {
   return {
-    ...(componentConfig as any),
+    ...componentConfig,
     fields: {
       ...componentConfig.fields,
       layout: layoutField,

--- a/apps/demo/config/root.tsx
+++ b/apps/demo/config/root.tsx
@@ -4,7 +4,7 @@ import { Footer } from "./components/Footer";
 
 export type RootProps = DefaultRootProps;
 
-export const Root: RootConfig<RootProps> = {
+export const Root: RootConfig<{ props: RootProps }> = {
   defaultProps: {
     title: "My Page",
   },

--- a/apps/demo/config/root.tsx
+++ b/apps/demo/config/root.tsx
@@ -4,7 +4,12 @@ import { Footer } from "./components/Footer";
 
 export type RootProps = DefaultRootProps;
 
-export const Root: RootConfig<{ props: RootProps }> = {
+export const Root: RootConfig<{
+  props: RootProps;
+  fields: {
+    userField: { type: "userField"; option: boolean };
+  };
+}> = {
   defaultProps: {
     title: "My Page",
   },

--- a/apps/demo/config/types.ts
+++ b/apps/demo/config/types.ts
@@ -1,4 +1,4 @@
-import { Config, Data } from "@/core";
+import { Config, ConfigWithExtensions, Data } from "@/core";
 import { ButtonProps } from "./blocks/Button";
 import { CardProps } from "./blocks/Card";
 import { GridProps } from "./blocks/Grid";
@@ -29,7 +29,16 @@ export type Props = {
   Space: SpaceProps;
 };
 
-export type UserConfig = Config<
+// Optional type extension for user-defined fields
+export type Extensions = {
+  Field: {
+    type: "userField";
+    option: boolean;
+  };
+};
+
+export type UserConfig = ConfigWithExtensions<
+  Extensions,
   Props,
   RootProps,
   "layout" | "typography" | "interactive"

--- a/apps/demo/config/types.ts
+++ b/apps/demo/config/types.ts
@@ -1,4 +1,4 @@
-import { ConfigWithExtensions, Data } from "@/core";
+import { Config, Data } from "@/core";
 import { ButtonProps } from "./blocks/Button";
 import { CardProps } from "./blocks/Card";
 import { GridProps } from "./blocks/Grid";
@@ -15,7 +15,7 @@ import { RootProps } from "./root";
 
 export type { RootProps } from "./root";
 
-export type Props = {
+export type Components = {
   Button: ButtonProps;
   Card: CardProps;
   Grid: GridProps;
@@ -29,19 +29,16 @@ export type Props = {
   Space: SpaceProps;
 };
 
-// Optional type extension for user-defined fields
-export type Extensions = {
-  Field: {
-    type: "userField";
-    option: boolean;
+export type UserConfig = Config<{
+  components: Components;
+  root: RootProps;
+  categories: ["layout", "typography", "interactive"];
+  fields: {
+    userField: {
+      type: "userField";
+      option: boolean;
+    };
   };
-};
+}>;
 
-export type UserConfig = ConfigWithExtensions<
-  Extensions,
-  Props,
-  RootProps,
-  "layout" | "typography" | "interactive"
->;
-
-export type UserData = Data<Props, RootProps>;
+export type UserData = Data<Components, RootProps>;

--- a/apps/demo/config/types.ts
+++ b/apps/demo/config/types.ts
@@ -1,4 +1,4 @@
-import { Config, ConfigWithExtensions, Data } from "@/core";
+import { ConfigWithExtensions, Data } from "@/core";
 import { ButtonProps } from "./blocks/Button";
 import { CardProps } from "./blocks/Card";
 import { GridProps } from "./blocks/Grid";

--- a/apps/demo/lib/use-demo-data.ts
+++ b/apps/demo/lib/use-demo-data.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import config, { componentKey } from "../config";
 import { initialData } from "../config/initial-data";
 import { Metadata, resolveAllData } from "@/core";
-import { Props, UserData } from "../config/types";
+import { Components, UserData } from "../config/types";
 import { RootProps } from "../config/root";
 
 const isBrowser = typeof window !== "undefined";
@@ -38,7 +38,7 @@ export const useDemoData = ({
 
   useEffect(() => {
     if (data && !isEdit) {
-      resolveAllData<Props, RootProps>(data, config, metadata).then(
+      resolveAllData<Components, RootProps>(data, config, metadata).then(
         setResolvedData
       );
     }

--- a/apps/docs/pages/docs/api-reference/fields/custom.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/custom.mdx
@@ -1,5 +1,6 @@
 import { Puck } from "@/puck";
 import { ConfigPreview, PuckPreview } from "@/docs/components/Preview";
+import { Callout } from "nextra/components";
 
 # Custom
 
@@ -150,6 +151,10 @@ Set the value of the field and optionally update the [Puck UI state](/docs/api-r
 ### contentEditable
 
 Enable inline text editing for this field. Only works if the value is a string. Defaults to `false`.
+
+<Callout type="warning">
+  When setting `contentEditable`, your [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) prop will be converted to an [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) when rendered inside [`<Puck>`](/docs/api-reference/components/puck) (but not [`<Render>`](/docs/api-reference/components/render)). When using TypeScript, change your `string` to  `string | ReactNode`.
+</Callout>
 
 ```tsx {7, 10} copy
 const config = {

--- a/apps/docs/pages/docs/api-reference/fields/text.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/text.mdx
@@ -1,5 +1,6 @@
 import { Puck } from "@/puck";
 import { ConfigPreview, PuckPreview } from "@/docs/components/Preview";
+import { Callout } from "nextra/components";
 
 # Text
 
@@ -71,6 +72,10 @@ const config = {
 ### contentEditable
 
 Enable inline text editing for this field. Defaults to `false`.
+
+<Callout type="warning">
+  When setting `contentEditable`, your [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) prop will be converted to an [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) when rendered inside [`<Puck>`](/docs/api-reference/components/puck) (but not [`<Render>`](/docs/api-reference/components/render)). When using TypeScript, change your `string` to  `string | ReactNode`.
+</Callout>
 
 ```tsx {7} copy
 const config = {

--- a/apps/docs/pages/docs/api-reference/fields/textarea.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/textarea.mdx
@@ -1,5 +1,6 @@
 import { Puck } from "@/puck";
 import { ConfigPreview, PuckPreview } from "@/docs/components/Preview";
+import { Callout } from "nextra/components";
 
 # Textarea
 
@@ -71,6 +72,10 @@ const config = {
 ### contentEditable
 
 Enable inline text editing for this field. Defaults to `false`.
+
+<Callout type="warning">
+  When setting `contentEditable`, your [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) prop will be converted to an [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) when rendered inside [`<Puck>`](/docs/api-reference/components/puck) (but not [`<Render>`](/docs/api-reference/components/render)). When using TypeScript, change your `string` to  `string | ReactNode`.
+</Callout>
 
 ```tsx {7} copy
 const config = {

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -226,7 +226,7 @@ function AutoFieldInternal<
         return null;
       }
       return field.render as any;
-    } else {
+    } else if (field.type !== "slot") {
       return render[field.type] as (props: FieldProps) => ReactElement;
     }
   }, [field.type, render]);
@@ -239,6 +239,10 @@ function AutoFieldInternal<
 
   if (field.type === "slot") {
     return null;
+  }
+
+  if (!FieldComponent) {
+    throw new Error(`Field type for ${field.type} did not exist.`);
   }
 
   return (

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -27,6 +27,7 @@ import {
   DragAxis,
   Metadata,
   PuckContext,
+  WithPuckProps,
 } from "../../types";
 
 import { useDroppable, UseDroppableInput } from "@dnd-kit/react";
@@ -517,7 +518,7 @@ const DropZoneRenderItem = ({
 
   const props = useSlots(config, item, (slotProps) => (
     <SlotRenderPure {...slotProps} config={config} metadata={metadata} />
-  ));
+  )) as WithPuckProps<ComponentData["props"]>;
 
   const nextContextValue = useMemo<DropZoneContext>(
     () => ({

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -25,6 +25,7 @@ import type {
   Config,
   Data,
   Metadata,
+  ConfigWithExtensions,
 } from "../../types";
 
 import { SidebarSection } from "../SidebarSection";
@@ -86,7 +87,7 @@ const FieldSideBar = () => {
 };
 
 type PuckProps<
-  UserConfig extends Config = Config,
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = {
   children?: ReactNode;
@@ -97,9 +98,9 @@ type PuckProps<
   onPublish?: (data: G["UserData"]) => void;
   onAction?: OnAction<G["UserData"]>;
   permissions?: Partial<Permissions>;
-  plugins?: Plugin[];
-  overrides?: Partial<Overrides>;
-  fieldTransforms?: FieldTransforms;
+  plugins?: Plugin<UserConfig>[];
+  overrides?: Partial<Overrides<UserConfig>>;
+  fieldTransforms?: FieldTransforms<UserConfig>;
   renderHeader?: (props: {
     children: ReactNode;
     dispatch: (action: PuckAction) => void;
@@ -136,7 +137,7 @@ export const usePropsContext = () =>
   useContext<PuckProps>(propsContext as Context<PuckProps>);
 
 function PuckProvider<
-  UserConfig extends Config = Config,
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >({ children }: PropsWithChildren) {
   const {
@@ -395,7 +396,7 @@ function PuckProvider<
 }
 
 function PuckLayout<
-  UserConfig extends Config = Config,
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >({ children }: PropsWithChildren) {
   const {
@@ -558,7 +559,7 @@ function PuckLayout<
 }
 
 export function Puck<
-  UserConfig extends Config = Config,
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >(props: PuckProps<UserConfig>) {
   return (

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -25,7 +25,6 @@ import type {
   Config,
   Data,
   Metadata,
-  ConfigWithExtensions,
 } from "../../types";
 
 import { SidebarSection } from "../SidebarSection";
@@ -87,7 +86,7 @@ const FieldSideBar = () => {
 };
 
 type PuckProps<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = {
   children?: ReactNode;
@@ -137,7 +136,7 @@ export const usePropsContext = () =>
   useContext<PuckProps>(propsContext as Context<PuckProps>);
 
 function PuckProvider<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >({ children }: PropsWithChildren) {
   const {
@@ -396,7 +395,7 @@ function PuckProvider<
 }
 
 function PuckLayout<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >({ children }: PropsWithChildren) {
   const {
@@ -559,7 +558,7 @@ function PuckLayout<
 }
 
 export function Puck<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >(props: PuckProps<UserConfig>) {
   return (

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -38,7 +38,7 @@ export function Render<
     ...data,
     root: data.root || {},
     content: data.content || [],
-  };
+  } as G["UserData"];
 
   // DEPRECATED
   const rootProps =

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -40,7 +40,6 @@ const Item = ({
       {...props}
       puck={{
         ...props.puck,
-        renderDropZone: DropZoneRender,
         metadata: metadata || {},
       }}
     />

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -1,8 +1,13 @@
 import { forwardRef } from "react";
 import { DropZoneProps } from "../DropZone/types";
-import { ComponentData, Config, Content, Metadata, Slot } from "../../types";
+import {
+  ComponentData,
+  Config,
+  Content,
+  Metadata,
+  WithPuckProps,
+} from "../../types";
 import { useSlots } from "../../lib/use-slots";
-import { DropZoneRender } from "../ServerRender";
 
 type SlotRenderProps = DropZoneProps & {
   content: Content;
@@ -28,7 +33,7 @@ const Item = ({
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const props = useSlots(config, item, (slotProps) => (
     <SlotRenderPure {...slotProps} config={config} metadata={metadata} />
-  ));
+  )) as WithPuckProps<ComponentData["props"]>;
 
   return (
     <Component.render

--- a/packages/core/lib/field-transforms/use-field-transforms.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms.tsx
@@ -28,7 +28,7 @@ export function useFieldTransforms<
   // This converts transformers to mappers by adding the `isReadOnly` param
   const mappers = useMemo<Mappers>(() => {
     return Object.keys(transforms).reduce<Mappers>((acc, _fieldType) => {
-      const fieldType = _fieldType as Field["type"];
+      const fieldType = _fieldType as G["UserField"]["type"];
 
       return {
         ...acc,
@@ -43,7 +43,10 @@ export function useFieldTransforms<
             forceReadOnly ||
             false;
 
-          const fn = transforms[fieldType] as FieldTransformFn<
+          // Side-step annoying type issue with some TS configs, such as for the docs site
+          const _transforms = transforms as any;
+
+          const fn = _transforms[fieldType] as FieldTransformFn<
             ExtractField<G["UserField"], Field["type"]>
           >;
 

--- a/packages/core/lib/field-transforms/use-field-transforms.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms.tsx
@@ -1,4 +1,10 @@
-import { ComponentData, Config, ExtractField, Field } from "../../types";
+import {
+  ComponentData,
+  Config,
+  ExtractField,
+  Field,
+  UserGenerics,
+} from "../../types";
 import { useMemo } from "react";
 import { RootData } from "../../types";
 import { mapFields, MapFnParams, Mappers } from "../data/map-fields";
@@ -7,8 +13,12 @@ import {
   FieldTransforms,
 } from "../../types/API/FieldTransforms";
 
-export function useFieldTransforms<T extends ComponentData | RootData>(
-  config: Config,
+export function useFieldTransforms<
+  T extends ComponentData | RootData,
+  UserConfig extends Config,
+  G extends UserGenerics<UserConfig>
+>(
+  config: UserConfig,
   item: T,
   transforms: FieldTransforms,
   readOnly?: T["readOnly"],
@@ -25,7 +35,7 @@ export function useFieldTransforms<T extends ComponentData | RootData>(
         [fieldType]: ({
           parentId,
           ...params
-        }: MapFnParams<ExtractField<Field["type"]>>) => {
+        }: MapFnParams<ExtractField<G["UserField"], Field["type"]>>) => {
           const wildcardPath = params.propPath.replace(/\[\d+\]/g, "[*]");
           const isReadOnly =
             readOnly?.[params.propPath] ||
@@ -34,7 +44,7 @@ export function useFieldTransforms<T extends ComponentData | RootData>(
             false;
 
           const fn = transforms[fieldType] as FieldTransformFn<
-            ExtractField<Field["type"]>
+            ExtractField<G["UserField"], Field["type"]>
           >;
 
           return fn?.({

--- a/packages/core/lib/field-transforms/use-field-transforms.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms.tsx
@@ -27,7 +27,7 @@ export function useFieldTransforms<
   // This converts transformers to mappers by adding the `isReadOnly` param
   const mappers = useMemo<Mappers>(() => {
     return Object.keys(transforms).reduce<Mappers>((acc, _fieldType) => {
-      const fieldType = _fieldType as G["UserField"]["type"];
+      const fieldType = _fieldType as Field["type"]; // Not strictly true, as could include user fields, but this should be safe enough
 
       return {
         ...acc,

--- a/packages/core/lib/field-transforms/use-field-transforms.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../types/API/FieldTransforms";
 
 export function useFieldTransforms<
-  T extends ComponentData | RootData,
+  T extends ComponentData,
   UserConfig extends Config,
   G extends UserGenerics<UserConfig>
 >(
@@ -37,16 +37,14 @@ export function useFieldTransforms<
           ...params
         }: MapFnParams<ExtractField<G["UserField"], Field["type"]>>) => {
           const wildcardPath = params.propPath.replace(/\[\d+\]/g, "[*]");
+
           const isReadOnly =
             readOnly?.[params.propPath] ||
             readOnly?.[wildcardPath] ||
             forceReadOnly ||
             false;
 
-          // Side-step annoying type issue with some TS configs, such as for the docs site
-          const _transforms = transforms as any;
-
-          const fn = _transforms[fieldType] as FieldTransformFn<
+          const fn = transforms[fieldType] as FieldTransformFn<
             ExtractField<G["UserField"], Field["type"]>
           >;
 

--- a/packages/core/lib/field-transforms/use-field-transforms.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms.tsx
@@ -6,7 +6,6 @@ import {
   UserGenerics,
 } from "../../types";
 import { useMemo } from "react";
-import { RootData } from "../../types";
 import { mapFields, MapFnParams, Mappers } from "../data/map-fields";
 import {
   FieldTransformFn,

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -3,7 +3,7 @@ import {
   Config,
   Content,
   Data,
-  DefaultComponentProps,
+  DefaultComponents,
   DefaultRootFieldProps,
   Metadata,
   RootData,
@@ -14,7 +14,7 @@ import { toComponent } from "./data/to-component";
 import { mapFields } from "./data/map-fields";
 
 export async function resolveAllData<
-  Props extends DefaultComponentProps = DefaultComponentProps,
+  Components extends DefaultComponents = DefaultComponents,
   RootProps extends Record<string, any> = DefaultRootFieldProps
 >(
   data: Partial<Data>,
@@ -77,5 +77,5 @@ export async function resolveAllData<
     dynamic.zones![zoneKey] = await processContent(content);
   }, {});
 
-  return dynamic as Data<Props, RootProps>;
+  return dynamic as Data<Components, RootProps>;
 }

--- a/packages/core/lib/resolve-permissions.ts
+++ b/packages/core/lib/resolve-permissions.ts
@@ -1,21 +1,8 @@
-import {
-  AppState,
-  ComponentData,
-  Config,
-  Data,
-  ExtractPropsFromConfig,
-  ExtractRootPropsFromConfig,
-  Permissions,
-} from "../types";
+import { AppState, Config, Permissions, UserGenerics } from "../types";
 
 export const resolvePermissions = <
   UserConfig extends Config = Config,
-  UserProps extends ExtractPropsFromConfig<UserConfig> = ExtractPropsFromConfig<UserConfig>,
-  UserRootProps extends ExtractRootPropsFromConfig<UserConfig> = ExtractRootPropsFromConfig<UserConfig>,
-  UserData extends Data<UserProps, UserRootProps> | Data = Data<
-    UserProps,
-    UserRootProps
-  >
+  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 >({
   data,
   lastData,
@@ -25,13 +12,13 @@ export const resolvePermissions = <
   permissions,
   appState,
 }: {
-  data: UserData["content"][0] | undefined;
-  lastData: UserData["content"][0] | null;
+  data: G["UserData"]["content"][0] | undefined;
+  lastData: G["UserData"]["content"][0] | null;
   config: UserConfig;
   changed: Record<string, boolean>;
   lastPermissions: Partial<Permissions>;
   permissions: Partial<Permissions>;
-  appState: AppState<UserData>;
+  appState: AppState<G["UserData"]>;
 }) => {
   const componentConfig = data ? config.components[data.type] : null;
 

--- a/packages/core/lib/transform-props.ts
+++ b/packages/core/lib/transform-props.ts
@@ -3,27 +3,28 @@ import {
   Config,
   Data,
   DefaultComponentProps,
+  DefaultComponents,
   DefaultRootFieldProps,
 } from "../types";
 import { defaultData } from "./data/default-data";
 
 type PropTransform<
-  Props extends DefaultComponentProps = DefaultComponentProps,
+  Components extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultRootFieldProps
 > = Partial<
   {
-    [ComponentName in keyof Props]: (
-      props: Props[ComponentName] & { [key: string]: any }
-    ) => Props[ComponentName];
+    [ComponentName in keyof Components]: (
+      props: Components[ComponentName] & { [key: string]: any }
+    ) => Components[ComponentName];
   } & { root: (props: RootProps & { [key: string]: any }) => RootProps }
 >;
 
 export function transformProps<
-  Props extends DefaultComponentProps = DefaultComponentProps,
+  Components extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultRootFieldProps
 >(
   data: Partial<Data>,
-  propTransforms: PropTransform<Props, RootProps>,
+  propTransforms: PropTransform<Components, RootProps>,
   config: Config = { components: {} }
 ): Data {
   const mapItem = (item: any) => {

--- a/packages/core/lib/use-slots.tsx
+++ b/packages/core/lib/use-slots.tsx
@@ -19,7 +19,7 @@ export function useSlots<
 ): T["props"] {
   return useFieldTransforms(
     config,
-    item,
+    item as ComponentData,
     getSlotTransform(renderSlotEdit, renderSlotRender),
     readOnly,
     forceReadOnly

--- a/packages/core/lib/use-slots.tsx
+++ b/packages/core/lib/use-slots.tsx
@@ -4,8 +4,11 @@ import { DropZoneProps } from "../components/DropZone/types";
 import { useFieldTransforms } from "./field-transforms/use-field-transforms";
 import { getSlotTransform } from "./field-transforms/default-transforms/slot-transform";
 
-export function useSlots<T extends ComponentData | RootData>(
-  config: Config,
+export function useSlots<
+  T extends ComponentData | RootData,
+  UserConfig extends Config
+>(
+  config: UserConfig,
   item: T,
   renderSlotEdit: (dzProps: DropZoneProps & { content: Content }) => ReactNode,
   renderSlotRender: (

--- a/packages/core/types/API/FieldTransforms.ts
+++ b/packages/core/types/API/FieldTransforms.ts
@@ -1,5 +1,5 @@
 import { MapFnParams } from "../../lib/data/map-fields";
-import { Config, ExtractField, UserGenerics } from "../../types";
+import { Config, ExtractField, Field, UserGenerics } from "../../types";
 
 export type FieldTransformFnParams<T> = Omit<MapFnParams<T>, "parentId"> & {
   isReadOnly: boolean;
@@ -10,9 +10,8 @@ export type FieldTransformFn<T> = (params: FieldTransformFnParams<T>) => any;
 
 export type FieldTransforms<
   UserConfig extends Config = Config<{ fields: {} }>, // Setting fields: {} helps TS choose default field types
-  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
+  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>,
+  UserField extends { type: string } = Field | G["UserField"]
 > = Partial<{
-  [Type in G["UserField"]["type"]]: FieldTransformFn<
-    ExtractField<G["UserField"], Type>
-  >;
+  [Type in UserField["type"]]: FieldTransformFn<ExtractField<UserField, Type>>;
 }>;

--- a/packages/core/types/API/FieldTransforms.ts
+++ b/packages/core/types/API/FieldTransforms.ts
@@ -1,13 +1,18 @@
 import { MapFnParams } from "../../lib/data/map-fields";
-import { ExtractField, Field } from "../../types";
+import { ConfigWithExtensions, ExtractField, UserGenerics } from "../../types";
 
 export type FieldTransformFnParams<T> = Omit<MapFnParams<T>, "parentId"> & {
   isReadOnly: boolean;
   componentId: string;
 };
-export type FieldTransformFn<T = any> = (
-  params: FieldTransformFnParams<T>
-) => any;
-export type FieldTransforms = Partial<{
-  [FieldType in Field["type"]]: FieldTransformFn<ExtractField<FieldType>>;
+
+export type FieldTransformFn<T> = (params: FieldTransformFnParams<T>) => any;
+
+export type FieldTransforms<
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
+> = Partial<{
+  [FieldType in G["UserField"]["type"]]: FieldTransformFn<
+    ExtractField<G["UserField"], FieldType>
+  >;
 }>;

--- a/packages/core/types/API/FieldTransforms.ts
+++ b/packages/core/types/API/FieldTransforms.ts
@@ -9,7 +9,7 @@ export type FieldTransformFnParams<T> = Omit<MapFnParams<T>, "parentId"> & {
 export type FieldTransformFn<T> = (params: FieldTransformFnParams<T>) => any;
 
 export type FieldTransforms<
-  UserConfig extends Config = { components: {}; fields: {} },
+  UserConfig extends Config = Config<{ fields: {} }>, // Setting fields: {} helps TS choose default field types
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = Partial<{
   [Type in G["UserField"]["type"]]: FieldTransformFn<

--- a/packages/core/types/API/FieldTransforms.ts
+++ b/packages/core/types/API/FieldTransforms.ts
@@ -1,5 +1,5 @@
 import { MapFnParams } from "../../lib/data/map-fields";
-import { ConfigWithExtensions, ExtractField, UserGenerics } from "../../types";
+import { Config, ExtractField, UserGenerics } from "../../types";
 
 export type FieldTransformFnParams<T> = Omit<MapFnParams<T>, "parentId"> & {
   isReadOnly: boolean;
@@ -9,10 +9,10 @@ export type FieldTransformFnParams<T> = Omit<MapFnParams<T>, "parentId"> & {
 export type FieldTransformFn<T> = (params: FieldTransformFnParams<T>) => any;
 
 export type FieldTransforms<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = { components: {}; fields: {} },
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = Partial<{
-  [FieldType in G["UserField"]["type"]]: FieldTransformFn<
-    ExtractField<G["UserField"], FieldType>
+  [Type in G["UserField"]["type"]]: FieldTransformFn<
+    ExtractField<G["UserField"], Type>
   >;
 }>;

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -68,11 +68,12 @@ export type Overrides<UserConfig extends Config = Config> = OverridesGeneric<{
 
 export type FieldRenderFunctions<
   UserConfig extends Config = Config,
-  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
+  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>,
+  UserField extends { type: string } = Field | G["UserField"]
 > = Omit<
   {
-    [Type in G["UserField"]["type"]]: React.FunctionComponent<
-      FieldProps<ExtractField<G["UserField"], Type>, any> & {
+    [Type in UserField["type"]]: React.FunctionComponent<
+      FieldProps<ExtractField<UserField, Type>, any> & {
         children: ReactNode;
         name: string;
       }

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -1,6 +1,8 @@
 import { ReactElement, ReactNode } from "react";
 import { Field, FieldProps } from "../Fields";
 import { ItemSelector } from "../../lib/data/get-item";
+import { TypeExtensions, UserGenerics } from "../Utils";
+import { ConfigWithExtensions } from "../Config";
 
 // Plugins can use `usePuck` instead of relying on props
 type RenderFunc<
@@ -25,8 +27,10 @@ export type OverrideKey = (typeof overrideKeys)[number];
 
 type OverridesGeneric<Shape extends { [key in OverrideKey]: any }> = Shape;
 
-export type Overrides = OverridesGeneric<{
-  fieldTypes: Partial<FieldRenderFunctions>;
+export type Overrides<
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions
+> = OverridesGeneric<{
+  fieldTypes: Partial<FieldRenderFunctions<UserConfig>>;
   header: RenderFunc<{ actions: ReactNode; children: ReactNode }>;
   actionBar: RenderFunc<{
     label?: string;
@@ -64,21 +68,17 @@ export type Overrides = OverridesGeneric<{
   puck: RenderFunc;
 }>;
 
-export type FieldRenderFunctions = Omit<
+export type FieldRenderFunctions<
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
+> = Omit<
   {
-    [Type in Field["type"]]: React.FunctionComponent<
-      FieldProps<Extract<Field, { type: Type }>, any> & {
+    [Type in G["UserField"]["type"]]: React.FunctionComponent<
+      FieldProps<Extract<G["UserField"], { type: Type }>, any> & {
         children: ReactNode;
         name: string;
       }
     >;
   },
   "custom"
-> & {
-  [key: string]: React.FunctionComponent<
-    FieldProps<any> & {
-      children: ReactNode;
-      name: string;
-    }
-  >;
-};
+>;

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode } from "react";
-import { FieldProps } from "../Fields";
+import { Field, FieldProps } from "../Fields";
 import { ItemSelector } from "../../lib/data/get-item";
 import { ExtractField, UserGenerics } from "../Utils";
 import { Config } from "../Config";

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -1,8 +1,8 @@
 import { ReactElement, ReactNode } from "react";
-import { Field, FieldProps } from "../Fields";
+import { FieldProps } from "../Fields";
 import { ItemSelector } from "../../lib/data/get-item";
-import { TypeExtensions, UserGenerics } from "../Utils";
-import { ConfigWithExtensions } from "../Config";
+import { ExtractField, UserGenerics } from "../Utils";
+import { Config } from "../Config";
 
 // Plugins can use `usePuck` instead of relying on props
 type RenderFunc<
@@ -27,9 +27,7 @@ export type OverrideKey = (typeof overrideKeys)[number];
 
 type OverridesGeneric<Shape extends { [key in OverrideKey]: any }> = Shape;
 
-export type Overrides<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions
-> = OverridesGeneric<{
+export type Overrides<UserConfig extends Config = Config> = OverridesGeneric<{
   fieldTypes: Partial<FieldRenderFunctions<UserConfig>>;
   header: RenderFunc<{ actions: ReactNode; children: ReactNode }>;
   actionBar: RenderFunc<{
@@ -69,12 +67,12 @@ export type Overrides<
 }>;
 
 export type FieldRenderFunctions<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
+  UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>
 > = Omit<
   {
     [Type in G["UserField"]["type"]]: React.FunctionComponent<
-      FieldProps<Extract<G["UserField"], { type: Type }>, any> & {
+      FieldProps<ExtractField<G["UserField"], Type>, any> & {
         children: ReactNode;
         name: string;
       }

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -1,11 +1,11 @@
 import { PuckAction } from "../../reducer";
-import { DefaultAllProps, WithDeepSlots } from "../Internal";
+import { WithDeepSlots } from "../Internal";
 import { DefaultComponentProps } from "../Props";
 import { AppState } from "./../AppState";
 import { ComponentDataOptionalId, Content, Data } from "./../Data";
 import { Overrides } from "./Overrides";
 import { FieldTransforms } from "./FieldTransforms";
-import { ConfigWithExtensions } from "../Config";
+import { Config, DefaultComponents } from "../Config";
 
 export type Permissions = {
   drag: boolean;
@@ -26,9 +26,7 @@ export type OnAction<UserData extends Data = Data> = (
   prevAppState: AppState<UserData>
 ) => void;
 
-export type Plugin<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions
-> = {
+export type Plugin<UserConfig extends Config = Config> = {
   overrides?: Partial<Overrides<UserConfig>>;
   fieldTransforms?: FieldTransforms<UserConfig>;
 };
@@ -67,8 +65,8 @@ export type Slot<
 
 export type WithSlotProps<
   Target extends Record<string, any>,
-  AllProps extends DefaultAllProps = DefaultAllProps,
-  SlotType extends Content<AllProps> = Content<AllProps>
+  Components extends DefaultComponents = DefaultComponents,
+  SlotType extends Content<Components> = Content<Components>
 > = WithDeepSlots<Target, SlotType>;
 
 export * from "./DropZone";

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -5,6 +5,7 @@ import { AppState } from "./../AppState";
 import { ComponentDataOptionalId, Content, Data } from "./../Data";
 import { Overrides } from "./Overrides";
 import { FieldTransforms } from "./FieldTransforms";
+import { ConfigWithExtensions } from "../Config";
 
 export type Permissions = {
   drag: boolean;
@@ -25,9 +26,11 @@ export type OnAction<UserData extends Data = Data> = (
   prevAppState: AppState<UserData>
 ) => void;
 
-export type Plugin = {
-  overrides?: Partial<Overrides>;
-  fieldTransforms?: FieldTransforms;
+export type Plugin<
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions
+> = {
+  overrides?: Partial<Overrides<UserConfig>>;
+  fieldTransforms?: FieldTransforms<UserConfig>;
 };
 
 export type History<D = any> = {

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -95,8 +95,13 @@ export type ComponentConfig<
   DataShape = Omit<ComponentData<FieldProps>, "type"> // NB this doesn't include AllProps, so types will not contain deep slot types. To fix, we require a breaking change.
 > = RenderPropsOrParams extends ComponentConfigParams<
   infer ParamsRenderProps,
-  infer ParamsFields
+  never
 >
+  ? ComponentConfigInternal<ParamsRenderProps, FieldProps, DataShape, {}>
+  : RenderPropsOrParams extends ComponentConfigParams<
+      infer ParamsRenderProps,
+      infer ParamsFields
+    >
   ? ComponentConfigInternal<
       ParamsRenderProps,
       FieldProps,
@@ -123,11 +128,13 @@ export type RootConfig<
     RootPropsOrParams,
     DefaultComponentProps,
     ComponentConfigParams
-  > = DefaultComponentProps | ComponentConfigParams
-> = RootPropsOrParams extends ComponentConfigParams<
-  infer Props,
-  infer UserFields
->
+  > = DefaultComponentProps
+> = RootPropsOrParams extends ComponentConfigParams<infer Props, never>
+  ? Partial<RootConfigInternal<WithChildren<Props>, {}>>
+  : RootPropsOrParams extends ComponentConfigParams<
+      infer Props,
+      infer UserFields
+    >
   ? Partial<
       RootConfigInternal<
         WithChildren<Props>,
@@ -182,8 +189,15 @@ export type Config<
   infer ParamComponents,
   infer ParamRoot,
   infer ParamCategoryName,
-  infer ParamFields
+  never
 >
+  ? ConfigInternal<ParamComponents, ParamRoot, ParamCategoryName[number], Field>
+  : PropsOrParams extends ConfigParams<
+      infer ParamComponents,
+      infer ParamRoot,
+      infer ParamCategoryName,
+      infer ParamFields
+    >
   ? ConfigInternal<
       ParamComponents,
       ParamRoot,

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -2,7 +2,13 @@ import type { JSX, ReactNode } from "react";
 import { Fields } from "./Fields";
 import { ComponentData, Metadata, RootData } from "./Data";
 
-import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";
+import {
+  AsFieldProps,
+  TypeExtensions,
+  WithChildren,
+  WithId,
+  WithPuckProps,
+} from "./Utils";
 import { AppState } from "./AppState";
 import { DefaultComponentProps } from "./Props";
 import { Permissions } from "./API";
@@ -26,10 +32,6 @@ type WithPartialProps<T, Props extends DefaultComponentProps> = Omit<
   "props"
 > & {
   props?: Partial<Props>;
-};
-
-type TypeExtensions = {
-  Field?: { type: string };
 };
 
 type ComponentConfigInternal<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -174,7 +174,9 @@ export type Config<
   CategoryName extends string = string
 > = ConfigInternal<
   PropsOrParams extends ConfigParams<infer Props> ? Props : PropsOrParams,
-  RootProps,
+  PropsOrParams extends ConfigParams<any, infer ParamRootProps>
+    ? ParamRootProps
+    : RootProps,
   PropsOrParams extends ConfigParams<any, any, infer ParamCategoryName>
     ? ParamCategoryName[number]
     : CategoryName,

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -10,9 +10,8 @@ import { DropZoneProps } from "../components/DropZone/types";
 import {
   ComponentConfigParams,
   ConfigParams,
-  ExactComponentConfigParams,
-  ExactConfigParams,
   FieldsExtension,
+  LeftOrExactRight,
   WithDeepSlots,
 } from "./Internal";
 
@@ -84,12 +83,11 @@ type ComponentConfigInternal<
 
 // DEPRECATED - remove old generics in favour of Params
 export type ComponentConfig<
-  RenderPropsOrParams extends
-    | (DefaultComponentProps & RenderPropsOrParams extends ComponentConfigParams
-        ? ExactComponentConfigParams<RenderPropsOrParams>
-        : DefaultComponentProps)
-    | (ComponentConfigParams &
-        ExactComponentConfigParams<RenderPropsOrParams>) = DefaultComponentProps,
+  RenderPropsOrParams extends LeftOrExactRight<
+    RenderPropsOrParams,
+    DefaultComponentProps,
+    ComponentConfigParams
+  > = DefaultComponentProps,
   FieldProps extends DefaultComponentProps = RenderPropsOrParams extends ComponentConfigParams
     ? RenderPropsOrParams["props"]
     : RenderPropsOrParams,
@@ -120,12 +118,11 @@ type RootConfigInternal<
 
 // DEPRECATED - remove old generics in favour of Params
 export type RootConfig<
-  RootPropsOrParams extends
-    | (DefaultComponentProps & RootPropsOrParams extends ComponentConfigParams
-        ? ExactComponentConfigParams<RootPropsOrParams>
-        : DefaultComponentProps)
-    | (ComponentConfigParams &
-        ExactComponentConfigParams<RootPropsOrParams>) = DefaultComponentProps
+  RootPropsOrParams extends LeftOrExactRight<
+    RootPropsOrParams,
+    DefaultComponentProps,
+    ComponentConfigParams
+  > = DefaultComponentProps | ComponentConfigParams
 > = RootPropsOrParams extends ComponentConfigParams<
   infer Props,
   infer UserFields
@@ -173,13 +170,11 @@ export type DefaultComponents = Record<string, any>;
 
 // DEPRECATED - remove old generics in favour of Params
 export type Config<
-  PropsOrParams extends
-    | (DefaultComponents & PropsOrParams extends ConfigParams // Catch any type widening
-        ? ExactConfigParams<PropsOrParams>
-        : DefaultComponents)
-    | (ConfigParams & ExactConfigParams<PropsOrParams>) =
-    | DefaultComponents
-    | ConfigParams,
+  PropsOrParams extends LeftOrExactRight<
+    PropsOrParams,
+    DefaultComponents,
+    ConfigParams
+  > = DefaultComponents | ConfigParams,
   RootProps extends DefaultComponentProps = DefaultComponentProps,
   CategoryName extends string = string
 > = PropsOrParams extends ConfigParams<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -1,5 +1,5 @@
 import type { JSX, ReactNode } from "react";
-import { BaseField, Field, Fields } from "./Fields";
+import { BaseField, Fields } from "./Fields";
 import { ComponentData, Metadata, RootData } from "./Data";
 
 import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -218,24 +218,12 @@ export type ExtractConfigParams<UserConfig extends ConfigInternal> =
     infer PropsOrParams,
     infer RootProps,
     infer CategoryName,
-    never
+    infer UserField
   >
     ? {
         props: PropsOrParams;
         rootProps: RootProps & DefaultRootFieldProps;
         categoryNames: CategoryName;
-        field: Field;
-      }
-    : UserConfig extends ConfigInternal<
-        infer PropsOrParams,
-        infer RootProps,
-        infer CategoryName,
-        infer UserField
-      >
-    ? {
-        props: PropsOrParams;
-        rootProps: RootProps & DefaultRootFieldProps;
-        categoryNames: CategoryName;
-        field: UserField;
+        field: UserField extends { type: string } ? UserField : Field;
       }
     : never;

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -175,7 +175,9 @@ export type Config<
 > = ConfigInternal<
   PropsOrParams extends ConfigParams<infer Props> ? Props : PropsOrParams,
   RootProps,
-  CategoryName,
+  PropsOrParams extends ConfigParams<any, any, infer ParamCategoryName>
+    ? ParamCategoryName[number]
+    : CategoryName,
   PropsOrParams extends ConfigParams<any, any, any, infer UserFields>
     ? UserFields[keyof UserFields] // Combine fields into union
     : {}

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -211,7 +211,7 @@ export type Config<
       any
     >
   ? ConfigInternal<ParamComponents, ParamRoot, ParamCategoryName[number], {}>
-  : ConfigInternal<PropsOrParams, RootProps, CategoryName, Field>;
+  : ConfigInternal<PropsOrParams, RootProps, CategoryName>;
 
 export type ExtractConfigParams<UserConfig extends ConfigInternal> =
   UserConfig extends ConfigInternal<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -204,6 +204,13 @@ export type Config<
       ParamCategoryName[number],
       ParamFields[keyof ParamFields] & BaseField
     >
+  : PropsOrParams extends ConfigParams<
+      infer ParamComponents,
+      infer ParamRoot,
+      infer ParamCategoryName,
+      any
+    >
+  ? ConfigInternal<ParamComponents, ParamRoot, ParamCategoryName[number], {}>
   : ConfigInternal<PropsOrParams, RootProps, CategoryName, Field>;
 
 export type ExtractConfigParams<UserConfig extends ConfigInternal> =

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -10,6 +10,8 @@ import { DropZoneProps } from "../components/DropZone/types";
 import {
   ComponentConfigParams,
   ConfigParams,
+  ExactComponentConfigParams,
+  ExactConfigParams,
   FieldsExtension,
   WithDeepSlots,
 } from "./Internal";
@@ -83,8 +85,11 @@ type ComponentConfigInternal<
 // DEPRECATED - remove old generics in favour of Params
 export type ComponentConfig<
   RenderPropsOrParams extends
-    | DefaultComponentProps
-    | ComponentConfigParams = DefaultComponentProps,
+    | (DefaultComponentProps & RenderPropsOrParams extends ComponentConfigParams
+        ? ExactComponentConfigParams<RenderPropsOrParams>
+        : DefaultComponentProps)
+    | (ComponentConfigParams &
+        ExactComponentConfigParams<RenderPropsOrParams>) = DefaultComponentProps,
   FieldProps extends DefaultComponentProps = RenderPropsOrParams extends ComponentConfigParams
     ? RenderPropsOrParams["props"]
     : RenderPropsOrParams,
@@ -158,7 +163,13 @@ export type DefaultComponents = Record<string, any>;
 
 // DEPRECATED - remove old generics in favour of Params
 export type Config<
-  PropsOrParams extends DefaultComponents | ConfigParams = DefaultComponents,
+  PropsOrParams extends
+    | (DefaultComponents & PropsOrParams extends ConfigParams // Catch any type widening
+        ? ExactConfigParams<PropsOrParams>
+        : DefaultComponents)
+    | (ConfigParams & ExactConfigParams<PropsOrParams>) =
+    | DefaultComponents
+    | ConfigParams,
   RootProps extends DefaultComponentProps = any,
   CategoryName extends string = string
 > = ConfigInternal<

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -154,7 +154,7 @@ type ConfigInternal<
   Props extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultComponentProps,
   CategoryName extends string = string,
-  UserField extends {} = {}
+  UserField extends {} = Field
 > = {
   categories?: Record<CategoryName, Category<keyof Props>> & {
     other?: Category<keyof Props>;
@@ -191,7 +191,7 @@ export type Config<
   infer ParamCategoryName,
   never
 >
-  ? ConfigInternal<ParamComponents, ParamRoot, ParamCategoryName[number], Field>
+  ? ConfigInternal<ParamComponents, ParamRoot, ParamCategoryName[number]>
   : PropsOrParams extends ConfigParams<
       infer ParamComponents,
       infer ParamRoot,
@@ -202,7 +202,7 @@ export type Config<
       ParamComponents,
       ParamRoot,
       ParamCategoryName[number],
-      (ParamFields[keyof ParamFields] & BaseField) | Field
+      ParamFields[keyof ParamFields] & BaseField
     >
   : ConfigInternal<PropsOrParams, RootProps, CategoryName, Field>;
 

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -154,7 +154,7 @@ type ConfigInternal<
   Props extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultComponentProps,
   CategoryName extends string = string,
-  UserField extends {} = Field
+  UserField extends {} = {}
 > = {
   categories?: Record<CategoryName, Category<keyof Props>> & {
     other?: Category<keyof Props>;
@@ -211,8 +211,20 @@ export type ExtractConfigParams<UserConfig extends ConfigInternal> =
     infer PropsOrParams,
     infer RootProps,
     infer CategoryName,
-    infer UserField
+    never
   >
+    ? {
+        props: PropsOrParams;
+        rootProps: RootProps & DefaultRootFieldProps;
+        categoryNames: CategoryName;
+        field: Field;
+      }
+    : UserConfig extends ConfigInternal<
+        infer PropsOrParams,
+        infer RootProps,
+        infer CategoryName,
+        infer UserField
+      >
     ? {
         props: PropsOrParams;
         rootProps: RootProps & DefaultRootFieldProps;

--- a/packages/core/types/Data.tsx
+++ b/packages/core/types/Data.tsx
@@ -1,4 +1,5 @@
-import { DefaultAllProps, WithDeepSlots } from "./Internal";
+import { DefaultComponents } from "./Config";
+import { WithDeepSlots } from "./Internal";
 import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
 import { AsFieldProps, WithId } from "./Utils";
 
@@ -27,13 +28,13 @@ export type RootData<
 export type ComponentData<
   Props extends DefaultComponentProps = DefaultComponentProps,
   Name = string,
-  AllProps extends Record<string, DefaultComponentProps> = Record<
+  Components extends Record<string, DefaultComponentProps> = Record<
     string,
     DefaultComponentProps
   >
 > = {
   type: Name;
-  props: WithDeepSlots<WithId<Props>, Content<AllProps>>;
+  props: WithDeepSlots<WithId<Props>, Content<Components>>;
 } & BaseData<Props>;
 
 export type ComponentDataOptionalId<
@@ -50,14 +51,14 @@ export type ComponentDataOptionalId<
 export type MappedItem = ComponentData;
 
 export type ComponentDataMap<
-  AllProps extends DefaultAllProps = DefaultAllProps
+  Components extends DefaultComponents = DefaultComponents
 > = {
-  [K in keyof AllProps]: ComponentData<
-    AllProps[K],
+  [K in keyof Components]: ComponentData<
+    Components[K],
     K extends string ? K : never,
-    AllProps
+    Components
   >;
-}[keyof AllProps];
+}[keyof Components];
 
 export type Content<
   PropsMap extends { [key: string]: DefaultComponentProps } = {
@@ -66,12 +67,12 @@ export type Content<
 > = ComponentDataMap<PropsMap>[];
 
 export type Data<
-  AllProps extends DefaultAllProps = DefaultAllProps,
+  Components extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultRootFieldProps
 > = {
-  root: WithDeepSlots<RootData<RootProps>, Content<AllProps>>;
-  content: Content<AllProps>;
-  zones?: Record<string, Content<AllProps>>;
+  root: WithDeepSlots<RootData<RootProps>, Content<Components>>;
+  content: Content<Components>;
+  zones?: Record<string, Content<Components>>;
 };
 
 export type Metadata = { [key: string]: any };

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -46,11 +46,14 @@ export type RadioField = BaseField & {
 };
 
 export type ArrayField<
-  Props extends { [key: string]: any }[] = { [key: string]: any }[]
+  Props extends { [key: string]: any }[] = { [key: string]: any }[],
+  UserField extends {} = {}
 > = BaseField & {
   type: "array";
   arrayFields: {
-    [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
+    [SubPropName in keyof Props[0]]: UserField extends { type: PropertyKey }
+      ? Field<Props[0][SubPropName], UserField> | UserField
+      : Field<Props[0][SubPropName], UserField>;
   };
   defaultItemProps?: Props[0];
   getItemSummary?: (item: Props[0], index?: number) => string;
@@ -58,13 +61,17 @@ export type ArrayField<
   min?: number;
 };
 
-export type ObjectField<Props extends any = { [key: string]: any }> =
-  BaseField & {
-    type: "object";
-    objectFields: {
-      [SubPropName in keyof Props]: Field<Props[SubPropName]>;
-    };
+export type ObjectField<
+  Props extends any = { [key: string]: any },
+  UserField extends {} = {}
+> = BaseField & {
+  type: "object";
+  objectFields: {
+    [SubPropName in keyof Props]: UserField extends { type: PropertyKey }
+      ? Field<Props[SubPropName]> | UserField
+      : Field<Props[SubPropName]>;
   };
+};
 
 // DEPRECATED
 export type Adaptor<
@@ -129,14 +136,17 @@ export type SlotField = BaseField & {
   disallow?: string[];
 };
 
-export type Field<ValueType = any> =
+export type Field<ValueType = any, UserField extends {} = {}> =
   | TextField
   | NumberField
   | TextareaField
   | SelectField
   | RadioField
-  | ArrayField<ValueType extends { [key: string]: any }[] ? ValueType : {}[]>
-  | ObjectField<ValueType>
+  | ArrayField<
+      ValueType extends { [key: string]: any }[] ? ValueType : {}[],
+      UserField
+    >
+  | ObjectField<ValueType, UserField>
   | ExternalField<ValueType>
   | ExternalFieldWithAdaptor<ValueType>
   | CustomField<ValueType>
@@ -149,7 +159,7 @@ export type Fields<
   [PropName in keyof Omit<ComponentProps, "editMode">]: UserField extends {
     type: PropertyKey;
   }
-    ? Field<ComponentProps[PropName]> | UserField
+    ? Field<ComponentProps[PropName], UserField> | UserField
     : Field<ComponentProps[PropName]>;
 };
 

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -144,11 +144,14 @@ export type Field<ValueType = any> =
   | SlotField;
 
 export type Fields<
-  ComponentProps extends DefaultComponentProps = DefaultComponentProps
+  ComponentProps extends DefaultComponentProps = DefaultComponentProps,
+  UserField extends {} = {}
 > = {
-  [PropName in keyof Omit<ComponentProps, "editMode">]: Field<
-    ComponentProps[PropName]
-  >;
+  [PropName in keyof Omit<ComponentProps, "editMode">]: UserField extends {
+    type: string;
+  }
+    ? Field<ComponentProps[PropName]> | UserField
+    : Field<ComponentProps[PropName]>;
 };
 
 export type FieldProps<F = Field<any>, ValueType = any> = {

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -46,7 +46,7 @@ export type RadioField = BaseField & {
 };
 
 export type ArrayField<
-  Props extends { [key: string]: any } = { [key: string]: any }
+  Props extends { [key: string]: any }[] = { [key: string]: any }[]
 > = BaseField & {
   type: "array";
   arrayFields: {
@@ -135,7 +135,7 @@ export type Field<ValueType = any> =
   | TextareaField
   | SelectField
   | RadioField
-  | ArrayField<ValueType extends { [key: string]: any } ? ValueType : {}>
+  | ArrayField<ValueType extends { [key: string]: any }[] ? ValueType : {}[]>
   | ObjectField<ValueType>
   | ExternalField<ValueType>
   | ExternalFieldWithAdaptor<ValueType>

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -148,7 +148,7 @@ export type Fields<
   UserField extends {} = {}
 > = {
   [PropName in keyof Omit<ComponentProps, "editMode">]: UserField extends {
-    type: string;
+    type: PropertyKey;
   }
     ? Field<ComponentProps[PropName]> | UserField
     : Field<ComponentProps[PropName]>;

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -45,19 +45,18 @@ export type RadioField = BaseField & {
   options: FieldOptions;
 };
 
-export type ArrayField<Props extends any = { [key: string]: any }> =
-  Props extends { [key: string]: any }
-    ? BaseField & {
-        type: "array";
-        arrayFields: {
-          [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
-        };
-        defaultItemProps?: Props[0];
-        getItemSummary?: (item: Props[0], index?: number) => string;
-        max?: number;
-        min?: number;
-      }
-    : never;
+export type ArrayField<
+  Props extends { [key: string]: any } = { [key: string]: any }
+> = BaseField & {
+  type: "array";
+  arrayFields: {
+    [SubPropName in keyof Props[0]]: Field<Props[0][SubPropName]>;
+  };
+  defaultItemProps?: Props[0];
+  getItemSummary?: (item: Props[0], index?: number) => string;
+  max?: number;
+  min?: number;
+};
 
 export type ObjectField<Props extends any = { [key: string]: any }> =
   BaseField & {
@@ -136,7 +135,7 @@ export type Field<ValueType = any> =
   | TextareaField
   | SelectField
   | RadioField
-  | ArrayField<ValueType>
+  | ArrayField<ValueType extends { [key: string]: any } ? ValueType : {}>
   | ObjectField<ValueType>
   | ExternalField<ValueType>
   | ExternalFieldWithAdaptor<ValueType>

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -62,12 +62,12 @@ export type WithDeepSlots<T, SlotType = T> =
 export type ConfigParams<
   Components extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = any,
-  CategoryNames extends string[] = [],
+  CategoryNames extends string[] = string[],
   UserFields extends FieldsExtension = {}
 > = {
   components?: Components;
   root?: RootProps;
-  categoryNames?: CategoryNames;
+  categories?: CategoryNames;
   fields?: UserFields;
 };
 

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -109,3 +109,7 @@ export type ExtractConfigParams<UserConfig extends Config> =
           : never;
       }
     : never;
+
+export type Exact<T, Target> = Record<Exclude<keyof T, keyof Target>, never>;
+export type ExactConfigParams<T> = Exact<T, ConfigParams>;
+export type ExactComponentConfigParams<T> = Exact<T, ComponentConfigParams>;

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -1,8 +1,7 @@
 import { Slot } from "./API";
 import { AppState } from "./AppState";
-import { ComponentConfig, Config, DefaultComponents } from "./Config";
+import { Config, DefaultComponents } from "./Config";
 import { ComponentData, Data } from "./Data";
-import { Field } from "./Fields";
 import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
 
 export type ZoneType = "root" | "dropzone" | "slot";

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -68,7 +68,7 @@ export type ConfigParams<
   components?: Components;
   root?: RootProps;
   categories?: CategoryNames;
-  fields?: AssertHasValue<UserFields, UserFields, {}>;
+  fields?: AssertHasValue<UserFields>;
 };
 
 export type FieldsExtension = { [Type in string]: { type: Type } };

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -81,35 +81,6 @@ export type ComponentConfigParams<
   fields?: UserField;
 };
 
-export type ExtractConfigParams<UserConfig extends Config> =
-  UserConfig extends Config<
-    infer PropsOrParams,
-    infer RootProps,
-    infer CategoryName
-  >
-    ? {
-        props: PropsOrParams extends ConfigParams<infer Props> ? Props : never;
-        rootProps: PropsOrParams extends ConfigParams<any, infer ParamRootProps>
-          ? ParamRootProps & DefaultRootFieldProps
-          : RootProps & DefaultRootFieldProps;
-        categoryNames: PropsOrParams extends ConfigParams<
-          any,
-          any,
-          infer ParamCategoryName
-        >
-          ? ParamCategoryName[keyof ParamCategoryName] // Convert to union
-          : CategoryName;
-        fields: PropsOrParams extends ConfigParams<
-          any,
-          any,
-          any,
-          infer ParamField
-        >
-          ? ParamField
-          : never;
-      }
-    : never;
-
 // Check the keys of T do not introduce additional ones to Target
 export type Exact<T, Target> = Record<Exclude<keyof T, keyof Target>, never>;
 

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -1,7 +1,9 @@
 import { Slot } from "./API";
 import { AppState } from "./AppState";
+import { ComponentConfig, Config, DefaultComponents } from "./Config";
 import { ComponentData, Data } from "./Data";
-import { DefaultComponentProps } from "./Props";
+import { Field } from "./Fields";
+import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
 
 export type ZoneType = "root" | "dropzone" | "slot";
 
@@ -28,8 +30,6 @@ export type PrivateAppState<UserData extends Data = Data> =
       zones: ZoneIndex;
     };
   };
-
-export type DefaultAllProps = Record<string, DefaultComponentProps>;
 
 type BuiltinTypes =
   | Date
@@ -59,3 +59,54 @@ export type WithDeepSlots<T, SlotType = T> =
     T extends object
     ? { [K in keyof T]: WithDeepSlots<T[K], SlotType> }
     : T;
+
+export type ConfigParams<
+  Components extends DefaultComponents = DefaultComponents,
+  RootProps extends DefaultComponentProps = any,
+  CategoryNames extends string[] = [],
+  UserFields extends FieldsExtension = {}
+> = {
+  components?: Components;
+  root?: RootProps;
+  categoryNames?: CategoryNames;
+  fields?: UserFields;
+};
+
+export type FieldsExtension = { [Type in string]: { type: Type } };
+
+export type ComponentConfigParams<
+  Props extends DefaultComponentProps = DefaultComponentProps,
+  UserField extends FieldsExtension = FieldsExtension
+> = {
+  props: Props;
+  fields?: UserField;
+};
+
+export type ExtractConfigParams<UserConfig extends Config> =
+  UserConfig extends Config<
+    infer PropsOrParams,
+    infer RootProps,
+    infer CategoryName
+  >
+    ? {
+        props: PropsOrParams extends ConfigParams<infer Props> ? Props : never;
+        rootProps: PropsOrParams extends ConfigParams<any, infer ParamRootProps>
+          ? ParamRootProps & DefaultRootFieldProps
+          : RootProps & DefaultRootFieldProps;
+        categoryNames: PropsOrParams extends ConfigParams<
+          any,
+          any,
+          infer ParamCategoryName
+        >
+          ? ParamCategoryName[keyof ParamCategoryName] // Convert to union
+          : CategoryName;
+        fields: PropsOrParams extends ConfigParams<
+          any,
+          any,
+          any,
+          infer ParamField
+        >
+          ? ParamField
+          : never;
+      }
+    : never;

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -61,7 +61,7 @@ export type WithDeepSlots<T, SlotType = T> =
 
 export type ConfigParams<
   Components extends DefaultComponents = DefaultComponents,
-  RootProps extends DefaultComponentProps = any,
+  RootProps extends DefaultComponentProps = DefaultComponentProps,
   CategoryNames extends string[] = string[],
   UserFields extends FieldsExtension = {}
 > = {

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -63,22 +63,22 @@ export type ConfigParams<
   Components extends DefaultComponents = DefaultComponents,
   RootProps extends DefaultComponentProps = DefaultComponentProps,
   CategoryNames extends string[] = string[],
-  UserFields extends FieldsExtension = {}
+  UserFields extends FieldsExtension = FieldsExtension
 > = {
   components?: Components;
   root?: RootProps;
   categories?: CategoryNames;
-  fields?: UserFields;
+  fields?: AssertHasValue<UserFields, UserFields, {}>;
 };
 
 export type FieldsExtension = { [Type in string]: { type: Type } };
 
 export type ComponentConfigParams<
   Props extends DefaultComponentProps = DefaultComponentProps,
-  UserField extends FieldsExtension = FieldsExtension
+  UserFields extends FieldsExtension = never
 > = {
   props: Props;
-  fields?: UserField;
+  fields?: AssertHasValue<UserFields>;
 };
 
 // Check the keys of T do not introduce additional ones to Target
@@ -89,3 +89,9 @@ export type Exact<T, Target> = Record<Exclude<keyof T, keyof Target>, never>;
 export type LeftOrExactRight<Union, Left, Right> =
   | (Left & Union extends Right ? Exact<Union, Right> : Left)
   | (Right & Exact<Union, Right>);
+
+export type AssertHasValue<T, True = T, False = never> = [keyof T] extends [
+  never
+]
+  ? False
+  : True;

--- a/packages/core/types/Internal.tsx
+++ b/packages/core/types/Internal.tsx
@@ -110,6 +110,11 @@ export type ExtractConfigParams<UserConfig extends Config> =
       }
     : never;
 
+// Check the keys of T do not introduce additional ones to Target
 export type Exact<T, Target> = Record<Exclude<keyof T, keyof Target>, never>;
-export type ExactConfigParams<T> = Exact<T, ConfigParams>;
-export type ExactComponentConfigParams<T> = Exact<T, ComponentConfigParams>;
+
+// Ensures the union either extends the left type, or is exactly the right type
+// This prevents type widening
+export type LeftOrExactRight<Union, Left, Right> =
+  | (Left & Union extends Right ? Exact<Union, Right> : Left)
+  | (Right & Exact<Union, Right>);

--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -20,4 +20,4 @@ export type DefaultRootRenderProps<
 
 export type DefaultRootProps = DefaultRootRenderProps; // Deprecated
 
-export type DefaultComponentProps = { [key: string]: unknown };
+export type DefaultComponentProps = { [key: string]: any };

--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -10,7 +10,6 @@ export type PuckContext = {
 };
 
 export type DefaultRootFieldProps = {
-  [key: string]: any;
   title?: string;
 };
 

--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -20,4 +20,4 @@ export type DefaultRootRenderProps<
 
 export type DefaultRootProps = DefaultRootRenderProps; // Deprecated
 
-export type DefaultComponentProps = { [key: string]: any };
+export type DefaultComponentProps = { [key: string]: unknown };

--- a/packages/core/types/Utils.tsx
+++ b/packages/core/types/Utils.tsx
@@ -1,10 +1,9 @@
 import { ReactNode } from "react";
-import { Config } from "./Config";
+import { Config, ExtractConfigParams } from "./Config";
 import { DefaultRootFieldProps, PuckContext } from "./Props";
 import { ComponentData, Data } from "./Data";
-import { ExtractConfigParams, PrivateAppState } from "./Internal";
+import { PrivateAppState } from "./Internal";
 import { AppState } from "./AppState";
-import { BaseField, Field } from "./Fields";
 
 export type WithId<Props> = Props & {
   id: string;
@@ -38,9 +37,7 @@ export type UserGenerics<
   UserAppState: UserAppState;
   UserPublicAppState: UserPublicAppState;
   UserComponentData: UserComponentData;
-  UserField:
-    | (UserParams["fields"][keyof UserParams["fields"]] & BaseField)
-    | Field;
+  UserField: UserParams["field"];
 };
 
 export type ExtractField<

--- a/packages/core/types/Utils.tsx
+++ b/packages/core/types/Utils.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from "react";
-import { Config } from "./Config";
+import { Config, ConfigWithExtensions } from "./Config";
 import { PuckContext } from "./Props";
 import { ComponentData, Data } from "./Data";
 import { PrivateAppState } from "./Internal";
 import { AppState } from "./AppState";
-import { Field } from "./Fields";
+import { BaseField, Field } from "./Fields";
 
 export type WithId<Props> = Props & {
   id: string;
@@ -36,8 +36,11 @@ export type ExtractRootPropsFromConfig<UserConfig> = UserConfig extends Config<
   ? P
   : never;
 
+export type ExtractTypeExtensions<UserConfig> =
+  UserConfig extends ConfigWithExtensions<infer P> ? P : never;
+
 export type UserGenerics<
-  UserConfig extends Config = Config,
+  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
   UserProps extends ExtractPropsFromConfig<UserConfig> = ExtractPropsFromConfig<UserConfig>,
   UserRootProps extends ExtractRootPropsFromConfig<UserConfig> = ExtractRootPropsFromConfig<UserConfig>,
   UserData extends Data<UserProps, UserRootProps> | Data = Data<
@@ -46,7 +49,15 @@ export type UserGenerics<
   >,
   UserAppState extends PrivateAppState<UserData> = PrivateAppState<UserData>,
   UserPublicAppState extends AppState<UserData> = AppState<UserData>,
-  UserComponentData extends ComponentData = UserData["content"][0]
+  UserComponentData extends ComponentData = UserData["content"][0],
+  UserTypeExtensions extends ExtractTypeExtensions<UserConfig> = ExtractTypeExtensions<UserConfig>,
+  UserField extends {
+    type: PropertyKey;
+  } = UserTypeExtensions["Field"] extends {
+    type: PropertyKey;
+  }
+    ? (UserTypeExtensions["Field"] & BaseField) | Field
+    : Field
 > = {
   UserConfig: UserConfig;
   UserProps: UserProps;
@@ -55,6 +66,15 @@ export type UserGenerics<
   UserAppState: UserAppState;
   UserPublicAppState: UserPublicAppState;
   UserComponentData: UserComponentData;
+  UserTypeExtensions: UserTypeExtensions;
+  UserField: UserField;
 };
 
-export type ExtractField<T extends Field["type"]> = Extract<Field, { type: T }>;
+export type ExtractField<
+  UserField extends { type: PropertyKey },
+  T extends UserField["type"]
+> = Extract<UserField, { type: T }>;
+
+export type TypeExtensions = {
+  Field?: { type: string };
+};

--- a/packages/core/types/Utils.tsx
+++ b/packages/core/types/Utils.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
-import { Config, ConfigWithExtensions } from "./Config";
-import { PuckContext } from "./Props";
+import { Config } from "./Config";
+import { DefaultRootFieldProps, PuckContext } from "./Props";
 import { ComponentData, Data } from "./Data";
-import { PrivateAppState } from "./Internal";
+import { ExtractConfigParams, PrivateAppState } from "./Internal";
 import { AppState } from "./AppState";
 import { BaseField, Field } from "./Fields";
 
@@ -20,61 +20,30 @@ export type WithChildren<Props> = Props & {
   children: ReactNode;
 };
 
-export type ExtractPropsFromConfig<UserConfig> = UserConfig extends Config<
-  infer P,
-  any,
-  any
->
-  ? P
-  : never;
-
-export type ExtractRootPropsFromConfig<UserConfig> = UserConfig extends Config<
-  any,
-  infer P,
-  any
->
-  ? P
-  : never;
-
-export type ExtractTypeExtensions<UserConfig> =
-  UserConfig extends ConfigWithExtensions<infer P> ? P : never;
-
 export type UserGenerics<
-  UserConfig extends ConfigWithExtensions = ConfigWithExtensions,
-  UserProps extends ExtractPropsFromConfig<UserConfig> = ExtractPropsFromConfig<UserConfig>,
-  UserRootProps extends ExtractRootPropsFromConfig<UserConfig> = ExtractRootPropsFromConfig<UserConfig>,
-  UserData extends Data<UserProps, UserRootProps> | Data = Data<
-    UserProps,
-    UserRootProps
-  >,
+  UserConfig extends Config = Config,
+  UserParams extends ExtractConfigParams<UserConfig> = ExtractConfigParams<UserConfig>,
+  UserData extends
+    | Data<UserParams["props"], UserParams["rootProps"]>
+    | Data = Data<UserParams["props"], UserParams["rootProps"]>,
   UserAppState extends PrivateAppState<UserData> = PrivateAppState<UserData>,
   UserPublicAppState extends AppState<UserData> = AppState<UserData>,
-  UserComponentData extends ComponentData = UserData["content"][0],
-  UserTypeExtensions extends ExtractTypeExtensions<UserConfig> = ExtractTypeExtensions<UserConfig>,
-  UserField extends {
-    type: PropertyKey;
-  } = UserTypeExtensions["Field"] extends {
-    type: PropertyKey;
-  }
-    ? (UserTypeExtensions["Field"] & BaseField) | Field
-    : Field
+  UserComponentData extends ComponentData = UserData["content"][0]
 > = {
   UserConfig: UserConfig;
-  UserProps: UserProps;
-  UserRootProps: UserRootProps;
+  UserParams: UserParams;
+  UserProps: UserParams["props"];
+  UserRootProps: UserParams["rootProps"] & DefaultRootFieldProps;
   UserData: UserData;
   UserAppState: UserAppState;
   UserPublicAppState: UserPublicAppState;
   UserComponentData: UserComponentData;
-  UserTypeExtensions: UserTypeExtensions;
-  UserField: UserField;
+  UserField:
+    | (UserParams["fields"][keyof UserParams["fields"]] & BaseField)
+    | Field;
 };
 
 export type ExtractField<
   UserField extends { type: PropertyKey },
   T extends UserField["type"]
 > = Extract<UserField, { type: T }>;
-
-export type TypeExtensions = {
-  Field?: { type: string };
-};


### PR DESCRIPTION
Closes #729, addressing support for user-defined fields in `overrides` and `fieldTransforms` (#1191). Also types plugins using the same mechanism.

This introduces generic types for `Config` (originally part of #1145) enabling typing via an object:

```ts
type UserConfig = Config<{
  components: { Hero: { background: string } },
  fields: { // Define new fields
    color: {
      type: "color",
      mode: "hex" | "rgb"
    }
  }
}>;
```

And for `ComponentConfig`:

```ts
type HeroConfig = Config<{
  props: { background: string },
  fields: { // Define new fields
    color: {
      type: "color",
      mode: "hex" | "rgb"
    }
  }
}>;
```

It is not possible to introduce automatic typing for field transforms, and the user must do this themselves. For inline text fields, the user must set the node to `string | ReactNode`.