### PR TITLE
fix: don't crash richtext field when string is empty

### DIFF
--- a/packages/core/components/Puck/__tests__/richtext.spec.tsx
+++ b/packages/core/components/Puck/__tests__/richtext.spec.tsx
@@ -185,66 +185,6 @@ describe("Puck - richtext programmatic updates", () => {
     expect(screen.queryByText("Hello world")).not.toBeInTheDocument();
   });
 
-  it("updates richtext when only the richtext field changes on a component with multiple fields", async () => {
-    const config: Config = {
-      components: {
-        Card: {
-          fields: {
-            title: { type: "text" },
-            body: { type: "richtext", contentEditable: false },
-          },
-          render: ({ title, body }) => (
-            <div>
-              <h2>{title}</h2>
-              <div data-testid="body">{body}</div>
-            </div>
-          ),
-        },
-      },
-    };
-
-    const data: Data = {
-      root: { props: {} },
-      content: [
-        {
-          type: "Card",
-          props: {
-            id: "card-1",
-            title: "My Card",
-            body: "<p>Original body</p>",
-          },
-        },
-      ],
-    };
-
-    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
-    await flush();
-
-    await waitFor(() => {
-      expect(screen.getByText("Original body")).toBeInTheDocument();
-    });
-
-    const { appStore } = getInternal();
-
-    act(() => {
-      dispatchReplace(appStore, "card-1", {
-        type: "Card",
-        props: {
-          id: "card-1",
-          title: "My Card",
-          body: "<p>Updated body</p>",
-        },
-      });
-    });
-    await flush();
-
-    await waitFor(() => {
-      expect(screen.getByText("Updated body")).toBeInTheDocument();
-    });
-    expect(screen.getByText("My Card")).toBeInTheDocument();
-    expect(screen.queryByText("Original body")).not.toBeInTheDocument();
-  });
-
   it("updates richtext when value transitions from empty string to content", async () => {
     const config: Config = {
       components: {

--- a/packages/core/components/Puck/__tests__/richtext.spec.tsx
+++ b/packages/core/components/Puck/__tests__/richtext.spec.tsx
@@ -1,0 +1,331 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { Config, Data } from "../../../types";
+import "@testing-library/jest-dom";
+
+jest.mock("../styles.module.css");
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+const originalConsoleError = console.error;
+jest.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  if (
+    args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+  ) {
+    return;
+  }
+  originalConsoleError(...(args as Parameters<typeof console.error>));
+});
+
+jest.spyOn(console, "warn").mockImplementation(() => {});
+
+import { Puck } from "../index";
+import { AppStoreApi } from "../../../store";
+
+type PuckInternal = {
+  appStore: AppStoreApi;
+};
+
+const getInternal = () => {
+  return (window as any).__PUCK_INTERNAL_DO_NOT_USE as PuckInternal;
+};
+
+const flush = () => act(async () => {});
+
+const dispatchReplace = (
+  appStore: AppStoreApi,
+  componentId: string,
+  data: any
+) => {
+  const node = appStore.getState().state.indexes.nodes[componentId];
+  const zoneCompound = `${node.parentId}:${node.zone}`;
+  const index = appStore
+    .getState()
+    .state.indexes.zones[zoneCompound].contentIds.indexOf(componentId);
+
+  appStore.getState().dispatch({
+    type: "replace",
+    data,
+    destinationIndex: index,
+    destinationZone: zoneCompound,
+  });
+};
+
+describe("Puck - richtext programmatic updates", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("updates the preview when a richtext field is changed via dispatch", async () => {
+    const config: Config = {
+      components: {
+        RichTextBlock: {
+          fields: {
+            body: { type: "richtext", contentEditable: false },
+          },
+          render: ({ body }) => <div data-testid="richtext-output">{body}</div>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "RichTextBlock",
+          props: { id: "block-1", body: "<p>Hello world</p>" },
+        },
+      ],
+    };
+
+    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      dispatchReplace(appStore, "block-1", {
+        type: "RichTextBlock",
+        props: { id: "block-1", body: "<p>Updated content</p>" },
+      });
+    });
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated content")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Hello world")).not.toBeInTheDocument();
+  });
+
+  it("updates the preview when a contentEditable richtext field is changed via dispatch", async () => {
+    const config: Config = {
+      components: {
+        RichTextBlock: {
+          fields: {
+            body: { type: "richtext" },
+          },
+          render: ({ body }) => <div data-testid="richtext-output">{body}</div>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "RichTextBlock",
+          props: { id: "block-1", body: "<p>Hello world</p>" },
+        },
+      ],
+    };
+
+    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      dispatchReplace(appStore, "block-1", {
+        type: "RichTextBlock",
+        props: { id: "block-1", body: "<p>Updated content</p>" },
+      });
+    });
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated content")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Hello world")).not.toBeInTheDocument();
+  });
+
+  it("updates richtext when only the richtext field changes on a component with multiple fields", async () => {
+    const config: Config = {
+      components: {
+        Card: {
+          fields: {
+            title: { type: "text" },
+            body: { type: "richtext", contentEditable: false },
+          },
+          render: ({ title, body }) => (
+            <div>
+              <h2>{title}</h2>
+              <div data-testid="body">{body}</div>
+            </div>
+          ),
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Card",
+          props: {
+            id: "card-1",
+            title: "My Card",
+            body: "<p>Original body</p>",
+          },
+        },
+      ],
+    };
+
+    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Original body")).toBeInTheDocument();
+    });
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      dispatchReplace(appStore, "card-1", {
+        type: "Card",
+        props: {
+          id: "card-1",
+          title: "My Card",
+          body: "<p>Updated body</p>",
+        },
+      });
+    });
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated body")).toBeInTheDocument();
+    });
+    expect(screen.getByText("My Card")).toBeInTheDocument();
+    expect(screen.queryByText("Original body")).not.toBeInTheDocument();
+  });
+
+  it("updates richtext when value transitions from empty string to content", async () => {
+    const config: Config = {
+      components: {
+        Block: {
+          fields: {
+            body: { type: "richtext", contentEditable: false },
+          },
+          render: ({ body }) => <div data-testid="output">{body}</div>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Block",
+          props: { id: "block-1", body: "" },
+        },
+      ],
+    };
+
+    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
+    await flush();
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      dispatchReplace(appStore, "block-1", {
+        type: "Block",
+        props: { id: "block-1", body: "<p>No longer empty</p>" },
+      });
+    });
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("No longer empty")).toBeInTheDocument();
+    });
+  });
+
+  it("updates richtext when value is set to plain text (no HTML tags)", async () => {
+    const config: Config = {
+      components: {
+        Block: {
+          fields: {
+            body: { type: "richtext", contentEditable: false },
+          },
+          render: ({ body }) => <div data-testid="output">{body}</div>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Block",
+          props: { id: "block-1", body: "<p>HTML content</p>" },
+        },
+      ],
+    };
+
+    render(<Puck config={config} data={data} iframe={{ enabled: false }} />);
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("HTML content")).toBeInTheDocument();
+    });
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      dispatchReplace(appStore, "block-1", {
+        type: "Block",
+        props: { id: "block-1", body: "Plain text value" },
+      });
+    });
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByText("Plain text value")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core/components/RichTextEditor/components/Render.tsx
+++ b/packages/core/components/RichTextEditor/components/Render.tsx
@@ -29,6 +29,10 @@ export function RichTextRender({
     }
 
     if (typeof content === "string") {
+      if (!content) {
+        return { type: "doc", content: [] };
+      }
+
       const isHtml = /<\/?[a-z][\s\S]*>/i.test(content);
 
       if (isHtml) {


### PR DESCRIPTION
## Description

Fixes a crash in RichTextRender when a richtext field contains an empty string, impacting AI generation.

ProseMirror rejects empty text nodes, so programmatically setting a richtext field to `""` (or initializing it as empty) would throw `RangeError: Empty text nodes are not allowed`, preventing the component from rendering and blocking subsequent updates.

## Changes made

- Added an early return in `RichTextRender` for empty strings, returning an empty doc (`{ type: "doc", content: [] }`) instead of an invalid text node.
- Added focused test coverage for programmatic richtext field updates via `dispatch`, including the empty string edge case and plain-text transition.
- Removed the broader multi-field dispatch test based on review feedback to keep this suite scoped to richtext behavior.

## How to test

Create a component with a richtext field initialized to `""`, then programmatically update it via dispatch. The updated content should render correctly:

```ts
// Initial data with empty richtext
const data = {
  content: [{ type: "Block", props: { id: "1", body: "" } }],
};

// Later, dispatch a replace to set the value
dispatch({
  type: "replace",
  data: { type: "Block", props: { id: "1", body: "<p>Hello</p>" } },
  destinationIndex: 0,
  destinationZone: "default-zone",
});
```