### PR TITLE
feat: add delete hotkey for component deletion (backspace/delete)

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -50,6 +50,7 @@ import { useLoadedOverrides } from "../../lib/use-loaded-overrides";
 import { DefaultOverride } from "../DefaultOverride";
 import { useInjectGlobalCss } from "../../lib/use-inject-css";
 import { usePreviewModeHotkeys } from "../../lib/use-preview-mode-hotkeys";
+import { useDeleteHotkeys } from "../../lib/use-delete-hotkeys";
 import { useRegisterHistorySlice } from "../../store/slices/history";
 import { useRegisterPermissionsSlice } from "../../store/slices/permissions";
 import { monitorHotkeys, useMonitorHotkeys } from "../../lib/use-hotkey";
@@ -481,6 +482,7 @@ function PuckLayout<
   const ready = useAppStore((s) => s.status === "READY");
 
   useMonitorHotkeys();
+  useDeleteHotkeys();
 
   useEffect(() => {
     if (ready && iframe.enabled) {

--- a/packages/core/lib/use-delete-hotkeys.ts
+++ b/packages/core/lib/use-delete-hotkeys.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useHotkey } from "./use-hotkey";
+import { useAppStoreApi } from "../store";
+
+const isEditableElement = (target: EventTarget | null): boolean => {
+  if (!target || !(target instanceof HTMLElement)) return false;
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "input" || tagName === "textarea") return true;
+  if (target.isContentEditable) return true;
+
+  return false;
+};
+
+export const useDeleteHotkeys = () => {
+  const appStore = useAppStoreApi();
+
+  const deleteSelectedComponent = useCallback((e?: KeyboardEvent) => {
+    if (isEditableElement(document.activeElement)) {
+      return false;
+    }
+
+    const { state, dispatch } = appStore.getState();
+    const { itemSelector } = state.ui;
+
+    if (!itemSelector || !itemSelector.zone) {
+      return false;
+    }
+
+    dispatch({
+      type: "remove",
+      index: itemSelector.index,
+      zone: itemSelector.zone,
+    });
+
+    return true;
+  }, [appStore]);
+
+  useHotkey({ delete: true }, deleteSelectedComponent);
+  useHotkey({ backspace: true }, deleteSelectedComponent);
+};

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -32,6 +32,8 @@ const keys = [
   "x",
   "y",
   "z",
+  "delete",
+  "backspace",
 ] as const;
 
 type KeyStrict = (typeof keys)[number];
@@ -72,6 +74,8 @@ const keyCodeMap: KeyCodeMap = {
   KeyX: "x",
   KeyY: "y",
   KeyZ: "z",
+  Delete: "delete",
+  Backspace: "backspace",
 };
 
 const useHotkeyStore = create<{
@@ -110,10 +114,13 @@ export const monitorHotkeys = (doc: Document) => {
             ([key, value]) => value === !!(combo as KeyMap)[key]
           );
 
-        if (conditionMet) {
-          e.preventDefault();
-          cb();
-        }
+          // Call hotkey with event; skip preventDefault if callback returns false to allow native input behavior.
+          if (conditionMet) {
+            const handled = cb(e);
+            if (handled !== false) {
+              e.preventDefault();
+            }
+          }
       });
 
       // Only retain hold on modifiers


### PR DESCRIPTION
## Description  
Addresses #1132
This PR adds delete hotkeys for removing the currently selected component. 

### Changes  
- Implemented **Proposal 1**: pressing **Backspace** or **Delete** will remove the selected component.  
- Made a small adjustment to the global hotkey functionality to ensure the delete/backspace combo works smoothly without interfering with other bindings and the native deletion in sidebar text editing.  

### Rationale  
Most design tools (e.g., Figma, Canva, etc.) allow deleting selected components with backspace or delete, so this behavior aligns with user expectations. Proposal 1 was chosen for consistency with those tools.  
