### PR TITLE
feat: add overlay portals for UI beneath overlay

### DIFF
--- a/apps/docs/components/Preview/index.tsx
+++ b/apps/docs/components/Preview/index.tsx
@@ -3,6 +3,7 @@ import React, {
   CSSProperties,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -24,6 +25,7 @@ import { codeToHtml } from "shiki";
 
 import { createStore } from "zustand";
 import { useContextStore } from "@/core/lib/use-context-store";
+import { Button, registerOverlayPortal } from "@/core";
 
 export const PreviewStoreContext = createContext(
   createStore(() => ({ drawerVisible: false }))
@@ -258,5 +260,59 @@ export const ConfigPreview = ({
     >
       <ConfigPreviewInner componentConfig={componentConfig} />
     </PuckPreview>
+  );
+};
+
+export const OverlayPortalPreview = () => {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => registerOverlayPortal(ref.current), [ref.current]);
+
+  return (
+    <span ref={ref}>
+      <Button onClick={() => alert("Click")}>Clickable</Button>
+    </span>
+  );
+};
+
+export const OverlayPortalTabsPreview = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const [selected, setSelected] = useState(1);
+
+  useEffect(() => registerOverlayPortal(ref.current), [ref.current]);
+
+  return (
+    <div>
+      <div ref={ref} style={{ display: "inline-flex", gap: 8 }}>
+        <Button
+          onClick={() => setSelected(1)}
+          variant={selected === 1 ? "primary" : "secondary"}
+        >
+          Tab 1
+        </Button>
+        <Button
+          onClick={() => setSelected(2)}
+          variant={selected === 2 ? "primary" : "secondary"}
+        >
+          Tab 2
+        </Button>
+      </div>
+      <div
+        style={{
+          background: "#eee",
+          display: "flex",
+          padding: 64,
+          justifyContent: "center",
+          alignItems: "center",
+          gap: 8,
+          marginTop: 8,
+          fontSize: 32,
+        }}
+      >
+        {selected === 1 && <div>Tab 1</div>}
+        {selected === 2 && <div>Tab 2</div>}
+      </div>
+    </div>
   );
 };

