### PR TITLE
feat: expose root to resolveData API

### DIFF
--- a/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
@@ -355,10 +355,10 @@ const config = {
 
 #### Args
 
-| Prop     | Example                                                              | Type   |
-| -------- | -------------------------------------------------------------------- | ------ |
-| `data`   | `{ props: { title: "Hello, world" }, readOnly: {} }`                 | Object |
-| `params` | `{ changed: { title: true }, metadata: { foo: "bar" }, parent: {} }` | Object |
+| Prop     | Example                                                                        | Type   |
+| -------- | ------------------------------------------------------------------------------ | ------ |
+| `data`   | `{ props: { title: "Hello, world" }, readOnly: {} }`                           | Object |
+| `params` | `{ changed: { title: true }, metadata: { foo: "bar" }, parent: {}, root: {} }` | Object |
 
 ##### `data.props`
 
@@ -413,6 +413,18 @@ const resolveData = async ({ props }, { metadata }) => {
 The [component data](/docs/api-reference/data-model/component-data) of the parent.
 
 If the parent implements [resolveData](#resolvedatadata-params), this parameter will return the unresolved data on initial render, as resolvers are executed bottom-up.
+
+##### `params.root`
+
+The [root data](/docs/api-reference/data-model/root-data) for the current document. Useful for resolving a component's props based on values stored on the root.
+
+```tsx copy {2} filename="Example using a root prop to resolve the title"
+const resolveData = async ({ props }, { root }) => {
+  return {
+    props: { title: `${root.props?.title} — ${props.title}` },
+  };
+};
+```
 
 ##### `params.trigger`
 

--- a/packages/core/lib/__tests__/resolve-all-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-all-data.spec.tsx
@@ -1,4 +1,4 @@
-import { ComponentData, Config, Data } from "../../types";
+import { ComponentData, Config, Data, RootData } from "../../types";
 import { resolveAllData } from "../resolve-all-data";
 
 const item4 = {
@@ -227,6 +227,76 @@ describe("resolve-data", () => {
     expect(receivedParentById[item1_2.props.id]?.props.id).toBe(item1.props.id);
     expect(receivedParentById[item1_2_1.props.id]?.props.id).toBe(
       item1_2.props.id
+    );
+  });
+
+  it("should pass the resolved root to every resolver in params", async () => {
+    const item1_2_1 = {
+      type: "ComponentWithResolveProps",
+      props: { id: "MyComponent-1_2_1", prop: "Original", slot: [] },
+    };
+    const item1_2 = {
+      type: "ComponentWithResolveProps",
+      props: { id: "MyComponent-1_2", prop: "Original", slot: [item1_2_1] },
+    };
+    const item1_1 = {
+      type: "ComponentWithResolveProps",
+      props: { id: "MyComponent-1_1", prop: "Original", slot: [] },
+    };
+    const item1 = {
+      type: "ComponentWithResolveProps",
+      props: { id: "MyComponent-1", prop: "Original", slot: [item1_1] },
+    };
+    const data: Data = {
+      root: { props: { title: "Original title" } },
+      content: [item1],
+      zones: {
+        "MyComponent-1:zone": [item1_2],
+      },
+    };
+
+    let receivedRootById: Record<string, RootData | undefined> = {};
+
+    const resolveData = jest.fn(async ({ props }, { root }) => {
+      receivedRootById[props.id] = root;
+
+      return { props: { ...props, prop: "Resolved" } };
+    });
+
+    const config: Config = {
+      components: {
+        ComponentWithResolveProps: {
+          fields: { slot: { type: "slot" } },
+          defaultProps: { prop: "example" },
+          resolveData,
+          render: () => <div />,
+        },
+      },
+      root: {
+        resolveData: async ({ props }) => ({
+          props: { ...props, title: "Resolved title" },
+        }),
+      },
+    };
+
+    // When: --------------------
+    await resolveAllData(data, config);
+
+    // Then: --------------------
+    expect(resolveData.mock.calls.every((call) => !!call[1].root)).toBe(true);
+
+    // Content, deep slot children and zones all receive the resolved root
+    expect(receivedRootById[item1.props.id]?.props?.title).toBe(
+      "Resolved title"
+    );
+    expect(receivedRootById[item1_1.props.id]?.props?.title).toBe(
+      "Resolved title"
+    );
+    expect(receivedRootById[item1_2.props.id]?.props?.title).toBe(
+      "Resolved title"
+    );
+    expect(receivedRootById[item1_2_1.props.id]?.props?.title).toBe(
+      "Resolved title"
     );
   });
 

--- a/packages/core/lib/__tests__/resolve-component-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-component-data.spec.tsx
@@ -367,6 +367,39 @@ describe("resolveComponentData", () => {
     expect(movedResolution.didChange).toBe(false);
   });
 
+  it("should pass root down to every resolver in the tree", async () => {
+    // When: ---------------
+    const root = { props: { title: "My root title" } };
+
+    await resolveComponentData(
+      toComponent({
+        type: "MyComponentWithResolver",
+        props: {
+          id: "parent",
+          prop: "Not yet resolved",
+          slot: [
+            {
+              type: "MyComponentWithResolver",
+              props: { id: "child", prop: "Not yet resolved" },
+            },
+          ],
+        },
+      }),
+      appStore.getState().config,
+      undefined,
+      undefined,
+      undefined,
+      "force",
+      null,
+      root
+    );
+
+    // Then: ---------------
+    expect(componentResolveData).toHaveBeenCalledTimes(2);
+    expect(componentResolveData.mock.calls[0][1].root).toStrictEqual(root);
+    expect(componentResolveData.mock.calls[1][1].root).toStrictEqual(root);
+  });
+
   it("shouldn't run for 'move' triggers before the component resolves once for other actions", async () => {
     // When: ---------------
     const movedResolution = await resolveComponentData(

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -32,7 +32,8 @@ export async function resolveAllData<
 
   const resolveNode = async <T extends ComponentData | RootData>(
     _node: T,
-    parent: ComponentData | null
+    parent: ComponentData | null,
+    root: RootData
   ) => {
     const node = toComponent(_node);
 
@@ -46,7 +47,8 @@ export async function resolveAllData<
         () => {},
         () => {},
         "force",
-        parent
+        parent,
+        root
       )
     ).node as T;
 
@@ -56,7 +58,7 @@ export async function resolveAllData<
     const resolvedDeepPromise = mapFields(
       resolved,
       {
-        slot: ({ value }) => processContent(value, resolvedAsComponent),
+        slot: ({ value }) => processContent(value, resolvedAsComponent, root),
       },
       config
     ) as unknown as Promise<T>;
@@ -69,7 +71,8 @@ export async function resolveAllData<
         async ({ zoneCompound, content }) => {
           resolvedZones[zoneCompound] = await processContent(
             content,
-            resolvedAsComponent
+            resolvedAsComponent,
+            root
           );
         }
       );
@@ -86,17 +89,19 @@ export async function resolveAllData<
 
   const processContent = async (
     content: Content,
-    parent: ComponentData | null
+    parent: ComponentData | null,
+    root: RootData
   ) => {
-    return Promise.all(content.map((item) => resolveNode(item, parent)));
+    return Promise.all(content.map((item) => resolveNode(item, parent, root)));
   };
 
   const result: Data = defaultData({});
 
-  result.root = await resolveNode(defaultedData.root, null);
+  result.root = await resolveNode(defaultedData.root, null, defaultedData.root);
   result.content = await processContent(
     defaultedData.content,
-    toComponent(result.root)
+    toComponent(result.root),
+    result.root
   );
   result.zones = resolvedZones;
 

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -4,6 +4,7 @@ import {
   Content,
   Metadata,
   ResolveDataTrigger,
+  RootData,
   RootDataWithProps,
 } from "../types";
 import { mapFields } from "./data/map-fields";
@@ -24,7 +25,8 @@ export const resolveComponentData = async <
   onResolveStart?: (item: T) => void,
   onResolveEnd?: (item: T) => void,
   trigger: ResolveDataTrigger = "replace",
-  parent: ComponentData | null = null
+  parent: ComponentData | null = null,
+  root: RootData = { props: {} }
 ) => {
   const configForItem =
     "type" in item && item.type !== "root"
@@ -72,6 +74,7 @@ export const resolveComponentData = async <
         metadata: { ...metadata, ...configForItem.metadata },
         trigger,
         parent,
+        root,
       });
 
     resolvedItem.props = {
@@ -103,7 +106,8 @@ export const resolveComponentData = async <
                   onResolveStart,
                   onResolveEnd,
                   trigger,
-                  itemAsComponentData
+                  itemAsComponentData,
+                  root
                 )
               ).node
           )

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -297,7 +297,8 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
             timeouts[id]();
           },
           trigger,
-          parentData
+          parentData,
+          state.data.root
         );
       },
       resolveAndCommitData: async () => {

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -72,6 +72,7 @@ type ComponentConfigInternal<
       metadata: ComponentMetadata;
       trigger: ResolveDataTrigger;
       parent: ComponentData | null;
+      root: RootData;
     }
   ) =>
     | Promise<WithPartialProps<DataShape, FieldProps>>


### PR DESCRIPTION
## Description

This PR exposes the document's root data to `resolveData` via a new `root` option on the resolver's `params` argument.

## Changes made

- Update types
- Thread through `resolveComponentData`
- Thread through `resolveAllData`
- Documented
- Added tests

## How to test

Add a `resolveData` that reads from the root and confirm a component re-resolves when a root field changes:

```tsx
const config = {
  root: {
    fields: { title: { type: "text" } },
  },
  components: {
    HeadingBlock: {
      fields: { title: { type: "text" } },
      resolveData: async ({ props }, { root }) => ({
        props: { title: `${root.props?.title}: ${props.title}` },
      }),
      render: ({ title }) => <h1>{title}</h1>,
    },
  },
};
```

Edit the root `title` field and confirm `HeadingBlock` re-resolves to include the root title prefix.
