### PR TITLE
Check for `disableDrag` first instead of `disableDragOnFocus`

### DIFF
--- a/packages/core/lib/overlay-portal/index.tsx
+++ b/packages/core/lib/overlay-portal/index.tsx
@@ -30,13 +30,13 @@ export const registerOverlayPortal = (
     });
   };
 
-  if (disableDragOnFocus) {
-    el.addEventListener("focus", onFocus, { capture: true });
-    el.addEventListener("blur", onBlur, { capture: true });
-  } else if (disableDrag) {
+  if (disableDrag) {
     el.addEventListener("pointerdown", stopPropagation, {
       capture: true,
     });
+  } else if (disableDragOnFocus) {
+    el.addEventListener("focus", onFocus, { capture: true });
+    el.addEventListener("blur", onBlur, { capture: true });
   }
 
   el.setAttribute("data-puck-overlay-portal", "true");
@@ -46,13 +46,13 @@ export const registerOverlayPortal = (
       capture: true,
     });
 
-    if (disableDragOnFocus) {
-      el.removeEventListener("focus", onFocus, { capture: true });
-      el.removeEventListener("blur", onFocus, { capture: true });
-    } else if (disableDrag) {
+    if (disableDrag) {
       el.removeEventListener("pointerdown", stopPropagation, {
         capture: true,
       });
+    } else if (disableDragOnFocus) {
+      el.removeEventListener("focus", onFocus, { capture: true });
+      el.removeEventListener("blur", onBlur, { capture: true });
     }
 
     el.removeAttribute("data-puck-overlay-portal");


### PR DESCRIPTION
The `disableDrag` option from `registerOverlayPortal` had no effect if `disableDragOnFocus` was also enabled. This happened because of the order of the `if` checks inside `registerOverlayPortal`: `disableDragOnFocus` always took precedence over `disableDrag`.

## Changes made

- Reordered the checks so that `disableDrag` is evaluated first. If `disableDrag` is enabled, its handling runs. If not, then the `disableDragOnFocus` handling runs.  
- Fixed another bug in the cleanup function: the `onFocus` callback was incorrectly removed for the `blur` event instead of `onBlur`.

## Manual testing

- Enabling the `disableDrag` option in `registerOverlayPortal` now correctly disables dragging components when dragging within the portal.  
- Disabling `disableDrag` and:  
  - Enabling `disableDragOnFocus` disables dragging when focusing on elements within the portal.  
  - Disabling `disableDragOnFocus` does not disable dragging when focusing on elements within the portal and the component can freely be repositioned.

Closes #1283
