### PR TITLE
Setup Config and Overrides for adding icons to Component/Drawer Item and optionally use in the outline items.

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -42,6 +42,7 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
           iframe={{
             enabled: params.get("disableIframe") === "true" ? false : true,
           }}
+          // showComponentIconsInOutline={false}
           fieldTransforms={{
             userField: ({ value }) => value, // Included to check types
           }}
@@ -62,6 +63,48 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
                 </FieldLabel>
               ),
             },
+            // Example of customizing the Drawer Items
+            drawerContainer: (props) => {
+              return <div 
+                {...props}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(64px, 1fr))",
+                  gap: 16,
+                }}
+              >
+                {props.children}
+              </div>;
+            },
+            drawerItem: ({ children, name, icon }) => (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: "100%",
+                  aspectRatio: "1 / 1",
+                  gap: 8,
+                }}
+              >
+                <span
+                  style={{
+                    width: 32,
+                    height: 32,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    background: "none",
+                    fontSize: 0,
+                    scale: 1.5,
+                  }}
+                >
+                  {icon || <Type size={24} />}
+                </span>
+                <div style={{ textAlign: "center", fontSize: "0.75rem" }}>{name}</div>
+              </div>
+            ),
             headerActions: ({ children }) => (
               <>
                 <div>

--- a/apps/demo/config/blocks/Button/index.tsx
+++ b/apps/demo/config/blocks/Button/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentConfig } from "@/core/types";
 import { Button as _Button } from "@/core/components/Button";
