### PR TITLE
feat: add disable hotkeys feature

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -160,7 +160,7 @@ function PuckProvider<
     metadata,
     onAction,
     fieldTransforms,
-    hotkeys,
+    hotkeys = { enabled: true },
   } = usePropsContext();
 
   const iframe: IframeConfig = useMemo(
@@ -244,7 +244,6 @@ function PuckProvider<
 
     const newAppState = {
       ...defaultAppState,
-      hotkeys,
       data: {
         ...initialData,
         root: { ...initialData?.root, props: root.props },
@@ -333,6 +332,7 @@ function PuckProvider<
         onAction,
         metadata,
         fieldTransforms: loadedFieldTransforms,
+        hotkeys: hotkeys,
       };
     },
     [
@@ -345,6 +345,7 @@ function PuckProvider<
       onAction,
       metadata,
       loadedFieldTransforms,
+      hotkeys
     ]
   );
 
@@ -434,7 +435,7 @@ function PuckLayout<
   const rightSideBarVisible = useAppStore(
     (s) => s.state.ui.rightSideBarVisible
   );
-  const enabledHotkeys = useAppStore((s) => s.state.hotkeys.enabled);
+  const enabledHotkeys = useAppStore((s) => s.hotkeys.enabled);
 
   const {
     width: leftWidth,

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -345,7 +345,7 @@ function PuckProvider<
       onAction,
       metadata,
       loadedFieldTransforms,
-      hotkeys
+      hotkeys.enabled
     ]
   );
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -27,7 +27,7 @@ import type {
   Metadata,
   AsFieldProps,
   DefaultComponentProps,
-  ComponentData,
+  HotkeyState,
 } from "../../types";
 
 import { SidebarSection } from "../SidebarSection";
@@ -124,6 +124,7 @@ type PuckProps<
   };
   initialHistory?: InitialHistory;
   metadata?: Metadata;
+  hotkeys?: HotkeyState
 };
 
 const propsContext = createContext<Partial<PuckProps>>({});
@@ -159,6 +160,7 @@ function PuckProvider<
     metadata,
     onAction,
     fieldTransforms,
+    hotkeys,
   } = usePropsContext();
 
   const iframe: IframeConfig = useMemo(
@@ -242,6 +244,7 @@ function PuckProvider<
 
     const newAppState = {
       ...defaultAppState,
+      hotkeys,
       data: {
         ...initialData,
         root: { ...initialData?.root, props: root.props },
@@ -431,7 +434,7 @@ function PuckLayout<
   const rightSideBarVisible = useAppStore(
     (s) => s.state.ui.rightSideBarVisible
   );
-  const disableHotKeys = useAppStore((s) => s.state.ui.disableHotKeys);
+  const enabledHotkeys = useAppStore((s) => s.state.hotkeys.enabled);
 
   const {
     width: leftWidth,
@@ -499,11 +502,11 @@ function PuckLayout<
     if (ready && iframe.enabled) {
       const frameDoc = getFrame();
 
-      if (frameDoc && !disableHotKeys) {
+      if (frameDoc && enabledHotkeys) {
         return monitorHotkeys(frameDoc);
       }
     }
-  }, [ready, iframe.enabled, disableHotKeys]);
+  }, [ready, iframe.enabled, enabledHotkeys]);
 
   usePreviewModeHotkeys();
 

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -332,7 +332,7 @@ function PuckProvider<
         onAction,
         metadata,
         fieldTransforms: loadedFieldTransforms,
-        hotkeys: hotkeys,
+        hotkeys,
       };
     },
     [

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -124,7 +124,7 @@ type PuckProps<
   };
   initialHistory?: InitialHistory;
   metadata?: Metadata;
-  hotkeys?: HotkeyState
+  hotkeys?: Partial<HotkeyState>
 };
 
 const propsContext = createContext<Partial<PuckProps>>({});

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -431,6 +431,7 @@ function PuckLayout<
   const rightSideBarVisible = useAppStore(
     (s) => s.state.ui.rightSideBarVisible
   );
