### PR TITLE
fix: unwrap propName in walkFields for nested slots

### DIFF
--- a/packages/core/lib/data/__tests__/walk-tree.spec.tsx
+++ b/packages/core/lib/data/__tests__/walk-tree.spec.tsx
@@ -365,4 +365,18 @@ describe("walk-tree", () => {
       { parentId: "my-component", propName: "array[0].arraySlot" }
     );
   });
+
+  it("should pass bare propName for slots of components nested inside other slots", () => {
+    const propNamesByParent: Record<string, string[]> = {};
+
+    walkTree(testData, config, (_content, { parentId, propName }) => {
+      propNamesByParent[parentId] ??= [];
+      propNamesByParent[parentId].push(propName);
+    });
+
+    // slotted-a-id is a child inside slotA of another-id.
+    // Its own slots should still receive bare field names, not ".props.slotA".
+    expect(propNamesByParent["slotted-a-id"]?.sort()).toEqual(["slotA", "slotB"]);
+    expect(propNamesByParent["slotted-b-id"]?.sort()).toEqual(["slotA", "slotB"]);
+  });
 });

--- a/packages/core/lib/data/map-fields.ts
+++ b/packages/core/lib/data/map-fields.ts
@@ -71,22 +71,11 @@ export const walkField = ({
 
     const mappedContent = recurseSlots
       ? content.map((el) => {
-          const componentConfig = config.components[el.type];
-
-          if (!componentConfig) {
+          if (!config.components[el.type]) {
             throw new Error(`Could not find component config for ${el.type}`);
           }
 
-          const fields = componentConfig.fields ?? {};
-
-          return walkField({
-            value: { ...el, props: defaultSlots(el.props, fields) },
-            fields,
-            mappers,
-            id: el.props.id,
-            config,
-            recurseSlots,
-          });
+          return mapFields(el, mappers, config, recurseSlots);
         })
       : content;
 


### PR DESCRIPTION
Closes a bug in walkFields, resulting in `propName` coming through as `.props.slotA` for nested components.

This affects both `walkFields`, and likely causes other issues with nested slots.

## Description

`walkTree`'s callback receives incorrect `propName` values for components nested inside slots. Instead of receiving the bare field name (e.g. `"content"`), the callback receives a dotted path prefixed with `.props.` (e.g. `".props.content"`). This only affects components that are children inside a slot — top-level components are fine.

## How to test


Create a config with two levels of slot nesting: an Outer component with a content slot, and an Inner component with a body slot nested inside it.

```tsx
import { Config, Data, walkTree } from "@puckeditor/core";

const config: Config = {
  components: {
    Outer: {
      fields: {
        content: { type: "slot" },
      },
      render: ({ content }) => <div>{content}</div>,
    },
    Inner: {
      fields: {
        body: { type: "slot" },
      },
      render: ({ body }) => <section>{body}</section>,
    },
  },
};

const data: Data = {
  root: { props: {} },
  content: [
    {
      type: "Outer",
      props: {
        id: "outer-1",
        content: [
          {
            type: "Inner",
            props: {
              id: "inner-1",
              body: [],
            },
          },
        ],
      },
    },
  ],
  zones: {},
};
```

Call `walkTree`

```tsx
walkTree(data, config, (content, { parentId, propName }) => {
  console.log({ parentId, propName });
});
```

Before the fix

```
{ parentId: 'outer-1', propName: 'content' }        // ✅ correct
{ parentId: 'inner-1', propName: '.props.body' }     // ❌ wrong
```

Now

```
{ parentId: 'outer-1', propName: 'content' }         // ✅ correct
{ parentId: 'inner-1', propName: 'body' }             // ✅ correct
```