### PR TITLE
fix: prevent hidden category components from showing in 'Other'

### DIFF
--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -15,10 +15,18 @@ export const useComponentList = () => {
 
       _componentList = Object.entries(uiComponentList).map(
         ([categoryKey, category]) => {
-          if (category.visible === false || !category.components) {
+          if (!category.components) {
             return null;
           }
-
+      
+          category.components.forEach((componentName) => {
+            matchedComponents.push(componentName as string);
+          });
+      
+          if (category.visible === false) {
+            return null;
+          }
+      
           return (
             <ComponentList
               id={categoryKey}
@@ -26,10 +34,8 @@ export const useComponentList = () => {
               title={category.title || categoryKey}
             >
               {category.components.map((componentName, i) => {
-                matchedComponents.push(componentName as string);
-
                 const componentConf = config.components[componentName] || {};
-
+      
                 return (
                   <ComponentList.Item
                     key={componentName}


### PR DESCRIPTION
### Addresses #1257 
### Fix: Prevent Hidden Category Components from Appearing in "Other"

#### What was happening
Components assigned to categories marked `visible: false` were being rendered under the default "Other" category. This was incorrect — components in hidden categories should not appear in the sidebar at all.

#### What’s the fix
We now ensure that all components in hidden categories are **tracked** as categorized, so they don’t fall through to the "Other" fallback list — even though they are not rendered.

#### How it works
- Added hidden components to the `matchedComponents` list
- Preserved the existing visibility condition to prevent rendering them
- Keeps existing behavior for uncategorized components, and respects custom hidden "Other" categories

#### Manual testing
- Hidden category components do not render anywhere
- Uncategorized components show up in "Other"
- Custom hidden "Other" category hides fallback list
- All expected visible components still show up

#### Additional notes
This is a simple categorization fix with no change to rendering behavior, only to the logic that tracks categorized components.


