### PR TITLE
Inherit text decoration styles in the inline text field

### DIFF
--- a/packages/core/components/InlineTextField/styles.module.css
+++ b/packages/core/components/InlineTextField/styles.module.css
@@ -2,6 +2,7 @@
   cursor: text;
   display: inline-block;
   white-space: pre-wrap;
+  text-decoration: inherit;
 }
 
 /* Safari fixes for https://bugs.webkit.org/show_bug.cgi?id=112854 */


### PR DESCRIPTION
Per CSS especification, `inline-block` elements don't inherit text decoration styles. This leads to any text decoration applied to inline editable fields to be ignored.

To fix this, this PR includes an explicit inheritance of the text decoration in the inline text field component.

Closes #1336 