### PR TITLE
fix(core): prevent canvas loader from blocking pointer events when hidden

### DIFF
--- a/packages/core/components/Puck/components/Canvas/styles.module.css
+++ b/packages/core/components/Puck/components/Canvas/styles.module.css
@@ -77,6 +77,17 @@
   justify-content: center;
   transition: opacity 250ms ease-out;
   opacity: 0;
+  /*
+   * The loader covers the whole canvas area (height: 100%) and remains in
+   * the DOM even after ready, since `height: 0` is only applied when both
+   * `--showLoader` and `--ready` are set. If `--showLoader` is never added
+   * (e.g. when initial loading completes synchronously), the loader stays
+   * at `height: 100%` with `opacity: 0` — invisible but still receiving
+   * pointer events, blocking hover/click on UI overlaid on the canvas
+   * (e.g. custom componentOverlay buttons). The loader is a presentation
+   * indicator and should never receive pointer events.
+   */
+  pointer-events: none;
 }
 
 .PuckCanvas--showLoader .PuckCanvas-loader {

--- a/packages/core/components/Puck/components/Canvas/styles.module.css
+++ b/packages/core/components/Puck/components/Canvas/styles.module.css
@@ -77,16 +77,6 @@
   justify-content: center;
   transition: opacity 250ms ease-out;
   opacity: 0;
-  /*
-   * The loader covers the whole canvas area (height: 100%) and remains in
-   * the DOM even after ready, since `height: 0` is only applied when both
-   * `--showLoader` and `--ready` are set. If `--showLoader` is never added
-   * (e.g. when initial loading completes synchronously), the loader stays
-   * at `height: 100%` with `opacity: 0` — invisible but still receiving
-   * pointer events, blocking hover/click on UI overlaid on the canvas
-   * (e.g. custom componentOverlay buttons). The loader is a presentation
-   * indicator and should never receive pointer events.
-   */
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

`PuckCanvas-loader` silently captures pointer events on the entire canvas area when it is hidden, breaking any UI overlaid on the canvas (e.g. custom `componentOverlay` buttons that extend beyond the rect of their host component).

## Cause

`PuckCanvas-loader` has `height: 100%` and stays in the DOM after the canvas becomes ready. The rule that collapses it to `height: 0` only applies when **both** `--showLoader` **and** `--ready` are present:

```css
.PuckCanvas-loader { height: 100%; opacity: 0; }
.PuckCanvas--showLoader.PuckCanvas--ready .PuckCanvas-loader { opacity: 0; height: 0; }
```

If `--showLoader` is never added (e.g. when initial loading completes synchronously and the spinner is never shown), the loader stays at `height: 100%` with `opacity: 0` — invisible, but covering the canvas. Since `pointer-events` is unspecified it defaults to `auto`, so the loader silently captures hover/click events on anything overlaid on the canvas.

## Reproduction

Render a custom `componentOverlay` whose UI visually extends beyond the host component's rect (e.g. a `+` button positioned with `transform: translate(-50%, -50%)` so half of it sits outside the host). On the half overlapping the canvas (but outside the host's rect), hover does not fire pointer events on the button — the hidden loader silently absorbs them.

## Fix

Set `pointer-events: none` unconditionally on `.PuckCanvas-loader`. The loader is purely a presentation indicator (a spinner) and has no reason to receive pointer events, regardless of which loader-related classes happen to be present.

## Test plan

- [ ] Repro: with a custom `componentOverlay` extending beyond a component's rect, verify pointer events now fire on the overlapping area inside the canvas
- [ ] Existing loader behavior unchanged: spinner still appears during loading and is collapsed once ready