### PR TITLE
fix: prevent inline editor from dropping first change

### DIFF
--- a/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
+++ b/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
@@ -56,10 +56,16 @@ export function useSyncedEditor({
     immediatelyRender: false,
     parseOptions: { preserveWhitespace: "full" },
     onUpdate: ({ editor }) => {
-      // This can trigger during undo/redo history loads
-      if (syncingRef.current || !isFocused) {
-        appStoreApi.getState().setUi({ field: { focus: name } });
+      // Check focus via multiple sources to avoid stale closure issues.
+      // `isFocused` comes from React's render cycle and can be stale when
+      // this callback fires (React defers re-renders via MessageChannel).
+      // Fall back to the Zustand store directly, then to TipTap's DOM state.
+      const currentlyFocused =
+        isFocused ||
+        appStoreApi.getState().state.ui.field.focus === name ||
+        editor.isFocused;
 
+      if (syncingRef.current || !currentlyFocused) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes #1557 — inline text formatting (and any first edit action) in a RichText field doesn't call `onChange`.

The `onUpdate` handler in `useSyncedEditor` checks `isFocused` to decide whether to propagate changes. This value comes from a React render closure (`useAppStore` selector), but it's **stale** when TipTap fires the callback — React defers re-renders via `MessageChannel`, so the closure still holds `false` from the previous render.

### Root cause

**Bug 1: Stale closure drops the first change**

1. User clicks inline text → `onFocusChange` fires → store sets `field.focus = name`
2. React **defers** the re-render (not synchronous)
3. User types or applies formatting
4. TipTap's `onUpdate` fires — but `isFocused` in the closure is still `false`
5. Early return → change never reaches `onChange` → not saved in history

The text visually updates (TipTap manages its own DOM), but the Puck data store never receives the change. This is why undo doesn't capture it and `onChange` is never called.

**Bug 2: `setUi` in early return steals focus**

The early return calls `setUi({ field: { focus: name } })`. Each richtext field has two `useSyncedEditor` instances — one for inline (`mainText::inline`) and one for sidebar (`mainText`). When the sidebar editor initializes, its `onUpdate` fires with `isFocused: false`, and the early return overwrites the correct focus value, stealing focus from the inline editor.

### Fix

Use a triple fallback for focus detection instead of relying solely on the React closure:

```js
const currentlyFocused =
  isFocused ||                                                    // React closure (correct after re-render)
  appStoreApi.getState().state.ui.field.focus === name ||          // Zustand store (correct immediately)
  editor.isFocused;                                               // DOM-level (always correct)
```

Also removes the `setUi` call from the early return to prevent focus theft between editor instances.

## Test plan

- [ ] Click on an inline RichText field and immediately type — first character should be captured in undo history
- [ ] Select all text (`Ctrl+A`) and apply formatting (bold, italic, etc.) — change should persist and be undoable
- [ ] Click on an inline field, apply a formatting action from the floating toolbar — should not be dropped
- [ ] Components with both inline and sidebar editors should not exhibit focus flickering
- [ ] Undo/redo should capture all inline editing changes including the first one