### PR TITLE
feat: add move up and move down actions to DraggableComponent and Action Component Again.

### DIFF
--- a/packages/core/components/ActionBar/index.tsx
+++ b/packages/core/components/ActionBar/index.tsx
@@ -29,16 +29,19 @@ export const Action = ({
   children,
   label,
   onClick,
+  disabled
 }: {
   children: ReactNode;
   label?: string;
   onClick: (e: SyntheticEvent) => void;
+  disabled?: boolean;
 }) => (
   <button
     type="button"
     className={getClassName("action")}
     onClick={onClick}
     title={label}
+    disabled={disabled}
   >
     {children}
   </button>

--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -92,3 +92,8 @@
 .ActionBar-group * {
   margin: 0;
 }
+
+.ActionBar-action:disabled {
+  cursor: default;
+  color: var(--puck-color-grey-05);
+}

--- a/packages/core/lib/get-zone-content-ids.ts
+++ b/packages/core/lib/get-zone-content-ids.ts
@@ -1,0 +1,10 @@
+import { Data, DefaultComponents } from "../types";
+import { PrivateAppState } from "../types/Internal";
+
+export const getZoneContentIds = (zoneCompound: string, state: PrivateAppState<Data<DefaultComponents, any>>) => {
+  if (!zoneCompound) {
+    return [];
+  }
+
+  return state.indexes.zones[zoneCompound].contentIds;
+};

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -34,6 +34,8 @@ export type Overrides<UserConfig extends Config = Config> = OverridesGeneric<{
     label?: string;
     children: ReactNode;
     parentAction: ReactNode;
+    moveUpAction: ReactNode;
+    moveDownAction: ReactNode;
   }>;
   headerActions: RenderFunc<{ children: ReactNode }>;
   preview: RenderFunc;


### PR DESCRIPTION
This PR is attempting to close #668. 

* Added "Move Up" and "Move Down" buttons to the `DraggableComponent`'s action bar, with corresponding icons and logic to dispatch move actions and update UI selection. Actions are disabled when the item is at the boundary or drag is not permitted. 

- Checks permissions.drag before moving.
- Uses MoveUp/MoveDown lucide-react icons
- Disabled action state
- Only use isLast to disable the onMoveDown

Known Issues:
- onMoveUp does not rerender the selection.