+  const disableHotKeys = useAppStore((s) => s.state.ui.disableHotKeys);
 
   const {
     width: leftWidth,
@@ -498,11 +499,11 @@ function PuckLayout<
     if (ready && iframe.enabled) {
       const frameDoc = getFrame();
 
-      if (frameDoc) {
+      if (frameDoc && !disableHotKeys) {
         return monitorHotkeys(frameDoc);
       }
     }
-  }, [ready, iframe.enabled]);
+  }, [ready, iframe.enabled, disableHotKeys]);
 
   usePreviewModeHotkeys();
 

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
-import { useAppStore } from '../store';
+import { useAppStore } from "../store";
 
 const keys = [
   "ctrl",
@@ -169,7 +169,7 @@ export const monitorHotkeys = (doc: Document) => {
 };
 
 export const useMonitorHotkeys = () => {
-  const enabledHotkeys = useAppStore((s) => s.state.hotkeys.enabled)
+  const enabledHotkeys = useAppStore((s) => s.hotkeys.enabled);
 
   useEffect(() => {
     if (!enabledHotkeys) return;

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -98,6 +98,8 @@ const useHotkeyStore = create<{
 );
 
 export const monitorHotkeys = (doc: Document) => {
+  console.log("monitorHotkeys");
+
   const onKeyDown = (e: KeyboardEvent) => {
     const key = keyCodeMap[e.code];
 
@@ -169,12 +171,12 @@ export const monitorHotkeys = (doc: Document) => {
 };
 
 export const useMonitorHotkeys = () => {
-  const disableHotKeys = useAppStore((s) => s.state.ui.disableHotKeys)
+  const enabledHotkeys = useAppStore((s) => s.state.hotkeys.enabled)
 
   useEffect(() => {
-    if (disableHotKeys) return;
+    if (!enabledHotkeys) return;
     return monitorHotkeys(document);
-  }, [disableHotKeys]);
+  }, [enabledHotkeys]);
 };
 
 export const useHotkey = (combo: KeyMapStrict, cb: Function) => {

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -98,8 +98,6 @@ const useHotkeyStore = create<{
 );
 
 export const monitorHotkeys = (doc: Document) => {
-  console.log("monitorHotkeys");
-
   const onKeyDown = (e: KeyboardEvent) => {
     const key = keyCodeMap[e.code];
 

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
+import { useAppStore } from '../store';
 
 const keys = [
   "ctrl",
@@ -168,7 +169,12 @@ export const monitorHotkeys = (doc: Document) => {
 };
 
 export const useMonitorHotkeys = () => {
-  useEffect(() => monitorHotkeys(document), []);
+  const disableHotKeys = useAppStore((s) => s.state.ui.disableHotKeys)
+
+  useEffect(() => {
+    if (disableHotKeys) return;
+    return monitorHotkeys(document);
+  }, [disableHotKeys]);
 };
 
 export const useHotkey = (combo: KeyMapStrict, cb: Function) => {

--- a/packages/core/store/default-app-state.ts
+++ b/packages/core/store/default-app-state.ts
@@ -2,9 +2,9 @@ import { defaultViewports } from "../components/ViewportControls/default-viewpor
 import { PrivateAppState } from "../types/Internal";
 
 export const defaultAppState: PrivateAppState = {
+  hotkeys: { enabled: true },
   data: { content: [], root: {}, zones: {} },
   ui: {
-    disableHotKeys: false,
     leftSideBarVisible: true,
     rightSideBarVisible: true,
     arrayState: {},

--- a/packages/core/store/default-app-state.ts
+++ b/packages/core/store/default-app-state.ts
@@ -2,7 +2,6 @@ import { defaultViewports } from "../components/ViewportControls/default-viewpor
 import { PrivateAppState } from "../types/Internal";
 
 export const defaultAppState: PrivateAppState = {
-  hotkeys: { enabled: true },
   data: { content: [], root: {}, zones: {} },
   ui: {
     leftSideBarVisible: true,

--- a/packages/core/store/default-app-state.ts
+++ b/packages/core/store/default-app-state.ts
@@ -4,6 +4,7 @@ import { PrivateAppState } from "../types/Internal";
 export const defaultAppState: PrivateAppState = {
   data: { content: [], root: {}, zones: {} },
   ui: {
+    disableHotKeys: false,
     leftSideBarVisible: true,
     rightSideBarVisible: true,
     arrayState: {},

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -14,6 +14,7 @@ import {
   ComponentData,
   RootDataWithProps,
   ResolveDataTrigger,
+  HotkeyState,
 } from "../types";
 import { createReducer, PuckAction } from "../reducer";
 import { getItem } from "../lib/data/get-item";
@@ -87,6 +88,7 @@ export type AppStore<
   nodes: NodesSlice;
   permissions: PermissionsSlice;
   fieldTransforms: FieldTransforms;
+  hotkeys: HotkeyState;
 };
 
 export type AppStoreApi = StoreApi<AppStore>;
@@ -113,6 +115,7 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
       iframe: {},
       metadata: {},
       fieldTransforms: {},
+      hotkeys: { enabled: true },
       ...initialAppStore,
       fields: createFieldsSlice(set, get),
       history: createHistorySlice(set, get),

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -88,7 +88,7 @@ export type AppStore<
   nodes: NodesSlice;
   permissions: PermissionsSlice;
   fieldTransforms: FieldTransforms;
-  hotkeys: HotkeyState;
+  hotkeys: Partial<HotkeyState>;
 };
 
 export type AppStoreApi = StoreApi<AppStore>;

--- a/packages/core/types/AppState.tsx
+++ b/packages/core/types/AppState.tsx
@@ -9,8 +9,11 @@ export type ItemWithId = {
 
 export type ArrayState = { items: ItemWithId[]; openId: string };
 
+export type HotkeyState = {
+  enabled: boolean;
+}
+
 export type UiState = {
-  disableHotKeys?: boolean;
   leftSideBarVisible: boolean;
   rightSideBarVisible: boolean;
   leftSideBarWidth?: number | null;
@@ -40,6 +43,7 @@ export type UiState = {
 };
 
 export type AppState<UserData extends Data = Data> = {
+  hotkeys: HotkeyState;
   data: UserData;
   ui: UiState;
 };

--- a/packages/core/types/AppState.tsx
+++ b/packages/core/types/AppState.tsx
@@ -43,7 +43,6 @@ export type UiState = {
 };
 
 export type AppState<UserData extends Data = Data> = {
-  hotkeys: HotkeyState;
   data: UserData;
   ui: UiState;
 };

--- a/packages/core/types/AppState.tsx
+++ b/packages/core/types/AppState.tsx
@@ -10,6 +10,7 @@ export type ItemWithId = {
 export type ArrayState = { items: ItemWithId[]; openId: string };
 
 export type UiState = {
+  disableHotKeys?: boolean;
   leftSideBarVisible: boolean;
   rightSideBarVisible: boolean;
   leftSideBarWidth?: number | null;


### PR DESCRIPTION
when using a wysiwyg editor to the puck, using the CTRL+Z or CTRL+R keys will trigger undo or redo simultaneously.