--- a/apps/docs/pages/docs/api-reference/functions/register-overlay-portal.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/register-overlay-portal.mdx
@@ -1,0 +1,44 @@
+---
+title: registerOverlayPortal
+---
+
+# registerOverlayPortal
+
+Register a node as an [Overlay Portal](/docs/integrating-puck/overlay-portals), enabling interaction beneath the Puck overlay.
+
+```tsx copy
+import { registerOverlayPortal } from "@measured/puck";
+
+const MyComponent = () => {
+  const ref = useRef(null);
+
+  useEffect(() => registerOverlayPortal(ref.current), [ref.current]);
+
+  return <button ref={ref}>Clickable</button>;
+};
+```
+
+## Args
+
+| Param           | Example | Type                                                                        | Status |
+| --------------- | ------- | --------------------------------------------------------------------------- | ------ |
+| [`el`](#el)     | `div`   | [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) | -      |
+| [`opts`](#opts) | `{}`    | [Config](/docs/api-reference/configuration/config)                          | -      |
+
+### `el`
+
+The element to turn into a portal. Will do nothing if `null` or `undefined`.
+
+### `opts`
+
+| Param         | Example | Type    | Status |
+| ------------- | ------- | ------- | ------ |
+| `disableDrag` | `false` | boolean | -      |
+
+#### `opts.disableDrag`
+
+Disable triggering a drag of the parent component when this element is dragged. Defaults to `false`.
+
+## Returns
+
+A function to clean-up the portal.

--- a/apps/docs/pages/docs/integrating-puck/overlay-portals.mdx
+++ b/apps/docs/pages/docs/integrating-puck/overlay-portals.mdx
@@ -1,0 +1,84 @@
+import {
+  PuckPreview,
+  OverlayPortalPreview,
+  OverlayPortalTabsPreview,
+} from "@/docs/components/Preview";
+import { Puck } from "@/puck";
+
+# Overlay Portals
+
+Overlay Portals enable you to disable the Puck overlay when hovering over specific elements, making them interactive in the editor.
+
+Use the [`registerOverlayPortal` API](/docs/api-reference/functions/register-overlay-portal) to mark an element as a portal.
+
+```tsx
+const ref = useRef<HTMLButtonElement>(null);
+
+useEffect(() => registerOverlayPortal(ref.current), [ref.current]);
+
+return (
+  <button ref={ref} onClick={() => alert("Click")}>
+    Clickable
+  </button>
+);
+```
+
+<PuckPreview
+  label="Overlay Portals example"
+  config={{
+    components: {
+      Example: {
+        render: () => {
+          return (
+            <div style={{ padding: 32 }}>
+              <OverlayPortalPreview />
+            </div>
+          );
+        },
+      },
+    },
+  }}
+  data={{
+    content: [
+      {
+        type: "Example",
+        props: {
+          id: "Example-1",
+        },
+      },
+    ],
+    root: { props: {} },
+  }}
+>
+  <Puck.Preview />
+</PuckPreview>
+
+Portals can be used to create interactive functionality for previewing, such as to paginate through tabs, or combined with [`usePuck()`](/docs/extending-puck/internal-puck-api) to create an inline form input.
+
+## Example: Tabs
+
+<PuckPreview
+  label="Tabs example"
+  config={{
+    components: {
+      Example: {
+        render: () => {
+          return <OverlayPortalTabsPreview />;
+        },
+      },
+    },
+  }}
+  data={{
+    content: [
+      {
+        type: "Example",
+        props: {
+          id: "Example-1",
+        },
+      },
+    ],
+    root: { props: {} },
+  }}
+>
+  <Puck.Preview />
+</PuckPreview>

--- a/packages/core/bundle/core.ts
+++ b/packages/core/bundle/core.ts
@@ -19,6 +19,7 @@ export * from "../components/Render";
 
 export * from "../lib/migrate";
 export * from "../lib/transform-props";
+export { registerOverlayPortal } from "../lib/overlay-portal";
 export * from "../lib/resolve-all-data";
 export { walkTree } from "../lib/data/walk-tree";
 export {

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -349,7 +349,11 @@ export const DraggableComponent = ({
 
   const onClick = useCallback(
     (e: Event | SyntheticEvent) => {
-      e.stopPropagation();
+      const el = e.target as Element;
+
+      if (!el.closest("[data-puck-overlay-portal]")) {
+        e.stopPropagation();
+      }
 
       dispatch({
         type: "setUi",

--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -163,13 +163,20 @@ export const Canvas = () => {
         ready: status === "READY" || !iframe.enabled || !iframe.waitForStyles,
         showLoader,
       })}
-      onClick={() =>
-        dispatch({
-          type: "setUi",
-          ui: { itemSelector: null },
-          recordHistory: true,
-        })
-      }
+      onClick={(e) => {
+        const el = e.target as Element;
+
+        if (
+          !el.hasAttribute("data-puck-component") &&
+          !el.hasAttribute("data-puck-dropzone")
+        ) {
+          dispatch({
+            type: "setUi",
+            ui: { itemSelector: null },
+            recordHistory: true,
+          });
+        }
+      }}
     >
       {viewports.controlsVisible && iframe.enabled && (
         <div className={getClassName("controls")}>

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -134,8 +134,15 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
       className={getClassName()}
       id={id}
       data-puck-preview
-      onClick={() => {
-        dispatch({ type: "setUi", ui: { itemSelector: null } });
+      onClick={(e) => {
+        const el = e.target as Element;
+
+        if (
+          !el.hasAttribute("data-puck-component") &&
+          !el.hasAttribute("data-puck-dropzone")
+        ) {
+          dispatch({ type: "setUi", ui: { itemSelector: null } });
+        }
       }}
     >
       {iframe.enabled ? (

--- a/packages/core/lib/overlay-portal/index.tsx
+++ b/packages/core/lib/overlay-portal/index.tsx
@@ -1,6 +1,5 @@
 import "./styles.css";
 
-// TODO prevent drag
 export const registerOverlayPortal = (
   el: HTMLElement | null | undefined,
   opts: { disableDrag?: boolean } = {}

--- a/packages/core/lib/overlay-portal/index.tsx
+++ b/packages/core/lib/overlay-portal/index.tsx
@@ -1,0 +1,42 @@
+import "./styles.css";
+
+// TODO prevent drag
+export const registerOverlayPortal = (
+  el: HTMLElement | null | undefined,
+  opts: { disableDrag?: boolean } = {}
+) => {
+  if (!el) return;
+
+  const { disableDrag = true } = opts;
+
+  const stopPropagation = (e: MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  el.addEventListener("mouseover", stopPropagation, {
+    capture: true,
+  });
+
+  // Disables dnd PointerSensor
+  if (disableDrag) {
+    el.addEventListener("pointerdown", stopPropagation, {
+      capture: true,
+    });
+  }
+
+  el.setAttribute("data-puck-overlay-portal", "true");
+
+  return () => {
+    el.removeEventListener("mouseover", stopPropagation, {
+      capture: true,
+    });
+
+    if (disableDrag) {
+      el.removeEventListener("pointerdown", stopPropagation, {
+        capture: true,
+      });
+    }
+
+    el.removeAttribute("data-puck-overlay-portal");
+  };
+};

--- a/packages/core/lib/overlay-portal/styles.css
+++ b/packages/core/lib/overlay-portal/styles.css
@@ -1,0 +1,14 @@
+[data-puck-overlay-portal],
+[data-puck-overlay-portal] * {
+  pointer-events: auto;
+}
+
+[data-puck-overlay-portal]:hover {
+  outline: 2px var(--puck-color-azure-09) solid;
+  outline-offset: 2px;
+}
+
+[data-puck-overlay-portal]:focus-within {
+  outline: 2px var(--puck-color-azure-07) solid;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Add overlay portals via a new `registerOverlayPortal` API. Overlay portals enable parts of the component to be punch-through the overlay, enabling targeted interactivity.

This will enable inline content editing (often conflated with rich text), amongst other functionality.

https://github.com/user-attachments/assets/020a5ec9-881e-4b8d-9a72-f49122829b76

## Usage

```tsx
import { registerOverlayPortal } from "@measured/puck";

const MyComponent = () => {
  const ref = useRef<HTMLDivElement>(null);

  useEffect(() => registerOverlayPortal(ref.current), [ref.current]);

  return <button ref={ref}>Clickable</button>
}
```

## Tasks

- [x] Don't block `click` event (buttons not clickable)
- [x] Optionally prevent dragging
- [x] Document API