### PR TITLE
docs: update broken links to slots documentation

### DIFF
--- a/apps/docs/pages/docs/api-reference/data-model/data.mdx
+++ b/apps/docs/pages/docs/api-reference/data-model/data.mdx
@@ -68,7 +68,7 @@ An object describing data for the [`root` config](/docs/api-reference/configurat
 
 <Callout>
   This parameter will soon be deprecated, as DropZones have been replaced by
-  [`slot` fields](/docs/api-reference/fields/slots). For migration notes, see
+  [`slot` fields](/docs/api-reference/fields/slot). For migration notes, see
   [these docs](/docs/guides/migrations/dropzones-to-slots).
 </Callout>
 

--- a/apps/docs/pages/docs/api-reference/data-model/item-selector.mdx
+++ b/apps/docs/pages/docs/api-reference/data-model/item-selector.mdx
@@ -37,6 +37,6 @@ The root of the payload is represented by the `root` id. The default content is 
 
 <Callout>
   DropZones have been replaced by [`slot`
-  fields](/docs/api-reference/fields/slots). For migration notes, see [these
+  fields](/docs/api-reference/fields/slot). For migration notes, see [these
   docs](/docs/guides/migrations/dropzones-to-slots).
 </Callout>

--- a/apps/docs/pages/docs/api-reference/functions/walk-tree.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/walk-tree.mdx
@@ -4,7 +4,7 @@ title: walkTree
 
 # walkTree
 
-Recursively walk the entire tree for the [`Data`](/docs/api-reference/data-model/data) or a single [`ComponentData`](/docs/api-reference/data-model/component-data) node, using a depth-first approach where the deepest [slots](/docs/api-reference/fields/slots) are processed first.
+Recursively walk the entire tree for the [`Data`](/docs/api-reference/data-model/data) or a single [`ComponentData`](/docs/api-reference/data-model/component-data) node, using a depth-first approach where the deepest [slots](/docs/api-reference/fields/slot) are processed first.
 
 Receives a callback function that is called once for each slot. You can optionally return a value to update the slot.
 


### PR DESCRIPTION
It appears that there isn't a `/docs/api-reference/fields/slots` documentation page at the moment so readers encounter 404 errors.  The `/docs/api-reference/fields/slot` seems like the closest approximation to what the author intends.  Feedback welcome.