### PR TITLE
fix: preserve caret position in controlled custom fields

### DIFF
--- a/packages/core/components/AutoField/index.spec.tsx
+++ b/packages/core/components/AutoField/index.spec.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { appStoreContext, createAppStore } from "../../store";
+import { fieldContextStore } from "./store";
+import { AutoFieldPrivate } from ".";
+
+jest.mock("../Sortable", () => ({
+  Sortable: ({
+    children,
+  }: {
+    children: (props: {
+      isDragging: boolean;
+      ref: null;
+      handleRef: null;
+    }) => JSX.Element;
+  }) => children({ isDragging: false, ref: null, handleRef: null }),
+  SortableProvider: ({ children }: { children: JSX.Element }) => children,
+}));
+
+jest.mock("../../bundle", () => {
+  const { setDeep } = jest.requireActual("../../lib/data/set-deep");
+
+  return { setDeep };
+});
+
+describe("AutoField", () => {
+  it("updates controlled custom fields immediately", () => {
+    const appStore = createAppStore();
+    const onChange = jest.fn();
+
+    render(
+      <appStoreContext.Provider value={appStore}>
+        <fieldContextStore.Provider value={{ title: "Hello world" }}>
+          <AutoFieldPrivate
+            field={{
+              type: "custom",
+              render: ({ id, value, onChange }) => (
+                <input
+                  id={id}
+                  value={value ?? ""}
+                  onChange={(e) => onChange(e.currentTarget.value)}
+                />
+              ),
+            }}
+            id="title"
+            name="title"
+            onChange={onChange}
+          />
+        </fieldContextStore.Provider>
+      </appStoreContext.Provider>
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Hello brave world" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("Hello brave world", undefined);
+    expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe(
+      "Hello brave world"
+    );
+  });
+});

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -1,5 +1,5 @@
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Field, FieldProps } from "../../types";
+import { Field, FieldProps, UiState } from "../../types";
 
 import styles from "./styles.module.css";
 import {
@@ -25,6 +25,7 @@ import { useSafeId } from "../../lib/use-safe-id";
 import { NestedFieldContext } from "./context";
 import { useShallow } from "zustand/react/shallow";
 import { getDeep } from "../../lib/data/get-deep";
+import { setDeep } from "../../lib/data/set-deep";
 import type {
   FieldLabelPropsInternal,
   FieldPropsInternalOptional,
@@ -78,6 +79,7 @@ function AutoFieldInternal<
   const field = props.field as Field<ValueType>;
   const label = field.label;
   const labelIcon = field.labelIcon;
+  const fieldStore = useFieldStoreApi();
 
   const defaultId = useSafeId();
   const resolvedId = id || defaultId;
@@ -106,6 +108,22 @@ function AutoFieldInternal<
     }
   });
 
+  const shouldSyncLocalValue =
+    field.type === "custom" || !!overrides.fieldTypes?.[field.type];
+
+  const onChange = useCallback(
+    (value: any, uiState?: Partial<UiState>) => {
+      if (shouldSyncLocalValue) {
+        fieldStore.setState(
+          setDeep(fieldStore.getState(), props.name ?? resolvedId, value)
+        );
+      }
+
+      props.onChange(value, uiState);
+    },
+    [fieldStore, props.name, props.onChange, resolvedId, shouldSyncLocalValue]
+  );
+
   const mergedProps = useMemo(
     () => ({
       ...props,
@@ -115,8 +133,9 @@ function AutoFieldInternal<
       Label,
       id: resolvedId,
       value: fieldValue,
+      onChange,
     }),
-    [props, field, label, labelIcon, Label, resolvedId, fieldValue]
+    [props, field, label, labelIcon, Label, resolvedId, fieldValue, onChange]
   );
 
   const onFocus = useCallback(


### PR DESCRIPTION
Closes #1642

<!--
  Replace XXXX with the actual issue number this PR closes.
  Every PR should be linked to an issue.
  PRs without an issue may take longer to review or may be closed as non-actionable.
-->

## Description

This PR fixes a bug in Puck where controlled custom input fields would move the caret to the end on every keystroke while editing existing text.

The root cause was that `custom` fields read from the local field store, but their value was only reflected back after the async `resolveComponentData -> replace` roundtrip completed. For controlled inputs, that delayed sync was enough to break normal browser caret preservation.

This change keeps the existing update flow intact, but synchronizes the local field store immediately for `custom` and override-backed field types so controlled inputs can be edited in place as expected.

<!--
  Include a concise and clear description of what this PR does.
  Mention any considerations or reasons behind the changes.
  Highlight any breaking changes.
  Keep the explanation centered around Puck.
 -->

## Changes made

- Updated `AutoField` to synchronously mirror changes for `custom` field types into the local field store before forwarding `onChange`.
- Applied the same local sync behavior to override-backed field types, since they use the same value path.
- Added a regression test covering controlled custom field updates.

<!--
  List the key changes made and the reasons behind them.
 -->

## How to test

- Create a custom field that renders a controlled `<input>`:

```tsx
const MyTextField = ({ id, value, onChange }) => {
  return (
    <input
      id={id}
      value={value ?? ""}
      onChange={(e) => onChange(e.target.value)}
    />
  );
};
