### PR TITLE
fix: add CommonJS export to emotion cache package.json

### DIFF
--- a/packages/plugin-emotion-cache/package.json
+++ b/packages/plugin-emotion-cache/package.json
@@ -10,6 +10,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     "import": "./dist/index.mjs",
+    "require": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "license": "MIT",


### PR DESCRIPTION
## Addresses #1274 by adding common js export

Add a missing `"require"` entry to the `exports` map in `package.json`.  
This fixes `ERR_PACKAGE_PATH_NOT_EXPORTED` errors when requiring  
`@measured/puck-plugin-emotion-cache` in CommonJS environments (e.g. Cypress component tests).