+import {  RectangleEllipsis } from "lucide-react";
 
 export type ButtonProps = {
   label: string;
@@ -10,6 +11,7 @@ export type ButtonProps = {
 
 export const Button: ComponentConfig<ButtonProps> = {
   label: "Button",
+  icon: <RectangleEllipsis size={16} />,
   fields: {
     label: {
       type: "text",

--- a/apps/demo/config/blocks/Card/index.tsx
+++ b/apps/demo/config/blocks/Card/index.tsx
@@ -6,6 +6,7 @@ import { getClassNameFactory } from "@/core/lib";
 import dynamic from "next/dynamic";
 import dynamicIconImports from "lucide-react/dynamicIconImports";
 import { withLayout, WithLayout } from "../../components/Layout";
+import { PanelBottom } from "lucide-react";
 
 const getClassName = getClassNameFactory("Card", styles);
 
@@ -33,6 +34,7 @@ export type CardProps = WithLayout<{
 }>;
 
 const CardInner: ComponentConfig<CardProps> = {
+  icon: <PanelBottom size={16} />,
   fields: {
     title: {
       type: "text",

--- a/apps/demo/config/blocks/Flex/index.tsx
+++ b/apps/demo/config/blocks/Flex/index.tsx
@@ -4,6 +4,7 @@ import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
 import { WithLayout, withLayout } from "../../components/Layout";
+import { StretchVertical } from "lucide-react";
 
 const getClassName = getClassNameFactory("Flex", styles);
 
@@ -16,6 +17,7 @@ export type FlexProps = WithLayout<{
 }>;
 
 const FlexInternal: ComponentConfig<FlexProps> = {
+  icon: <StretchVertical size={16} />,
   fields: {
     direction: {
       label: "Direction",

--- a/apps/demo/config/blocks/Grid/index.tsx
+++ b/apps/demo/config/blocks/Grid/index.tsx
@@ -4,6 +4,7 @@ import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
 import { withLayout } from "../../components/Layout";
+import { Grid2X2Icon } from "lucide-react";
 
 const getClassName = getClassNameFactory("Grid", styles);
 
@@ -14,6 +15,7 @@ export type GridProps = {
 };
 
 export const GridInternal: ComponentConfig<GridProps> = {
+  icon: <Grid2X2Icon size={16} />,
   fields: {
     numColumns: {
       type: "number",

--- a/apps/demo/config/blocks/Heading/index.tsx
+++ b/apps/demo/config/blocks/Heading/index.tsx
@@ -5,6 +5,7 @@ import { Heading as _Heading } from "@/core/components/Heading";
 import type { HeadingProps as _HeadingProps } from "@/core/components/Heading";
 import { Section } from "../../components/Section";
 import { WithLayout, withLayout } from "../../components/Layout";
+import { HeadingIcon } from "lucide-react";
 
 export type HeadingProps = WithLayout<{
   align: "left" | "center" | "right";
@@ -34,6 +35,7 @@ const levelOptions = [
 ];
 
 const HeadingInternal: ComponentConfig<HeadingProps> = {
+  icon: <HeadingIcon size={16} />,
   fields: {
     text: {
       type: "textarea",

--- a/apps/demo/config/blocks/Hero/client.tsx
+++ b/apps/demo/config/blocks/Hero/client.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { ComponentConfig } from "@/core/types";
 import { quotes } from "./quotes";
 import { AutoField, FieldLabel } from "@/core";
-import { Link2 } from "lucide-react";
+import { AppWindowMac, Link2 } from "lucide-react";
 import HeroComponent, { HeroProps } from "./Hero";
 
 export const Hero: ComponentConfig<{
@@ -15,6 +15,7 @@ export const Hero: ComponentConfig<{
     };
   };
 }> = {
+  icon: <AppWindowMac size={16} />,
   fields: {
     quote: {
       type: "external",

--- a/apps/demo/config/blocks/Logos/index.tsx
+++ b/apps/demo/config/blocks/Logos/index.tsx
@@ -4,6 +4,7 @@ import { ComponentConfig } from "@/core";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
+import { SquareDashedMousePointer } from "lucide-react";
 
 const getClassName = getClassNameFactory("Logos", styles);
 
@@ -15,6 +16,7 @@ export type LogosProps = {
 };
 
 export const Logos: ComponentConfig<LogosProps> = {
+  icon: <SquareDashedMousePointer size={16} />,
   fields: {
     logos: {
       type: "array",

--- a/apps/demo/config/blocks/Space/index.tsx
+++ b/apps/demo/config/blocks/Space/index.tsx
@@ -5,6 +5,7 @@ import { spacingOptions } from "../../options";
 import { getClassNameFactory } from "@/core/lib";
 
 import styles from "./styles.module.css";
+import { Minus } from "lucide-react";
 
 const getClassName = getClassNameFactory("Space", styles);
 
@@ -15,6 +16,7 @@ export type SpaceProps = {
 
 export const Space: ComponentConfig<SpaceProps> = {
   label: "Space",
+  icon: <Minus size={16} />,
   fields: {
     size: {
       type: "select",

--- a/apps/demo/config/blocks/Stats/index.tsx
+++ b/apps/demo/config/blocks/Stats/index.tsx
@@ -4,6 +4,7 @@ import { ComponentConfig } from "@/core";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "@/core/lib";
 import { Section } from "../../components/Section";
+import { TrendingUp } from "lucide-react";
 
 const getClassName = getClassNameFactory("Stats", styles);
 
@@ -15,6 +16,7 @@ export type StatsProps = {
 };
 
 export const Stats: ComponentConfig<StatsProps> = {
+  icon: <TrendingUp size={16} />,
   fields: {
     items: {
       type: "array",

--- a/apps/demo/config/blocks/Template/client.tsx
+++ b/apps/demo/config/blocks/Template/client.tsx
@@ -7,6 +7,7 @@ import { generateId } from "@/core/lib/generate-id";
 import { componentKey } from "../../index";
 import { type Components } from "../../types";
 import TemplateComponent, { TemplateProps } from "./Template";
+import { LayoutList } from "lucide-react";
 
 const usePuck = createUsePuck();
 
@@ -28,6 +29,7 @@ async function createComponent<T extends keyof Components>(
 type TemplateData = Record<string, { label: string; data: Slot }>;
 
 export const TemplateInternal: ComponentConfig<TemplateProps> = {
+  icon: <LayoutList size={16} />,
   fields: {
     template: {
       type: "custom",

--- a/apps/demo/config/blocks/Text/index.tsx
+++ b/apps/demo/config/blocks/Text/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ALargeSmall, AlignLeft } from "lucide-react";
+import { ALargeSmall, AlignLeft, TypeIcon } from "lucide-react";
 
 import { ComponentConfig } from "@/core/types";
 import { Section } from "../../components/Section";
@@ -15,6 +15,7 @@ export type TextProps = WithLayout<{
 }>;
 
 const TextInner: ComponentConfig<TextProps> = {
+  icon: <TypeIcon size={16} />,
   fields: {
     text: {
       type: "textarea",

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -43,6 +43,7 @@ export function Editor() {
 | [`overrides`](#overrides)                             | `overrides: { header: () => <div /> }`             | [Overrides](/docs/api-reference/overrides)                 | Experimental |
 | [`permissions`](#permissions)                         | `permissions: {}`                                  | [Plugin\[\]](/docs/api-reference/plugin)                   | Experimental |
 | [`plugins`](#plugins)                                 | `plugins: [myPlugin]`                              | [Plugin\[\]](/docs/api-reference/plugin)                   | Experimental |
+| [`showComponentIconsInOutline`](#showComponentIconsInOutline)           | `showComponentIconsInOutline: false`                        | boolean                                                    | -            |
 | [`ui`](#ui)                                           | `ui: {leftSideBarVisible: false}`                  | [AppState.ui](/docs/api-reference/data-model/app-state#ui) | -            |
 | [`viewports`](#viewports)                             | `viewports: [{ width: 1440 }]`                     | [Viewport\[\]](#viewport-params)                           | -            |
 
@@ -389,6 +390,21 @@ export function Editor() {
   return (
     <Puck
       plugins={[headingAnalyzer]}
+      // ...
+    />
+  );
+}
+```
+
+### `showComponentIconsInOutline`
+
+Show custom component icons in the component drawer and outline. When `true`, components will use their custom icons if defined. When `false`, all components will use default icons (Text icon for Text/Heading components, Grid icon for others). Components can define custom icons via the [`icon`](/docs/api-reference/configuration/component-config#icon) field in their config. Defaults to `true`.
+
+```tsx {4} copy
+export function Editor() {
+  return (
+    <Puck
+      showComponentIconsInOutline={false}
       // ...
     />
   );

--- a/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
@@ -31,6 +31,7 @@ const config = {
 | [`render()`](#renderprops)                               | `render: () => <div />`                         | Function | Required |
 | [`fields`](#fields)                                      | `fields: { title: { type: "text"} }`            | Object   | -        |
 | [`defaultProps`](#defaultprops)                          | `defaultProps: { title: "Hello, world" }`       | Object   | -        |
+| [`icon`](#icon)                                          | `icon: <MousePointer size={16} />`               | ReactNode| -        |
 | [`inline`](#inline)                                      | `inline: true`                                  | Boolean  | -        |
 | [`label`](#label)                                        | `label: "Heading Block"`                        | String   | -        |
 | [`metadata`](#metadata)                                  | `metadata: {}`                                  | Object   | -        |
@@ -202,6 +203,25 @@ const config = {
     },
   }}
 />
+
+### `icon`
+
+An icon to show in the component drawer and outline. Can be any React element.
+
+```tsx {4} copy showLineNumbers
+import { MousePointer } from "lucide-react";
+
+const config = {
+  components: {
+    HeadingBlock: {
+      icon: <MousePointer size={16} />,
+      render: () => <h1>Hello, World</h1>,
+    },
+  },
+};
+```
+
+When no icon is provided, Puck will fall back to default icons based on component type.
 
 ### `inline`
 

--- a/apps/docs/pages/docs/api-reference/overrides.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides.mdx
@@ -20,6 +20,7 @@ const overrides = {
 - [`actionBar`](overrides/action-bar): Override the action bar.
 - [`componentOverlay`](overrides/component-overlay): Override the overlay shown on hover or selection of a component.
 - [`drawer`](overrides/drawer): Override the component drawer.
+- [`drawerContainer`](overrides/drawer-container): Override the container that wraps the component drawer items.
 - [`drawerItem`](overrides/drawer-item): Override an item within the component drawer.
 - [`fields`](overrides/fields): Override the fields wrapper.
 - [`fieldLabel`](overrides/field-label): Override the [field labels](/docs/api-reference/configuration/field-label).

--- a/apps/docs/pages/docs/api-reference/overrides/drawer-container.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/drawer-container.mdx
@@ -1,0 +1,129 @@
+---
+title: drawerContainer
+---
+
+# drawerContainer
+
+Override the container that wraps the component drawer items. When provided, completely replaces the default drawer container while receiving all necessary props for drag-and-drop functionality.
+
+```tsx copy
+const overrides = {
+  drawerContainer: ({ children, className, ref, ...props }) => (
+    <div 
+      className={className} 
+      ref={ref} 
+      {...props}
+      style={{ border: "2px solid blue" }}
+    >
+      {children}
+    </div>
+  ),
+};
+```
+
+**Important**: When using this override, you must provide a complete implementation. The override completely replaces the default container, so ensure you pass through the required props for drag-and-drop functionality to work.
+
+## Props
+
+| Prop                              | Example                    | Type      | Description |
+| --------------------------------- | -------------------------- | --------- | ----------- |
+| [`children`](#children)           | `<div />`                  | ReactNode | The drawer items |
+| [`className`](#classname)         | `"Drawer-abc123"`          | string    | CSS class for styling |
+| [`ref`](#ref)                     | `ref`                      | RefObject | React ref for drag-and-drop |
+| [`data-puck-dnd`](#data-puck-dnd) | `"drawer-123"`             | string    | Drag-and-drop identifier |
+| [`data-puck-drawer`](#data-puck-drawer) | `true`               | boolean   | Marks as drawer container |
+| [`data-puck-dnd-void`](#data-puck-dnd-void) | `true`           | boolean   | Drag-and-drop collision handling |
+
+### `children`
+
+The drawer items to be rendered inside the container.
+
+### `className`
+
+The CSS class name for styling the drawer. Pass this through to maintain default styling.
+
+### `ref`
+
+React ref required for drag-and-drop functionality. Must be passed through.
+
+### `data-puck-dnd`
+
+Unique identifier for drag-and-drop operations. Must be passed through.
+
+### `data-puck-drawer`
+
+Boolean flag marking this as a drawer container. Must be passed through.
+
+### `data-puck-dnd-void`
+
+Flag for drag-and-drop collision handling. Must be passed through.
+
+## Examples
+
+### Custom styling while preserving functionality
+```tsx copy
+const overrides = {
+  drawerContainer: ({ children, className, ref, ...props }) => (
+    <div 
+      className={`${className} my-custom-class`} 
+      ref={ref} 
+      {...props}
+      style={{ background: "lightblue", padding: "8px" }}
+    >
+      {children}
+    </div>
+  ),
+};
+```
+
+### Adding header while preserving drag-and-drop
+```tsx copy
+const overrides = {
+  drawerContainer: ({ children, className, ref, ...props }) => (
+    <div>
+      <h3>Available Components</h3>
+      <div className={className} ref={ref} {...props}>
+        {children}
+      </div>
+    </div>
+  ),
+};
+```
+
+### Grid layout that fills available space
+```tsx copy
+const overrides = {
+  drawerContainer: ({ children, className, ref, ...props }) => (
+    <div 
+      className={className} 
+      ref={ref} 
+      {...props}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(64px, 1fr))",
+        gap: 16,
+      }}
+    >
+      {children}
+    </div>
+  ),
+};
+```
+
+### Completely custom container
+```tsx copy
+const overrides = {
+  drawerContainer: ({ children, className, ref, ...props }) => (
+    <section 
+      className="my-drawer-section" 
+      ref={ref} 
+      {...props} // Important: must pass through for drag-and-drop
+    >
+      <header>My Components</header>
+      <div className="drawer-content">
+        {children}
+      </div>
+    </section>
+  ),
+};
+```

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -10,9 +10,11 @@ const getClassName = getClassNameFactory("ComponentList", styles);
 const ComponentListItem = ({
   name,
   label,
+  icon,
 }: {
   name: string;
   label?: string;
+  icon?: ReactNode;
   index?: number; // TODO deprecate
 }) => {
   const overrides = useAppStore((s) => s.overrides);
@@ -33,7 +35,7 @@ const ComponentListItem = ({
   }, [overrides]);
 
   return (
-    <Drawer.Item label={label} name={name} isDragDisabled={!canInsert}>
+    <Drawer.Item label={label} name={name} icon={icon} isDragDisabled={!canInsert}>
       {overrides.componentItem ?? overrides.drawerItem}
     </Drawer.Item>
   );
@@ -87,13 +89,13 @@ const ComponentList = ({
         <Drawer>
           {children ||
             Object.keys(config.components).map((componentKey) => {
+              const componentConfig = config.components[componentKey];
               return (
                 <ComponentListItem
                   key={componentKey}
-                  label={
-                    config.components[componentKey]["label"] ?? componentKey
-                  }
+                  label={componentConfig["label"] ?? componentKey}
                   name={componentKey}
+                  icon={componentConfig["icon"]}
                 />
               );
             })}

--- a/packages/core/components/Drawer/styles.module.css
+++ b/packages/core/components/Drawer/styles.module.css
@@ -30,6 +30,7 @@
   justify-content: space-between;
   align-items: center;
   transition: background-color 50ms ease-in, color 50ms ease-in;
+  gap: 8px;
 }
 
 .DrawerItem--disabled .DrawerItem-draggable {
@@ -64,4 +65,19 @@
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
+}
+
+.DrawerItem-componentIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.DrawerItem-componentIcon svg {
+  width: 16px;
+  height: 16px;
 }

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -28,6 +28,7 @@ const Layer = ({
 }) => {
   const config = useAppStore((s) => s.config);
   const itemSelector = useAppStore((s) => s.state.ui.itemSelector);
+  const showComponentIconsInOutline = useAppStore((s) => s.showComponentIconsInOutline);
   const dispatch = useAppStore((s) => s.dispatch);
 
   const setItemSelector = useCallback(
@@ -77,6 +78,17 @@ const Layer = ({
   const componentConfig: ComponentConfig | undefined =
     config.components[nodeData.data.type];
   const label = componentConfig?.["label"] ?? nodeData.data.type.toString();
+  const componentIcon = componentConfig?.["icon"];
+
+  const getComponentIcon = () => {
+    if (showComponentIconsInOutline && componentIcon) {
+      return componentIcon;
+    }
+    if (nodeData.data.type === "Text" || nodeData.data.type === "Heading") {
+      return <Type size="16" />;
+    }
+    return <LayoutGrid size="16" />;
+  };
 
   return (
     <li
@@ -138,14 +150,11 @@ const Layer = ({
             </div>
           )}
           <div className={getClassNameLayer("title")}>
-            <div className={getClassNameLayer("icon")}>
-              {nodeData.data.type === "Text" ||
-              nodeData.data.type === "Heading" ? (
-                <Type size="16" />
-              ) : (
-                <LayoutGrid size="16" />
-              )}
-            </div>
+            {(
+              <div className={getClassNameLayer("icon")}>
+                {getComponentIcon()}
+              </div>
+            )}
             <div className={getClassNameLayer("name")}>{label}</div>
           </div>
         </button>

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -113,6 +113,7 @@ type PuckProps<
   headerPath?: string;
   viewports?: Viewports;
   iframe?: IframeConfig;
+  showComponentIconsInOutline?: boolean;
   dnd?: {
     disableAutoScroll?: boolean;
   };
@@ -149,6 +150,7 @@ function PuckProvider<
     overrides,
     viewports = defaultViewports,
     iframe: _iframe,
+    showComponentIconsInOutline = true,
     initialHistory: _initialHistory,
     metadata,
     onAction,
@@ -316,6 +318,7 @@ function PuckProvider<
         overrides: loadedOverrides,
         viewports,
         iframe,
+        showComponentIconsInOutline,
         onAction,
         metadata,
         fieldTransforms: loadedFieldTransforms,
@@ -328,6 +331,7 @@ function PuckProvider<
       loadedOverrides,
       viewports,
       iframe,
+      showComponentIconsInOutline,
       onAction,
       metadata,
       loadedFieldTransforms,

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -41,6 +41,7 @@ export const useComponentList = () => {
                     key={componentName}
                     label={(componentConf["label"] ?? componentName) as string}
                     name={componentName as string}
+                    icon={componentConf["icon"]}
                     index={i}
                   />
                 );
@@ -73,6 +74,7 @@ export const useComponentList = () => {
                   key={componentName}
                   name={componentName as string}
                   label={(componentConf["label"] ?? componentName) as string}
+                  icon={componentConf["icon"]}
                   index={i}
                 />
               );

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -77,6 +77,7 @@ export type AppStore<
   status: Status;
   setStatus: (status: Status) => void;
   iframe: IframeConfig;
+  showComponentIconsInOutline: boolean;
   selectedItem?: G["UserData"]["content"][0] | null;
   setUi: (ui: Partial<UiState>, recordHistory?: boolean) => void;
   getComponentConfig: (type?: string) => ComponentConfig | null | undefined;
@@ -111,6 +112,7 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
       },
       status: "LOADING",
       iframe: {},
+      showComponentIconsInOutline: true,
       metadata: {},
       fieldTransforms: {},
       ...initialAppStore,

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -16,6 +16,7 @@ export const overrideKeys = [
   "fields",
   "fieldLabel",
   "drawer",
+  "drawerContainer",
   "drawerItem",
   "componentOverlay",
   "outline",
@@ -51,9 +52,17 @@ export type Overrides<UserConfig extends Config = Config> = OverridesGeneric<{
     className?: string;
   }>;
   components: RenderFunc; // DEPRECATED
-  componentItem: RenderFunc<{ children: ReactNode; name: string }>; // DEPRECATED
+  componentItem: RenderFunc<{ children: ReactNode; name: string; icon?: ReactNode }>; // DEPRECATED
   drawer: RenderFunc;
-  drawerItem: RenderFunc<{ children: ReactNode; name: string }>;
+  drawerContainer: RenderFunc<{ 
+    children: ReactNode; 
+    className: string; 
+    ref: any; 
+    "data-puck-dnd": string;
+    "data-puck-drawer": boolean;
+    "data-puck-dnd-void": boolean;
+  }>;
+  drawerItem: RenderFunc<{ children: ReactNode; name: string; icon?: ReactNode }>;
   iframe: RenderFunc<{ children: ReactNode; document?: Document }>;
   outline: RenderFunc;
   componentOverlay: RenderFunc<{

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -41,6 +41,7 @@ type ComponentConfigInternal<
 > = {
   render: PuckComponent<RenderProps>;
   label?: string;
+  icon?: React.ReactNode;
   defaultProps?: FieldProps;
   fields?: Fields<FieldProps, UserField>;
   permissions?: Partial<Permissions>;


### PR DESCRIPTION
Attempting to close issue #1220

This pull request introduces support for custom icons in the component drawer and outline, allowing each component to specify its own icon via the `icon` field in its config. Documentation has been updated to reflect these changes, and several demo components now include custom icons. Additionally, **new UI override options for the drawer container** and items have been added, along with documentation for the new `showComponentIconsInOutline` feature.

**Custom Component Icons**

* Added an `icon` field to multiple demo component configs (`Button`, `Card`, `Flex`, `Grid`, `Heading`, `Hero`, `Logos`, `Space`, `Stats`, `Template`, `Text`) to display custom icons in the drawer and outline. [[1]](diffhunk://#diff-3c61826b1a218c3da2e47b1288fcbeff416f1a9fefa1ee3222e8bff8e88c11afR14) [[2]](diffhunk://#diff-f34fab76fd791b1e744bfd61f6d3e22d06c2af643b34052d4c36a1f360654357R37) [[3]](diffhunk://#diff-7abe002dc6cc69398029752c6870676c3a4e0da21cb267ae82865d81497e609fR20) [[4]](diffhunk://#diff-eee26751dded2ae22d74c893bb66f1cd0ac09abde4dc6a1196245b768b28e9c6R18) [[5]](diffhunk://#diff-bafcc8cc1ed12ac4d098c66900c3a416e95c656588a6a2291837cfb1c89a8661R38) [[6]](diffhunk://#diff-9193c7911330c3d4065fafee6bc695ab31fe0af8ea6e83bb71d6e893df9436d9R18) [[7]](diffhunk://#diff-f9ef88d4371cd9cbda0afce1337d1fad7ac819d7fc48048271c2d804f33d47f1R19) [[8]](diffhunk://#diff-9fc4d08ffb42b170cc382eb69c3f97e5d0b14647eee09fe4faf68367d63b8d62R19) [[9]](diffhunk://#diff-db326654c72d079d0bc4d5c402a2472d49a98ccb99c16d1d33bfa4f28127a0beR19) [[10]](diffhunk://#diff-a3507146ebee562bf7b9298123454e3059ddaf9f573f5d0318af8c63b59c19b2R32) [[11]](diffhunk://#diff-8bac06d8c42fb4b95232a0884677d11f743482acd0ddea0425a636a6bd076619R18)

* Updated the UI to support the new `showComponentIconsInOutline` prop, allowing toggling between custom and default icons. ([apps/demo/app/[...puckPath]/client.tsxR45](diffhunk://#diff-7b866a6e583a6fa3ba42af740e0a81e121399b75a323d66aa0ecda56c24ba019R45), [[1]](diffhunk://#diff-58c22cbd18c78bdfae01886c580eb11b6d1c1b2673960667a6043675ccb675d3R46) [[2]](diffhunk://#diff-58c22cbd18c78bdfae01886c580eb11b6d1c1b2673960667a6043675ccb675d3R399-R413)

**Component Drawer Customization**

* Added new UI override options: `drawerContainer` and `drawerItem`, enabling customization of the drawer layout and individual items. ([apps/demo/app/[...puckPath]/client.tsxR66-R107](diffhunk://#diff-7b866a6e583a6fa3ba42af740e0a81e121399b75a323d66aa0ecda56c24ba019R66-R107), [apps/docs/pages/docs/api-reference/overrides.mdxR23](diffhunk://#diff-8bfa94bc8713e752a9b83cf9aae2cfc4ce952cefd36843247900e8d33c1cf96fR23))

**Documentation Updates**

* Documented the new `icon` field for component configs and the `showComponentIconsInOutline` prop in the API reference and configuration docs. [[1]](diffhunk://#diff-554062ecc42dc2801655b562598e6983c346bace63cf2177ecd0117feeb864efR34) [[2]](diffhunk://#diff-554062ecc42dc2801655b562598e6983c346bace63cf2177ecd0117feeb864efR207-R225) [[3]](diffhunk://#diff-58c22cbd18c78bdfae01886c580eb11b6d1c1b2673960667a6043675ccb675d3R399-R413)

**Demo and Example Updates**

* Updated imports in demo component files to include relevant icons from `lucide-react`. [[1]](diffhunk://#diff-3c61826b1a218c3da2e47b1288fcbeff416f1a9fefa1ee3222e8bff8e88c11afR4) [[2]](diffhunk://#diff-f34fab76fd791b1e744bfd61f6d3e22d06c2af643b34052d4c36a1f360654357R9) [[3]](diffhunk://#diff-7abe002dc6cc69398029752c6870676c3a4e0da21cb267ae82865d81497e609fR7) [[4]](diffhunk://#diff-eee26751dded2ae22d74c893bb66f1cd0ac09abde4dc6a1196245b768b28e9c6R7) [[5]](diffhunk://#diff-bafcc8cc1ed12ac4d098c66900c3a416e95c656588a6a2291837cfb1c89a8661R8) [[6]](diffhunk://#diff-9193c7911330c3d4065fafee6bc695ab31fe0af8ea6e83bb71d6e893df9436d9L6-R6) [[7]](diffhunk://#diff-f9ef88d4371cd9cbda0afce1337d1fad7ac819d7fc48048271c2d804f33d47f1R7) [[8]](diffhunk://#diff-9fc4d08ffb42b170cc382eb69c3f97e5d0b14647eee09fe4faf68367d63b8d62R8) [[9]](diffhunk://#diff-db326654c72d079d0bc4d5c402a2472d49a98ccb99c16d1d33bfa4f28127a0beR7) [[10]](diffhunk://#diff-a3507146ebee562bf7b9298123454e3059ddaf9f573f5d0318af8c63b59c19b2R10) [[11]](diffhunk://#diff-8bac06d8c42fb4b95232a0884677d11f743482acd0ddea0425a636a6bd076619L2-R2)

**Some optimizations might be needed.**

<img width="1313" height="641" alt="image" src="https://github.com/user-attachments/assets/fa5b407b-75bb-4518-a27c-285fdb070f71" />


https://github.com/user-attachments/assets/b15be225-cf7e-4310-8bf1-100de037cabc

Rerendering in the video is due to an earlier change in the code.