### PR TITLE
fix: Generating new item id in walk-app-state if one doesn't exist

### DIFF
--- a/packages/core/lib/data/walk-app-state.ts
+++ b/packages/core/lib/data/walk-app-state.ts
@@ -15,6 +15,7 @@ import {
 } from "../../types/Internal";
 import { mapFields } from "./map-fields";
 import { flattenNode } from "./flatten-node";
+import { generateId } from "../generate-id";
 
 /**
  * Walk the Puck state, generate indexes and make modifications to nodes.
@@ -102,7 +103,8 @@ export function walkAppState<UserData extends Data = Data>(
     // Only modify the item if the user has returned it, enabling us to prevent unnecessary mapping and creating new references, which results in re-renders
     if (!mappedItem) return item;
 
-    const id = mappedItem.props.id;
+    // Generate a unique ID for the item if it doesn't have one
+    const id = mappedItem.props.id || generateId(mappedItem.type);
 
     const newProps = {
       ...mapFields(


### PR DESCRIPTION
Linked to #1221 

If only default props were defined for slots on root fields no ids were being created.   Without the id the keys weren't being added and all were `undefined` leading to the duplicate ids error. I've added a check to create an id if one doesn't exist when walking the app state.