### PR TITLE
fix: add request to NextResponse.next

### DIFF
--- a/recipes/next/middleware.ts
+++ b/recipes/next/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 export async function middleware(req: NextRequest) {
-  const res = NextResponse.next();
+  const res = NextResponse.next({ request: req });
 
   if (req.method === "GET") {
     // Rewrite routes that match "/[...puckPath]/edit" to "/puck/[...puckPath]"


### PR DESCRIPTION
Fixes #1361.

Ideally we would upgrade Next.js to the patched version but I've opted for the more immediate solution for now.