### PR TITLE
fix: InlineTextField renders empty for nullish values

### DIFF
--- a/packages/core/components/InlineTextField/__tests__/index.spec.tsx
+++ b/packages/core/components/InlineTextField/__tests__/index.spec.tsx
@@ -1,0 +1,76 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { InlineTextField } from "../index";
+
+// useAppStoreApi reads from a Zustand-style API; we only need a getState() that
+// returns the slice InlineTextField touches in its effect.
+const makeAppStore = () => ({
+  getState: () => ({
+    state: {
+      indexes: {
+        nodes: {
+          "comp-1": {
+            data: { type: "MyBlock", props: { id: "comp-1" } },
+          },
+        },
+      },
+    },
+    getComponentConfig: () => ({ fields: {} }),
+  }),
+});
+
+jest.mock("../../../store", () => ({
+  useAppStoreApi: () => makeAppStore(),
+}));
+
+jest.mock("../../../lib/overlay-portal", () => ({
+  registerOverlayPortal: () => () => undefined,
+}));
+
+jest.mock("../styles.module.css");
+
+describe("InlineTextField", () => {
+  it("renders empty when value is null instead of the literal string 'null'", () => {
+    const { container } = render(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value={null}
+        isReadOnly={false}
+      />
+    );
+
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.innerText ?? span?.textContent ?? "").toBe("");
+  });
+
+  it("renders empty when value is undefined instead of the literal string 'undefined'", () => {
+    const { container } = render(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value={undefined}
+        isReadOnly={false}
+      />
+    );
+
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.innerText ?? span?.textContent ?? "").toBe("");
+  });
+
+  it("renders the value when it is a non-empty string", () => {
+    const { container } = render(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value="Hello world"
+        isReadOnly={false}
+      />
+    );
+
+    const span = container.querySelector("span");
+    expect(span?.textContent).toBe("Hello world");
+  });
+});

--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -18,7 +18,7 @@ const InlineTextFieldInternal = ({
   opts = {},
 }: {
   propPath: string;
-  value: string;
+  value: string | null | undefined;
   componentId: string;
   isReadOnly: boolean;
   opts?: { disableLineBreaks?: boolean };
@@ -39,8 +39,12 @@ const InlineTextFieldInternal = ({
     }
 
     if (ref.current) {
-      if (value !== ref.current.innerText) {
-        ref.current.replaceChildren(value);
+      // Coerce nullish values to "" — Node.replaceChildren stringifies non-Node
+      // args, so passing null/undefined renders the literal text "null"/"undefined".
+      const safeValue = value ?? "";
+
+      if (safeValue !== ref.current.innerText) {
+        ref.current.replaceChildren(safeValue);
       }
 
       const cleanupPortal = registerOverlayPortal(ref.current);


### PR DESCRIPTION
Closes #1639

## Description

`InlineTextField` was rendering the literal text `"null"` (or `"undefined"`) in the contentEditable canvas whenever a `text` or `textarea` field with `contentEditable: true` received a nullish value. The cause is `Node.replaceChildren(...nodes)` coercing each non-Node argument via `String(...)` — `String(null) === "null"` and `String(undefined) === "undefined"` — so a defaultProp of `subtitle: null`, or a server response returning `null` for an unfilled optional field, persistently surfaced as `null` text in the editor until the user manually selected-all and deleted.

The `richtext` field type is unaffected because TipTap handles nullish content; this is specific to `InlineTextField` only.

## Changes made

- Coerce `value ?? ""` before calling `replaceChildren`, in the same effect that syncs the contentEditable span's text.
- Widen the `value` prop type from `string` to `string | null | undefined` so the type matches what the `text` / `textarea` field transforms actually pass in (the data model allows nullish props).
- Add jest tests covering `value={null}`, `value={undefined}`, and `value="Hello world"`.

## How to test

Minimal repro from the issue:

```tsx
const config = {
  components: {
    MyBlock: {
      fields: {
        subtitle: { type: 'textarea', contentEditable: true },
      },
      defaultProps: { subtitle: null },
      render: ({ subtitle }) => <p>{subtitle}</p>,
    },
  },
};
```

Insert `MyBlock` in the editor. Before: the canvas shows the text `null` where the subtitle would be. After: empty, like an empty string.

Or run `yarn test --testPathPattern=InlineTextField` from `packages/core` — 3 new tests cover the null / undefined / string cases.