### PR TITLE
fix(outline): enable horizontal scroll when content overflows

### DIFF
--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -99,7 +99,7 @@
   gap: 8px;
   align-items: center;
   margin: 8px 4px;
-  overflow-x: hidden;
+  min-width: max-content;
 }
 
 .Layer-name {


### PR DESCRIPTION
### Summary
The Outline was clipping long rows when it overflowed on the x-axis.

### Fix
Set `min-width: max-content` on `.Layer-title` and `.LayerTree-zoneTitle` so rows display fully. When content overflows, the existing container shows a horizontal scrollbar and nothing clips.

### Screenshot
<img width="255" height="860" alt="after" src="https://github.com/user-attachments/assets/91dc043c-f6c0-4924-a5a7-448f33546e90" />

closes #1048
