### PR TITLE
Theming (WIP)

### DIFF
--- a/apps/demo/app/styles.css
+++ b/apps/demo/app/styles.css
@@ -1,6 +1,8 @@
 @import url("https://rsms.me/inter/inter.css");
 
 body {
+  background-color: var(--puck-color-surface);
+  color: var(--puck-color-text);
   font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI,
     Helvetica Neue, sans-serif, Apple Color Emoji, Segoe UI Emoji,
     Segoe UI Symbol;
@@ -12,5 +14,31 @@ body {
     font-family: InterVariable, -apple-system, BlinkMacSystemFont, Segoe UI,
       Helvetica Neue, sans-serif, Apple Color Emoji, Segoe UI Emoji,
       Segoe UI Symbol;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --puck-color-text: var(--puck-color-grey-09);
+    --puck-color-text-strong: var(--puck-color-grey-08);
+    --puck-color-text-inverse: var(--puck-color-grey-01);
+    --puck-color-interactive: var(--puck-color-azure-05);
+    --puck-color-interactive-hover: var(--puck-color-azure-07);
+    /* This is used in unexpected ways, such as for outline and nav hover */
+    --puck-color-interactive-soft: var(--puck-color-grey-03);
+    --puck-color-interactive-subtle: var(--puck-color-grey-03);
+    --puck-color-interactive-subtle-hover: var(--puck-color-grey-03);
+    --puck-color-surface: var(--puck-color-grey-01);
+    --puck-color-surface-muted: var(--puck-color-grey-01);
+    --puck-color-surface-subtle: var(--puck-color-grey-02);
+    --puck-color-border: var(--puck-color-grey-02);
+
+    --puck-color-selection-bg: color-mix(
+      in srgb,
+      var(--puck-color-azure-05) 30%,
+      transparent
+    );
+    --puck-color-selection-border: var(--puck-color-azure-06);
+    --puck-color-focus-ring: var(--puck-color-azure-07);
   }
 }

--- a/apps/demo/config/blocks/Blank/styles.module.css
+++ b/apps/demo/config/blocks/Blank/styles.module.css
@@ -1,4 +1,4 @@
 .Blank {
   background: hotpink;
-  padding: 16px;
+  padding: var(--puck-space-4);
 }

--- a/apps/demo/config/blocks/Card/styles.module.css
+++ b/apps/demo/config/blocks/Card/styles.module.css
@@ -3,22 +3,28 @@
 }
 
 .Card--card {
-  background: white;
+  background: var(--puck-color-surface);
   box-shadow: rgba(140, 152, 164, 0.25) 0px 3px 6px 0px;
-  border-radius: 8px;
+  border-radius: var(--puck-radius-l);
   max-width: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+  .Card--card {
+    box-shadow: rgba(24, 31, 41, 0.25) 0px 3px 6px 0px;
+  }
 }
 
 .Card-inner {
   align-items: center;
   display: flex;
-  gap: 16px;
+  gap: var(--puck-space-4);
   flex-direction: column;
 }
 
 .Card--card .Card-inner {
   align-items: flex-start;
-  padding: 24px;
+  padding: var(--puck-space-5);
 }
 
 .Card-icon {
@@ -42,9 +48,9 @@
 }
 
 .Card-description {
-  font-size: 16px;
+  font-size: var(--puck-font-size-xs);
   line-height: 1.5;
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   text-align: center;
   font-weight: 300;
 }

--- a/apps/demo/config/blocks/Hero/styles.module.css
+++ b/apps/demo/config/blocks/Hero/styles.module.css
@@ -8,6 +8,15 @@
   position: relative;
 }
 
+@media (prefers-color-scheme: dark) {
+  .Hero {
+    background-image: linear-gradient(
+      rgba(255, 255, 255, 0),
+      rgb(28, 29, 31) 100%
+    );
+  }
+}
+
 .Hero-inner {
   display: flex;
   align-items: center;
@@ -36,16 +45,16 @@
 }
 
 .Hero-subtitle {
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   font-size: var(--puck-font-size-m);
   line-height: 1.5;
   margin: 0;
-  margin-bottom: 8px;
+  margin-bottom: var(--puck-space-2);
   font-weight: 300;
 }
 
 .Hero-subtitle strong {
-  font-weight: 500;
+  font-weight: var(--puck-font-weight-medium);
 }
 
 .Hero--hasImageBackground .Hero-subtitle {
@@ -93,7 +102,7 @@
 .Hero-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--puck-space-4);
   width: 100%;
 }
 
@@ -116,5 +125,5 @@
 
 .Hero-actions {
   display: flex;
-  gap: 16px;
+  gap: var(--puck-space-4);
 }

--- a/apps/demo/config/blocks/Logos/styles.module.css
+++ b/apps/demo/config/blocks/Logos/styles.module.css
@@ -7,7 +7,7 @@
   justify-content: space-between;
   padding-bottom: 64px;
   padding-top: 64px;
-  gap: 24px;
+  gap: var(--puck-space-5);
   filter: grayscale(1) brightness(100);
   opacity: 0.8;
 }

--- a/apps/demo/config/blocks/Stats/styles.module.css
+++ b/apps/demo/config/blocks/Stats/styles.module.css
@@ -12,19 +12,19 @@
   justify-content: space-between;
   margin: 0 auto;
   max-width: 768px;
-  padding: 64px 16px;
+  padding: 64px var(--puck-space-4);
 }
 
 @media (min-width: 768px) {
   .Stats-items {
-    padding: 64px 24px;
+    padding: 64px var(--puck-space-5);
   }
 }
 
 @media (min-width: 1024px) {
   .Stats-items {
     grid-template-columns: 1fr 1fr;
-    padding: 128px 24px;
+    padding: 128px var(--puck-space-5);
     max-width: 100%;
   }
 }
@@ -34,7 +34,7 @@
   flex-direction: column;
   align-items: center;
   color: white;
-  gap: 8px;
+  gap: var(--puck-space-2);
   width: 100%;
   text-align: center;
 }
@@ -53,12 +53,12 @@
 .Stats-label {
   font-size: 22px;
   text-align: center;
-  font-weight: 600;
+  font-weight: var(--puck-font-weight-semibold);
   opacity: 0.8;
 }
 
 .Stats-value {
   font-size: 72px;
   line-height: 1;
-  font-weight: 700;
+  font-weight: var(--puck-font-weight-bold);
 }

--- a/apps/demo/config/components/Footer/index.tsx
+++ b/apps/demo/config/components/Footer/index.tsx
@@ -35,7 +35,7 @@ const FooterList = ({
           padding: 0,
           fontSize: "inherit",
           fontWeight: "600",
-          color: "var(--puck-color-grey-03)",
+          color: "var(--puck-color-text-muted)",
         }}
       >
         {title}
@@ -56,7 +56,7 @@ const FooterList = ({
 
 const Footer = ({ children }: { children: ReactNode }) => {
   return (
-    <footer style={{ background: "var(--puck-color-grey-12)" }}>
+    <footer style={{ background: "var(--puck-color-surface)" }}>
       <h2 style={{ visibility: "hidden", height: 0, margin: 0 }}>Footer</h2>
       <div style={{ padding: 32 }}>
         <Section>
@@ -77,8 +77,8 @@ const Footer = ({ children }: { children: ReactNode }) => {
         style={{
           padding: 64,
           textAlign: "center",
-          color: "var(--puck-color-grey-03)",
-          background: "var(--puck-color-grey-11)",
+          color: "var(--puck-color-text-muted)",
+          background: "var(--puck-color-surface-muted)",
         }}
       >
         Made by{" "}

--- a/apps/demo/config/components/Header/index.tsx
+++ b/apps/demo/config/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { getClassNameFactory } from "@/core/lib";
 import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("Header", styles);
+const getClassNameItem = getClassNameFactory("HeaderItem", styles);
 
 const NavItem = ({ label, href }: { label: string; href: string }) => {
   const navPath =
@@ -15,16 +16,7 @@ const NavItem = ({ label, href }: { label: string; href: string }) => {
   const El = href ? "a" : "span";
 
   return (
-    <El
-      href={href || "/"}
-      style={{
-        textDecoration: "none",
-        color: isActive
-          ? "var(--puck-color-grey-02)"
-          : "var(--puck-color-grey-06)",
-        fontWeight: isActive ? "600" : "400",
-      }}
-    >
+    <El className={getClassNameItem({ isActive })} href={href || "/"}>
       {label}
     </El>
   );

--- a/apps/demo/config/components/Header/styles.module.css
+++ b/apps/demo/config/components/Header/styles.module.css
@@ -1,5 +1,5 @@
 .Header {
-  background-color: white;
+  background-color: var(--puck-color-surface);
   position: sticky;
   top: 0;
   z-index: 2;
@@ -11,25 +11,25 @@
   margin-inline-start: auto;
   margin-inline-end: auto;
   max-width: 1280px;
-  padding: 24px 16px;
+  padding: var(--puck-space-5) var(--puck-space-4);
 }
 
 @media (min-width: 768px) {
   .Header-inner {
-    padding: 24px;
+    padding: var(--puck-space-5);
   }
 }
 
 .Header-logo {
   font-size: 24px;
-  font-weight: 800;
+  font-weight: var(--puck-font-weight-heavy);
   letter-spacing: 1.4;
   opacity: 0.8;
 }
 
 .Header-items {
   display: flex;
-  gap: 24px;
+  gap: var(--puck-space-5);
   margin-inline-start: auto;
 }
 
@@ -37,4 +37,14 @@
   .Header-items {
     gap: 32px;
   }
+}
+
+.HeaderItem {
+  text-decoration: none;
+  color: var(--puck-color-grey-06);
+}
+
+.HeaderItem--isActive {
+  color: var(--puck-color-text-muted);
+  font-weight: 600;
 }

--- a/apps/demo/config/components/Section/styles.module.css
+++ b/apps/demo/config/components/Section/styles.module.css
@@ -1,12 +1,12 @@
 .Section:not(.Section .Section) {
-  padding-inline-start: 16px;
-  padding-inline-end: 16px;
+  padding-inline-start: var(--puck-space-4);
+  padding-inline-end: var(--puck-space-4);
 }
 
 @media (min-width: 768px) {
   .Section:not(.Section .Section) {
-    padding-inline-start: 24px;
-    padding-inline-end: 24px;
+    padding-inline-start: var(--puck-space-5);
+    padding-inline-end: var(--puck-space-5);
   }
 }
 

--- a/apps/docs/pages/docs/api-reference/theming.mdx
+++ b/apps/docs/pages/docs/api-reference/theming.mdx
@@ -1,43 +1,160 @@
-import { Callout } from "nextra/components";
-
 # Theming
-
-<Callout type="info">
-  Theming in Puck is currently limited in functionality, and being explored via
-  [#139 on GitHub](https://github.com/puckeditor/puck/issues/139).
-</Callout>
 
 CSS properties for theming the default Puck user interface.
 
-## Properties
-
-| Param                                                             | Example |
-| ----------------------------------------------------------------- | ------- |
-| [`--puck-font-family`](#--puck-font-family)                       | `Arial` |
-| [`--puck-font-family-monospaced`](#--puck-font-family-monospaced) | `Menlo` |
-
-### `--puck-font-family`
-
-The font family used for the Puck interface. Must be used with the `no-external` bundle that stops Puck from loading the default font.
+## Usage
 
 ```css
-/* Load bundle without existing font */
-@import "@puckeditor/core/no-external.css";
-
-:root {
-  --puck-font-family: Arial;
-}
-```
-
-### `--puck-font-family-monospaced`
-
-The font family used for monospaced elements of the Puck interface.
-
-```css
-/* Monospaced fonts don't use external files, so the default bundle is safe */
 @import "@puckeditor/core/puck.css";
 
 :root {
-  --puck-font-family-monospaced: Menlo;
+  --puck-color-interactive: #0f5fff;
+  --puck-color-focus-ring: #3b82f6;
+}
+```
+
+## Semantic Color Tokens
+
+| Token                                   | Default                                                           |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `--puck-color-surface`                  | `var(--puck-color-white)`                                         |
+| `--puck-color-surface-muted`            | `var(--puck-color-grey-12)`                                       |
+| `--puck-color-surface-subtle`           | `var(--puck-color-grey-11)`                                       |
+| `--puck-color-border`                   | `var(--puck-color-grey-09)`                                       |
+| `--puck-color-border-muted`             | `var(--puck-color-grey-10)`                                       |
+| `--puck-color-text`                     | `var(--puck-color-black)`                                         |
+| `--puck-color-text-strong`              | `var(--puck-color-grey-04)`                                       |
+| `--puck-color-text-muted`               | `var(--puck-color-grey-05)`                                       |
+| `--puck-color-text-subtle`              | `var(--puck-color-grey-07)`                                       |
+| `--puck-color-text-inverse`             | `var(--puck-color-white)`                                         |
+| `--puck-color-interactive`              | `var(--puck-color-azure-04)`                                      |
+| `--puck-color-interactive-hover`        | `var(--puck-color-azure-03)`                                      |
+| `--puck-color-interactive-active`       | `var(--puck-color-azure-02)`                                      |
+| `--puck-color-interactive-soft`         | `var(--puck-color-azure-10)`                                      |
+| `--puck-color-interactive-subtle`       | `var(--puck-color-azure-11)`                                      |
+| `--puck-color-interactive-subtle-hover` | `var(--puck-color-azure-12)`                                      |
+| `--puck-color-focus-ring`               | `var(--puck-color-azure-05)`                                      |
+| `--puck-color-selection-bg`             | `color-mix(in srgb, var(--puck-color-azure-09) 30%, transparent)` |
+| `--puck-color-selection-border`         | `var(--puck-color-azure-08)`                                      |
+| `--puck-color-disabled-bg`              | `var(--puck-color-grey-07)`                                       |
+| `--puck-color-disabled-text`            | `var(--puck-color-grey-03)`                                       |
+| `--puck-color-overlay-backdrop`         | `color-mix(in srgb, var(--puck-color-black) 75%, transparent)`    |
+| `--puck-color-danger`                   | `var(--puck-color-red-04)`                                        |
+
+## Non-Color Tokens
+
+### Spacing
+
+| Token             | Default               |
+| ----------------- | --------------------- |
+| `--puck-space-1`  | `4px`                 |
+| `--puck-space-2`  | `8px`                 |
+| `--puck-space-3`  | `12px`                |
+| `--puck-space-4`  | `16px`                |
+| `--puck-space-5`  | `24px`                |
+| `--puck-space-px` | `var(--puck-space-4)` |
+
+### Radius
+
+| Token                 | Default |
+| --------------------- | ------- |
+| `--puck-radius-none`  | `0`     |
+| `--puck-radius-xs`    | `2px`   |
+| `--puck-radius-s`     | `3px`   |
+| `--puck-radius-m`     | `4px`   |
+| `--puck-radius-l`     | `8px`   |
+| `--puck-radius-pill`  | `30px`  |
+| `--puck-radius-round` | `100%`  |
+
+### Border Width
+
+| Token                          | Default |
+| ------------------------------ | ------- |
+| `--puck-border-width-hairline` | `0.5px` |
+| `--puck-border-width-regular`  | `1px`   |
+| `--puck-border-width-focus`    | `2px`   |
+| `--puck-border-width-strong`   | `4px`   |
+
+### Motion
+
+| Token                    | Default       |
+| ------------------------ | ------------- |
+| `--puck-duration-fast`   | `50ms`        |
+| `--puck-duration-medium` | `150ms`       |
+| `--puck-duration-slow`   | `250ms`       |
+| `--puck-ease-standard`   | `ease-in`     |
+| `--puck-ease-emphasized` | `ease-in-out` |
+| `--puck-ease-exit`       | `ease-out`    |
+
+### Typography
+
+| Token                           | Default                                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--puck-font-family`            | `Inter, var(--fallback-font-stack)`                                                                |
+| `--puck-font-family-monospaced` | `ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace` |
+| `--puck-font-weight-regular`    | `400`                                                                                              |
+| `--puck-font-weight-medium`     | `500`                                                                                              |
+| `--puck-font-weight-semibold`   | `600`                                                                                              |
+| `--puck-font-weight-bold`       | `700`                                                                                              |
+| `--puck-font-weight-heavy`      | `800`                                                                                              |
+| `--puck-letter-spacing-ui`      | `0.05ch`                                                                                           |
+| `--puck-letter-spacing-heading` | `0.08ch`                                                                                           |
+| `--space-m-unitless`            | `24`                                                                                               |
+
+### Icon Size
+
+| Token                | Default |
+| -------------------- | ------- |
+| `--puck-icon-size-s` | `16px`  |
+| `--puck-icon-size-m` | `18px`  |
+| `--puck-icon-size-l` | `24px`  |
+
+### Functional Tokens
+
+| Token                              | Default                      |
+| ---------------------------------- | ---------------------------- |
+| `--min-empty-height`               | `128px`                      |
+| `--puck-user-left-side-bar-width`  | `var(--puck-side-bar-width)` |
+| `--puck-user-right-side-bar-width` | `var(--puck-side-bar-width)` |
+
+## Examples
+
+### Brand Colors
+
+```css
+@import "@puckeditor/core/puck.css";
+
+:root {
+  --puck-color-interactive: #0d9488;
+  --puck-color-interactive-hover: #0f766e;
+  --puck-color-interactive-active: #115e59;
+  --puck-color-focus-ring: #14b8a6;
+}
+```
+
+### Compact UI
+
+```css
+@import "@puckeditor/core/puck.css";
+
+:root {
+  --puck-space-4: 14px;
+  --puck-space-px: var(--puck-space-4);
+  --puck-radius-m: 3px;
+  --puck-radius-l: 6px;
+}
+```
+
+### Fonts
+
+If you load your own font file, use the `no-external.css` bundle to prevent loading Puck's default external font.
+
+```css
+/* @import "@puckeditor/core/puck.css"; */
+@import "@puckeditor/core/no-external.css";
+
+:root {
+  --puck-font-family: "IBM Plex Sans", sans-serif;
+  --puck-font-family-monospaced: "IBM Plex Mono", monospace;
 }
 ```

--- a/packages/core/bundle/core.css
+++ b/packages/core/bundle/core.css
@@ -1,4 +1,5 @@
 @import "../styles/color.css";
+@import "../styles/tokens.css";
 @import "../styles/typography.css";
 
 #frame-root {

--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -1,4 +1,11 @@
 .ActionBar {
+  --puck-action-bar-bg: var(--puck-color-grey-01);
+  --puck-action-bar-text: var(--puck-color-grey-08);
+  --puck-action-bar-separator: var(--puck-color-grey-05);
+  --puck-action-bar-disabled: var(--puck-color-grey-06);
+  --puck-action-bar-hover: var(--puck-color-azure-06);
+  --puck-action-bar-active: var(--puck-color-azure-07);
+
   align-items: center;
   cursor: default;
   display: flex;
@@ -9,14 +16,14 @@
   border-top-left-radius: var(--puck-radius-l);
   border-top-right-radius: var(--puck-radius-l);
   border-radius: var(--puck-radius-l);
-  background: var(--puck-color-grey-01);
+  background: var(--puck-action-bar-bg);
   color: var(--puck-color-text-inverse);
   font-family: var(--puck-font-family);
   min-height: 26px;
 }
 
 .ActionBar-label {
-  color: var(--puck-color-grey-08);
+  color: var(--puck-action-bar-text);
   font-size: var(--puck-font-size-xxxs);
   font-weight: var(--puck-font-weight-medium);
   padding-inline-start: var(--puck-space-2);
@@ -38,7 +45,7 @@
 .ActionBar-group {
   align-items: center;
   border-inline-start: var(--puck-border-width-hairline) solid
-    var(--puck-color-grey-05); /* Fractional value required due to scaling */
+    var(--puck-action-bar-separator); /* Fractional value required due to scaling */
   display: flex;
   height: 100%;
   padding-inline-start: var(--puck-space-1);
@@ -56,7 +63,7 @@
 .ActionBarAction {
   background: transparent;
   border: none;
-  color: var(--puck-color-grey-08);
+  color: var(--puck-action-bar-text);
   cursor: pointer;
   padding: 6px;
   margin-inline-start: var(--puck-space-1);
@@ -71,7 +78,7 @@
 
 .ActionBarAction--disabled {
   cursor: auto;
-  color: var(--puck-color-grey-06);
+  color: var(--puck-action-bar-disabled);
 }
 
 .ActionBarAction svg {
@@ -85,14 +92,14 @@
 
 @media (hover: hover) and (pointer: fine) {
   .ActionBarAction:hover:not(.ActionBarAction--disabled) {
-    color: var(--puck-color-azure-06);
+    color: var(--puck-action-bar-hover);
     transition: none;
   }
 }
 
 .ActionBarAction:active:not(.ActionBarAction--disabled),
 .ActionBarAction--active {
-  color: var(--puck-color-azure-07);
+  color: var(--puck-action-bar-active);
   transition: none;
 }
 
@@ -101,7 +108,7 @@
 }
 
 .ActionBar-separator {
-  background: var(--puck-color-grey-05);
+  background: var(--puck-action-bar-separator);
   margin-inline: var(--puck-space-1);
   width: var(--puck-border-width-hairline); /* Fractional value required due to scaling */
   height: 100%;

--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -3,14 +3,14 @@
   cursor: default;
   display: flex;
   width: auto;
-  padding: 4px;
+  padding: var(--puck-space-1);
   padding-inline-start: 0;
   padding-inline-end: 0;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-  border-radius: 8px;
+  border-top-left-radius: var(--puck-radius-l);
+  border-top-right-radius: var(--puck-radius-l);
+  border-radius: var(--puck-radius-l);
   background: var(--puck-color-grey-01);
-  color: var(--puck-color-white);
+  color: var(--puck-color-text-inverse);
   font-family: var(--puck-font-family);
   min-height: 26px;
 }
@@ -18,11 +18,11 @@
 .ActionBar-label {
   color: var(--puck-color-grey-08);
   font-size: var(--puck-font-size-xxxs);
-  font-weight: 500;
-  padding-inline-start: 8px;
-  padding-inline-end: 8px;
-  margin-inline-start: 4px;
-  margin-inline-end: 4px;
+  font-weight: var(--puck-font-weight-medium);
+  padding-inline-start: var(--puck-space-2);
+  padding-inline-end: var(--puck-space-2);
+  margin-inline-start: var(--puck-space-1);
+  margin-inline-end: var(--puck-space-1);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -32,16 +32,17 @@
 }
 
 .ActionBar-label + .ActionBarAction {
-  margin-inline-start: -4px;
+  margin-inline-start: calc(var(--puck-space-1) * -1);
 }
 
 .ActionBar-group {
   align-items: center;
-  border-inline-start: 0.5px solid var(--puck-color-grey-05); /* Fractional value required due to scaling */
+  border-inline-start: var(--puck-border-width-hairline) solid
+    var(--puck-color-grey-05); /* Fractional value required due to scaling */
   display: flex;
   height: 100%;
-  padding-inline-start: 4px;
-  padding-inline-end: 4px;
+  padding-inline-start: var(--puck-space-1);
+  padding-inline-end: var(--puck-space-1);
 }
 
 .ActionBar-group:first-of-type {
@@ -58,14 +59,14 @@
   color: var(--puck-color-grey-08);
   cursor: pointer;
   padding: 6px;
-  margin-inline-start: 4px;
-  margin-inline-end: 4px;
-  border-radius: 4px;
+  margin-inline-start: var(--puck-space-1);
+  margin-inline-end: var(--puck-space-1);
+  border-radius: var(--puck-radius-m);
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 50ms ease-in;
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .ActionBarAction--disabled {
@@ -78,8 +79,8 @@
 }
 
 .ActionBarAction:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: -2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: calc(var(--puck-border-width-focus) * -1);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -101,7 +102,7 @@
 
 .ActionBar-separator {
   background: var(--puck-color-grey-05);
-  margin-inline: 4px;
-  width: 0.5px; /* Fractional value required due to scaling */
+  margin-inline: var(--puck-space-1);
+  width: var(--puck-border-width-hairline); /* Fractional value required due to scaling */
   height: 100%;
 }

--- a/packages/core/components/AutoField/fields/ArrayField/styles.module.css
+++ b/packages/core/components/AutoField/fields/ArrayField/styles.module.css
@@ -5,54 +5,55 @@
 .ArrayField {
   display: flex;
   flex-direction: column;
-  background: var(--puck-color-azure-11);
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 4px;
+  background: var(--puck-color-interactive-subtle);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
 }
 
 .ArrayField--isDraggingFrom {
-  background-color: var(--puck-color-azure-11);
+  background-color: var(--puck-color-interactive-subtle);
   overflow: hidden;
 }
 
 .ArrayField-addButton {
-  background-color: var(--puck-color-white);
+  background-color: var(--puck-color-surface);
   border: none;
-  border-radius: 3px;
+  border-radius: var(--puck-radius-s);
   display: flex;
-  color: var(--puck-color-azure-05);
+  color: var(--puck-color-focus-ring);
   justify-content: center;
   cursor: pointer;
   width: 100%;
   margin: 0;
   padding: 14px; /* Retain same height as other items */
   text-align: left;
-  transition: background-color 50ms ease-in;
+  transition: background-color var(--puck-duration-fast)
+    var(--puck-ease-standard);
 }
 
 .ArrayField--hasItems > .ArrayField-addButton {
-  border-top: 1px solid var(--puck-color-grey-09);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
 
 .ArrayField-addButton:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
   position: relative;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ArrayField:not(.ArrayField--isDraggingFrom) > .ArrayField-addButton:hover {
-    background: var(--puck-color-azure-12);
-    color: var(--puck-color-azure-04);
+    background: var(--puck-color-interactive-subtle-hover);
+    color: var(--puck-color-interactive);
     transition: none;
   }
 }
 
 .ArrayField:not(.ArrayField--isDraggingFrom) > .ArrayField-addButton:active {
-  background: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
+  background: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
   transition: none;
 }
 
@@ -65,14 +66,14 @@
  */
 
 .ArrayFieldItem {
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
+  border-top-left-radius: var(--puck-radius-s);
+  border-top-right-radius: var(--puck-radius-s);
   display: block;
   position: relative;
 }
 
 .ArrayFieldItem {
-  border-top: 1px solid var(--puck-color-grey-09);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
 }
 
 .ArrayFieldItem--isDragging {
@@ -86,16 +87,17 @@
 .ArrayFieldItem--isExpanded {
   border-bottom: 0;
   outline-offset: 0px !important; /* Important helps to override Nextra docs */
-  outline: 1px solid var(--puck-color-azure-07) !important; /* Important helps to override Nextra docs */
+  outline: var(--puck-border-width-regular) solid var(--puck-color-azure-07) !important; /* Important helps to override Nextra docs */
   z-index: 2;
 }
 
 .ArrayFieldItem--isDragging {
-  outline: 2px var(--puck-color-azure-09) solid !important;
+  outline: var(--puck-border-width-focus) var(--puck-color-selection-border)
+    solid !important;
 }
 
 .ArrayFieldItem--isDragging .ArrayFieldItem-summary:active {
-  background-color: var(--puck-color-white);
+  background-color: var(--puck-color-surface);
 }
 
 .ArrayFieldItem + .ArrayFieldItem {
@@ -104,8 +106,8 @@
 }
 
 .ArrayFieldItem-summary {
-  background: var(--puck-color-white);
-  color: var(--puck-color-grey-04);
+  background: var(--puck-color-surface);
+  color: var(--puck-color-text-strong);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -113,10 +115,11 @@
   justify-content: space-between;
   font-size: var(--puck-font-size-xxs);
   list-style: none;
-  padding: 12px 15px;
+  padding: var(--puck-space-3) 15px;
   position: relative;
   overflow: hidden;
-  transition: background-color 50ms ease-in;
+  transition: background-color var(--puck-duration-fast)
+    var(--puck-ease-standard);
 }
 
 .ArrayFieldItem--noFields > .ArrayFieldItem-summary {
@@ -124,51 +127,51 @@
 }
 
 .ArrayFieldItem:first-of-type > .ArrayFieldItem-summary {
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
+  border-top-left-radius: var(--puck-radius-s);
+  border-top-right-radius: var(--puck-radius-s);
 }
 
 .ArrayField--addDisabled
   > .ArrayField-inner
   > .ArrayFieldItem:last-of-type:not(.ArrayFieldItem--isExpanded)
   > .ArrayFieldItem-summary {
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: var(--puck-radius-s);
+  border-bottom-right-radius: var(--puck-radius-s);
 }
 
 .ArrayField--addDisabled
   > .ArrayField-inner
   > .ArrayFieldItem--isExpanded:last-of-type {
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: var(--puck-radius-s);
+  border-bottom-right-radius: var(--puck-radius-s);
 }
 
 .ArrayFieldItem-summary:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ArrayFieldItem-summary:hover {
-    background-color: var(--puck-color-azure-12);
+    background-color: var(--puck-color-interactive-subtle-hover);
     transition: none;
   }
 }
 
 .ArrayFieldItem-summary:active {
-  background-color: var(--puck-color-azure-11);
+  background-color: var(--puck-color-interactive-subtle);
   transition: none;
 }
 
 .ArrayFieldItem--isExpanded > .ArrayFieldItem-summary {
-  background: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
-  font-weight: 600;
+  background: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
+  font-weight: var(--puck-font-weight-semibold);
   transition: none;
 }
 
 .ArrayFieldItem-body {
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
   display: none;
 }
 
@@ -178,22 +181,22 @@
 
 .ArrayFieldItem-fieldset {
   border: none;
-  border-top: 1px solid var(--puck-color-grey-09);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
   margin: 0;
   min-width: 0; /* Needed to ensure External input doesn't overflow, see https://stackoverflow.com/a/53784508 */
-  padding: 16px 15px;
+  padding: var(--puck-space-4) 15px;
 }
 
 .ArrayFieldItem-rhs {
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
   align-items: center;
 }
 
 .ArrayFieldItem-actions {
-  color: var(--puck-color-grey-04);
+  color: var(--puck-color-text-strong);
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
   opacity: 0;
 }
 

--- a/packages/core/components/AutoField/fields/ArrayField/styles.module.css
+++ b/packages/core/components/AutoField/fields/ArrayField/styles.module.css
@@ -3,6 +3,8 @@
  */
 
 .ArrayField {
+  --puck-array-field-expanded-outline: var(--puck-color-azure-07);
+
   display: flex;
   flex-direction: column;
   background: var(--puck-color-interactive-subtle);
@@ -87,7 +89,7 @@
 .ArrayFieldItem--isExpanded {
   border-bottom: 0;
   outline-offset: 0px !important; /* Important helps to override Nextra docs */
-  outline: var(--puck-border-width-regular) solid var(--puck-color-azure-07) !important; /* Important helps to override Nextra docs */
+  outline: var(--puck-border-width-regular) solid var(--puck-array-field-expanded-outline) !important; /* Important helps to override Nextra docs */
   z-index: 2;
 }
 

--- a/packages/core/components/AutoField/fields/ObjectField/styles.module.css
+++ b/packages/core/components/AutoField/fields/ObjectField/styles.module.css
@@ -5,14 +5,14 @@
 .ObjectField {
   display: flex;
   flex-direction: column;
-  background-color: var(--puck-color-white);
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 4px;
+  background-color: var(--puck-color-surface);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
 }
 
 .ObjectField-fieldset {
   border: none;
   margin: 0;
   min-width: 0; /* Needed to ensure External input doesn't overflow, see https://stackoverflow.com/a/53784508 */
-  padding: 16px 15px;
+  padding: var(--puck-space-4) 15px;
 }

--- a/packages/core/components/AutoField/styles.module.css
+++ b/packages/core/components/AutoField/styles.module.css
@@ -1,46 +1,47 @@
 .InputWrapper + .InputWrapper {
-  margin-top: 12px;
+  margin-top: var(--puck-space-3);
 }
 
 .Input-label {
   align-items: center;
-  color: var(--puck-color-grey-04);
+  color: var(--puck-color-text-strong);
   display: flex;
-  padding-bottom: 12px;
+  padding-bottom: var(--puck-space-3);
   font-size: var(--puck-font-size-xxs);
-  font-weight: 600;
+  font-weight: var(--puck-font-weight-semibold);
 }
 
 .Input-labelIcon {
-  color: var(--puck-color-grey-07);
+  color: var(--puck-color-text-subtle);
   display: flex;
-  margin-inline-end: 4px;
-  padding-inline-start: 4px;
+  margin-inline-end: var(--puck-space-1);
+  padding-inline-start: var(--puck-space-1);
 }
 
 .Input-disabledIcon {
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   margin-inline-start: auto;
 }
 
 .Input-input {
-  background: var(--puck-color-white);
-  border-width: 1px;
+  background: var(--puck-color-surface);
+  border-width: var(--puck-border-width-regular);
   border-style: solid;
-  border-color: var(--puck-color-grey-09);
-  border-radius: 4px;
+  border-color: var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
   box-sizing: border-box;
+  color: var(--puck-color-text);
   font-family: inherit;
-  font-size: 16px;
-  padding: 12px 15px;
-  transition: border-color 50ms ease-in;
+  font-size: var(--puck-font-size-xs);
+  padding: var(--puck-space-3) 15px;
+  transition: border-color var(--puck-duration-fast) var(--puck-ease-standard);
   width: 100%;
   max-width: 100%;
 }
 
 @media (min-width: 458px) {
   .Input-input {
-    font-size: 14px;
+    font-size: var(--puck-font-size-xxs);
   }
 }
 
@@ -51,7 +52,7 @@ select.Input-input {
   background-size: 12px;
   background-position: calc(100% - 12px) calc(50% + 3px);
   background-repeat: no-repeat;
-  background-color: var(--puck-color-white);
+  background-color: var(--puck-color-surface);
   cursor: pointer;
 }
 
@@ -62,28 +63,28 @@ select.Input-input:dir(rtl) {
 @media (hover: hover) and (pointer: fine) {
   .Input:has(> input):hover .Input-input:not([readonly]),
   .Input:has(> textarea):hover .Input-input:not([readonly]) {
-    border-color: var(--puck-color-grey-05);
+    border-color: var(--puck-color-text-muted);
     transition: none;
   }
   .Input:has(> select):hover .Input-input:not([disabled]) {
-    background-color: var(--puck-color-azure-12);
+    background-color: var(--puck-color-interactive-subtle-hover);
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%235a5a5a'><polygon points='0,0 100,0 50,50'/></svg>");
-    border-color: var(--puck-color-grey-05);
+    border-color: var(--puck-color-text-muted);
     transition: none;
   }
 }
 
 .Input-input:focus {
-  border-color: var(--puck-color-grey-05);
-  outline: 2px solid var(--puck-color-azure-05);
+  border-color: var(--puck-color-text-muted);
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
   transition: none;
 }
 
 .Input--readOnly > .Input-input,
 .Input--readOnly > select.Input-input {
-  background-color: var(--puck-color-grey-11);
-  border-color: var(--puck-color-grey-09);
-  color: var(--puck-color-grey-04);
+  background-color: var(--puck-color-surface-subtle);
+  border-color: var(--puck-color-border);
+  color: var(--puck-color-text-strong);
   cursor: default;
   opacity: 1;
   outline: 0;
@@ -92,75 +93,77 @@ select.Input-input:dir(rtl) {
 
 .Input-radioGroupItems {
   display: flex;
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 4px;
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
   flex-wrap: wrap;
 }
 
 .Input-radio {
-  border-inline-end: 1px solid var(--puck-color-grey-09);
+  border-inline-end: var(--puck-border-width-regular) solid
+    var(--puck-color-border);
   flex-grow: 1;
 }
 
 .Input-radio:first-of-type {
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
+  border-bottom-left-radius: var(--puck-radius-m);
+  border-top-left-radius: var(--puck-radius-m);
 }
 
 .Input-radio:first-of-type .Input-radioInner {
-  border-bottom-left-radius: 3px;
-  border-top-left-radius: 3px;
+  border-bottom-left-radius: var(--puck-radius-s);
+  border-top-left-radius: var(--puck-radius-s);
 }
 
 .Input-radio:last-of-type {
-  border-bottom-right-radius: 4px;
+  border-bottom-right-radius: var(--puck-radius-m);
   border-inline-end: 0;
-  border-top-right-radius: 4px;
+  border-top-right-radius: var(--puck-radius-m);
 }
 
 .Input-radio:last-of-type .Input-radioInner {
-  border-bottom-right-radius: 3px;
-  border-top-right-radius: 3px;
+  border-bottom-right-radius: var(--puck-radius-s);
+  border-top-right-radius: var(--puck-radius-s);
 }
 
 .Input-radioInner {
-  background-color: var(--puck-color-white);
-  color: var(--puck-color-grey-04);
+  background-color: var(--puck-color-surface);
+  color: var(--puck-color-text-strong);
   cursor: pointer;
   font-size: var(--puck-font-size-xxxs);
-  padding: 8px 12px;
+  padding: var(--puck-space-2) var(--puck-space-3);
   text-align: center;
-  transition: background-color 50ms ease-in;
+  transition: background-color var(--puck-duration-fast)
+    var(--puck-ease-standard);
 }
 
 .Input-radio:has(:focus-visible) {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
   position: relative;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Input-radioInner:hover {
-    background-color: var(--puck-color-azure-12);
+    background-color: var(--puck-color-interactive-subtle-hover);
     transition: none;
   }
 }
 
 .Input--readOnly .Input-radioInner {
-  background-color: var(--puck-color-white);
-  color: var(--puck-color-grey-04);
+  background-color: var(--puck-color-surface);
+  color: var(--puck-color-text-strong);
   cursor: default;
 }
 
 .Input-radio .Input-radioInput:checked ~ .Input-radioInner {
-  background-color: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
-  font-weight: 500;
+  background-color: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
+  font-weight: var(--puck-font-weight-medium);
 }
 
 .Input--readOnly .Input-radioInput:checked ~ .Input-radioInner {
-  background-color: var(--puck-color-grey-11);
-  color: var(--puck-color-grey-04);
+  background-color: var(--puck-color-surface-subtle);
+  color: var(--puck-color-text-strong);
 }
 
 .Input-radio .Input-radioInput {
@@ -174,5 +177,7 @@ select.Input-input:dir(rtl) {
 }
 
 textarea.Input-input {
-  margin-bottom: -4px; /* Remove strange bottom border */
+  margin-bottom: calc(
+    var(--puck-space-1) * -1
+  ); /* Remove strange bottom border */
 }

--- a/packages/core/components/Breadcrumbs/styles.module.css
+++ b/packages/core/components/Breadcrumbs/styles.module.css
@@ -1,40 +1,40 @@
 .Breadcrumbs {
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
 }
 
 .Breadcrumbs-breadcrumbLabel {
   background: none;
   border: 0;
-  border-radius: 2px;
-  color: var(--puck-color-azure-04);
+  border-radius: var(--puck-radius-xs);
+  color: var(--puck-color-interactive);
   cursor: pointer;
   font: inherit;
   flex-shrink: 0;
   padding: 0;
-  transition: color 50ms ease-in;
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .Breadcrumbs-breadcrumbLabel:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Breadcrumbs-breadcrumbLabel:hover {
-    color: var(--puck-color-azure-03);
+    color: var(--puck-color-interactive-hover);
     transition: none;
   }
 }
 
 .Breadcrumbs-breadcrumbLabel:active {
-  color: var(--puck-color-azure-02);
+  color: var(--puck-color-interactive-active);
   transition: none;
 }
 
 .Breadcrumbs-breadcrumb {
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
 }

--- a/packages/core/components/Button/Button.module.css
+++ b/packages/core/components/Button/Button.module.css
@@ -1,21 +1,23 @@
 .Button {
   appearance: none;
   background: none;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  color: var(--puck-color-white);
+  border: var(--puck-border-width-regular) solid transparent;
+  border-radius: var(--puck-radius-m);
+  color: var(--puck-color-text-inverse);
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  letter-spacing: 0.05ch;
+  gap: var(--puck-space-2);
+  letter-spacing: var(--puck-letter-spacing-ui);
   font-family: var(--puck-font-family);
-  font-size: 14px;
-  font-weight: 400;
+  font-size: var(--puck-font-size-xxs);
+  font-weight: var(--puck-font-weight-regular);
   box-sizing: border-box;
   line-height: 1;
   text-align: center;
   text-decoration: none;
-  transition: background-color 50ms ease-in;
+  transition:
+    background-color var(--puck-duration-fast) var(--puck-ease-standard),
+    color var(--puck-duration-fast) var(--puck-ease-standard);
   cursor: pointer;
   white-space: nowrap;
   margin: 0;
@@ -46,49 +48,49 @@
 }
 
 .Button--primary {
-  background: var(--puck-color-azure-04);
+  background: var(--puck-color-interactive);
 }
 
 .Button:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Button--primary:hover {
-    background-color: var(--puck-color-azure-03);
+    background-color: var(--puck-color-interactive-hover);
   }
 }
 
 .Button--primary:active {
-  background-color: var(--puck-color-azure-02);
+  background-color: var(--puck-color-interactive-active);
 }
 
 .Button--secondary {
-  border: 1px solid currentColor;
+  border: var(--puck-border-width-regular) solid currentColor;
   color: currentColor;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Button--secondary:hover {
-    background-color: var(--puck-color-azure-12);
-    color: var(--puck-color-black);
+    background-color: var(--puck-color-interactive-subtle);
+    color: var(--puck-color-text);
   }
 }
 
 .Button--secondary:active {
-  background-color: var(--puck-color-azure-11);
-  color: var(--puck-color-black);
+  background-color: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-text);
 }
 
 .Button--flush {
-  border-radius: 0;
+  border-radius: var(--puck-radius-none);
 }
 
 .Button--disabled,
 .Button--disabled:hover {
-  background-color: var(--puck-color-grey-07);
-  color: var(--puck-color-grey-03);
+  background-color: var(--puck-color-disabled-bg);
+  color: var(--puck-color-disabled-text);
   cursor: not-allowed;
 }
 
@@ -98,5 +100,5 @@
 }
 
 .Button-spinner {
-  padding-inline-start: 8px;
+  padding-inline-start: var(--puck-space-2);
 }

--- a/packages/core/components/ComponentList/styles.module.css
+++ b/packages/core/components/ComponentList/styles.module.css
@@ -3,7 +3,7 @@
 }
 
 .ComponentList--isExpanded + .ComponentList {
-  margin-top: 12px;
+  margin-top: var(--puck-space-3);
 }
 
 .ComponentList-content {
@@ -17,36 +17,38 @@
 .ComponentList-title {
   background-color: transparent;
   border: 0;
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   cursor: pointer;
   display: flex;
   font: inherit;
   font-size: var(--puck-font-size-xxxs);
   list-style: none;
   margin-bottom: 6px;
-  padding: 8px;
+  padding: var(--puck-space-2);
   text-transform: uppercase;
-  transition: background-color 50ms ease-in, color 50ms ease-in;
-  gap: 4px;
-  border-radius: 4px;
+  transition:
+    background-color var(--puck-duration-fast) var(--puck-ease-standard),
+    color var(--puck-duration-fast) var(--puck-ease-standard);
+  gap: var(--puck-space-1);
+  border-radius: var(--puck-radius-m);
   width: 100%;
 }
 
 .ComponentList-title:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ComponentList-title:hover {
-    background-color: var(--puck-color-azure-11);
-    color: var(--puck-color-azure-04);
+    background-color: var(--puck-color-interactive-subtle);
+    color: var(--puck-color-interactive);
     transition: none;
   }
 }
 
 .ComponentList-title:active {
-  background-color: var(--puck-color-azure-10);
+  background-color: var(--puck-color-interactive-soft);
   transition: none;
 }
 

--- a/packages/core/components/DragIcon/styles.module.css
+++ b/packages/core/components/DragIcon/styles.module.css
@@ -1,8 +1,8 @@
 .DragIcon {
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   cursor: grab;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--puck-space-1);
+  border-radius: var(--puck-radius-m);
 }
 
 .DragIcon--disabled {
@@ -11,7 +11,7 @@
 
 @media (hover: hover) and (pointer: fine) {
   .DragIcon:not(.DragIcon--disabled):hover {
-    color: var(--puck-color-azure-05);
-    background-color: var(--puck-color-azure-12);
+    color: var(--puck-color-focus-ring);
+    background-color: var(--puck-color-interactive-subtle-hover);
   }
 }

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -2,11 +2,7 @@
   position: absolute;
   pointer-events: none;
 
-  --overlay-background: color-mix(
-    in srgb,
-    var(--puck-color-azure-08) 30%,
-    transparent
-  );
+  --overlay-background: var(--puck-color-selection-bg);
 }
 
 .DraggableComponent-overlayWrapper {
@@ -22,23 +18,23 @@
 .DraggableComponent-overlay {
   cursor: pointer;
   height: 100%;
-  outline: 2px var(--puck-color-azure-09) solid;
-  outline-offset: -2px;
+  outline: var(--puck-border-width-focus) var(--puck-color-selection-border) solid;
+  outline-offset: calc(var(--puck-border-width-focus) * -1);
   width: 100%;
 }
 
 .DraggableComponent:focus-visible > .DraggableComponent-overlayWrapper {
-  outline: 1px solid var(--puck-color-azure-05);
+  outline: var(--puck-border-width-regular) solid var(--puck-color-focus-ring);
 }
 
 .DraggableComponent-loadingOverlay {
-  background: var(--puck-color-white);
-  color: var(--puck-color-grey-03);
-  border-radius: 4px;
+  background: var(--puck-color-surface);
+  color: var(--puck-color-text);
+  border-radius: var(--puck-radius-m);
   display: flex;
-  padding: 8px;
-  top: 8px;
-  right: 8px;
+  padding: var(--puck-space-2);
+  top: var(--puck-space-2);
+  right: var(--puck-space-2);
   position: absolute;
   z-index: 1;
   pointer-events: all;
@@ -51,7 +47,7 @@
   > .DraggableComponent-overlayWrapper
   > .DraggableComponent-overlay {
   background: var(--overlay-background);
-  outline: 2px var(--puck-color-azure-09) solid;
+  outline: var(--puck-border-width-focus) var(--puck-color-selection-border) solid;
 }
 
 .DraggableComponent--isSelected

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -1,8 +1,9 @@
 .DraggableComponent {
+  --puck-draggable-selected-outline: var(--puck-color-azure-07);
+  --overlay-background: var(--puck-color-selection-bg);
+
   position: absolute;
   pointer-events: none;
-
-  --overlay-background: var(--puck-color-selection-bg);
 }
 
 .DraggableComponent-overlayWrapper {
@@ -53,7 +54,7 @@
 .DraggableComponent--isSelected
   > .DraggableComponent-overlayWrapper
   > .DraggableComponent-overlay {
-  outline-color: var(--puck-color-azure-07);
+  outline-color: var(--puck-draggable-selected-outline);
 }
 
 /* Won't work in FF */

--- a/packages/core/components/Drawer/styles.module.css
+++ b/packages/core/components/Drawer/styles.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   font-family: var(--puck-font-family);
-  gap: 12px;
+  gap: var(--puck-space-3);
 }
 
 .Drawer-draggable {
@@ -20,21 +20,24 @@
 }
 
 .DrawerItem-draggable {
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
+  color: var(--puck-color-text);
   cursor: grab;
-  padding: 12px;
+  padding: var(--puck-space-3);
   display: flex;
-  border: 1px var(--puck-color-grey-09) solid;
-  border-radius: 4px;
+  border: var(--puck-border-width-regular) var(--puck-color-border) solid;
+  border-radius: var(--puck-radius-m);
   font-size: var(--puck-font-size-xxs);
   justify-content: space-between;
   align-items: center;
-  transition: background-color 50ms ease-in, color 50ms ease-in;
+  transition: background-color var(--puck-duration-fast)
+      var(--puck-ease-standard),
+    color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .DrawerItem--disabled .DrawerItem-draggable {
-  background: var(--puck-color-grey-11);
-  color: var(--puck-color-grey-05);
+  background: var(--puck-color-surface-subtle);
+  color: var(--puck-color-text-muted);
   cursor: not-allowed; /** Move this out of inline styles */
 }
 
@@ -45,17 +48,17 @@
 .Drawer:not(.Drawer--isDraggingFrom)
   .DrawerItem:focus-visible
   .DrawerItem-draggable {
-  border-radius: 4px;
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  border-radius: var(--puck-radius-m);
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Drawer:not(.Drawer--isDraggingFrom)
     .DrawerItem:not(.DrawerItem--disabled)
     .DrawerItem-draggable:hover {
-    background-color: var(--puck-color-azure-12);
-    color: var(--puck-color-azure-04);
+    background-color: var(--puck-color-interactive-subtle-hover);
+    color: var(--puck-color-interactive);
     transition: none;
   }
 }

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -1,10 +1,8 @@
 .DropZone {
-  --resize-animation-ms: 150ms;
-
   position: relative;
   height: 100%;
   min-height: var(--min-empty-height);
-  outline-offset: -2px;
+  outline-offset: calc(var(--puck-border-width-focus) * -1);
   width: 100%;
 }
 
@@ -18,30 +16,26 @@
 
 /* We use global data-puck-dragging to avoid re-rendering DropZone */
 [data-puck-entry]:not([data-puck-dragging]) .DropZone {
-  transition: min-height var(--resize-animation-ms) ease-in;
+  transition: min-height var(--puck-duration-medium) var(--puck-ease-standard);
 }
 
 .DropZone--isAreaSelected,
 .DropZone--hoveringOverArea:not(.DropZone--isRootZone) {
-  background: color-mix(in srgb, var(--puck-color-azure-09) 30%, transparent);
-  outline: 2px dashed var(--puck-color-azure-08);
+  background: var(--puck-color-selection-bg);
+  outline: var(--puck-border-width-focus) dashed var(--puck-color-selection-border);
 }
 
 .DropZone:empty {
-  background: color-mix(in srgb, var(--puck-color-azure-09) 30%, transparent);
-  outline: 2px dashed var(--puck-color-azure-08);
+  background: var(--puck-color-selection-bg);
+  outline: var(--puck-border-width-focus) dashed var(--puck-color-selection-border);
 }
 
 .DropZone--isDestination {
-  outline: 2px dashed var(--puck-color-azure-04) !important;
+  outline: var(--puck-border-width-focus) dashed var(--puck-color-interactive) !important;
 }
 
 .DropZone--isDestination:not(.DropZone--isRootZone) {
-  background: color-mix(
-    in srgb,
-    var(--puck-color-azure-09) 30%,
-    transparent
-  ) !important;
+  background: var(--puck-color-selection-bg) !important;
 }
 
 .DropZone-item {
@@ -50,14 +44,14 @@
 
 .DropZone-hitbox {
   position: absolute;
-  bottom: -12px;
-  height: 24px;
+  bottom: calc(var(--puck-space-3) * -1);
+  height: var(--puck-space-5);
   width: 100%;
   z-index: 1;
 }
 
 [data-puck-dragging] .DropZone--isEnabled {
-  outline: 2px dashed var(--puck-color-azure-06);
+  outline: var(--puck-border-width-focus) dashed var(--puck-color-azure-06);
 }
 
 .DropZone > *:not([data-puck-component]) {

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -1,4 +1,6 @@
 .DropZone {
+  --puck-drop-zone-enabled-outline: var(--puck-color-azure-06);
+
   position: relative;
   height: 100%;
   min-height: var(--min-empty-height);
@@ -51,7 +53,7 @@
 }
 
 [data-puck-dragging] .DropZone--isEnabled {
-  outline: var(--puck-border-width-focus) dashed var(--puck-color-azure-06);
+  outline: var(--puck-border-width-focus) dashed var(--puck-drop-zone-enabled-outline);
 }
 
 .DropZone > *:not([data-puck-component]) {

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -4,54 +4,57 @@
 
 .ExternalInput-button {
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   align-items: center;
   justify-content: center;
-  background-color: var(--puck-color-white);
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 4px;
-  color: var(--puck-color-azure-04);
-  padding: 12px 16px;
-  font-weight: 500;
+  background-color: var(--puck-color-surface);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
+  color: var(--puck-color-interactive);
+  padding: var(--puck-space-3) var(--puck-space-4);
+  font-weight: var(--puck-font-weight-medium);
   white-space: nowrap;
   text-overflow: ellipsis;
-  transition: background-color 50ms ease-in;
+  transition: background-color var(--puck-duration-fast)
+    var(--puck-ease-standard);
   position: relative;
   overflow: hidden;
   flex-grow: 1;
 }
 
 .ExternalInput--dataSelected .ExternalInput-button {
-  color: var(--puck-color-grey-03);
+  color: var(--puck-color-disabled-text);
   display: block;
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }
 
 .ExternalInput--readOnly .ExternalInput-button {
-  background-color: var(--puck-color-grey-11);
+  background-color: var(--puck-color-surface-subtle);
 }
 
 .ExternalInput-detachButton {
-  border: 1px solid var(--puck-color-grey-09);
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  background-color: var(--puck-color-grey-12);
-  color: var(--puck-color-grey-05);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-top-right-radius: var(--puck-radius-m);
+  border-bottom-right-radius: var(--puck-radius-m);
+  background-color: var(--puck-color-surface-muted);
+  color: var(--puck-color-text-muted);
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   align-items: center;
   justify-content: center;
-  padding: 8px 12px;
+  padding: var(--puck-space-2) var(--puck-space-3);
   position: relative;
-  transition: background-color 50ms ease-in, color 50ms ease-in;
+  transition:
+    background-color var(--puck-duration-fast) var(--puck-ease-standard),
+    color var(--puck-duration-fast) var(--puck-ease-standard);
   margin-inline-start: -1px;
 }
 
 .ExternalInput-button:focus-visible,
 .ExternalInput-detachButton:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
   z-index: 1;
 }
 
@@ -59,25 +62,25 @@
   .ExternalInput:not(.ExternalInput--readOnly) .ExternalInput-button:hover,
   .ExternalInput:not(.ExternalInput--readOnly)
     .ExternalInput-detachButton:hover {
-    background: var(--puck-color-azure-12);
+    background: var(--puck-color-interactive-subtle-hover);
     transition: none;
   }
 
   .ExternalInput:not(.ExternalInput--readOnly)
     .ExternalInput-detachButton:hover {
-    color: var(--puck-color-azure-04);
+    color: var(--puck-color-interactive);
   }
 }
 
 .ExternalInput:not(.ExternalInput--readOnly) .ExternalInput-button:active,
 .ExternalInput:not(.ExternalInput--readOnly)
   .ExternalInput-detachButton:active {
-  background: var(--puck-color-azure-11);
+  background: var(--puck-color-interactive-subtle);
   transition: none;
 }
 
 .ExternalInputModal {
-  color: var(--puck-color-black);
+  color: var(--puck-color-text);
   display: grid;
   grid-template-rows: min-content minmax(128px, 100%) min-content;
   grid-template-columns: 100%;
@@ -103,7 +106,7 @@
 }
 
 .ExternalInputModal-filters {
-  border-bottom: 1px solid var(--puck-color-grey-09);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
 }
 
 .ExternalInputModal--filtersToggled .ExternalInputModal-filters {
@@ -112,7 +115,8 @@
 
 @media (min-width: 458px) {
   .ExternalInputModal-filters {
-    border-inline-end: 1px solid var(--puck-color-grey-09);
+    border-inline-end: var(--puck-border-width-regular) solid
+      var(--puck-color-border);
     display: none;
   }
 
@@ -122,12 +126,12 @@
 }
 
 .ExternalInputModal-masthead {
-  background-color: var(--puck-color-grey-12);
-  border-bottom: 1px solid var(--puck-color-grey-09);
+  background-color: var(--puck-color-surface-muted);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
   display: flex;
   flex-wrap: wrap;
-  gap: 24px;
-  padding: 24px;
+  gap: var(--puck-space-5);
+  padding: var(--puck-space-5);
 }
 
 .ExternalInputModal-tableWrapper {
@@ -147,35 +151,36 @@
 }
 
 .ExternalInputModal-thead {
-  background-color: var(--puck-color-white);
+  background-color: var(--puck-color-surface);
   position: sticky;
   top: 0;
   z-index: 1;
 }
 
 .ExternalInputModal-th {
-  border-bottom: 1px solid var(--puck-color-grey-09);
-  color: var(--puck-color-grey-04);
-  font-weight: 500;
-  font-size: 14px;
-  padding: 16px 24px;
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
+  color: var(--puck-color-text-strong);
+  font-weight: var(--puck-font-weight-medium);
+  font-size: var(--puck-font-size-xxs);
+  padding: var(--puck-space-4) var(--puck-space-5);
 }
 
 .ExternalInputModal-td {
-  border-bottom: 1px solid var(--puck-color-grey-10);
-  padding: 16px 24px;
+  border-bottom: var(--puck-border-width-regular) solid
+    var(--puck-color-border-muted);
+  padding: var(--puck-space-4) var(--puck-space-5);
 }
 
 .ExternalInputModal-tr .ExternalInputModal-td:first-of-type {
-  font-weight: 500;
+  font-weight: var(--puck-font-weight-medium);
   width: 1%; /* Prevent growing */
   white-space: nowrap; /* Prevent growing */
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ExternalInputModal-tbody .ExternalInputModal-tr:hover {
-    background: var(--puck-color-azure-12);
-    color: var(--puck-color-azure-04);
+    background: var(--puck-color-interactive-subtle-hover);
+    color: var(--puck-color-interactive);
     cursor: pointer;
     position: relative;
     margin-inline-start: -5px;
@@ -184,7 +189,8 @@
   .ExternalInputModal-tbody
     .ExternalInputModal-tr:hover
     .ExternalInputModal-td:first-of-type {
-    border-inline-start: 4px solid var(--puck-color-azure-04);
+    border-inline-start: var(--puck-border-width-strong) solid
+      var(--puck-color-interactive);
     padding-inline-start: 20px;
   }
 }
@@ -207,7 +213,7 @@
   display: none;
   background-color: color-mix(
     in srgb,
-    var(--puck-color-white) 90%,
+    var(--puck-color-surface) 90%,
     transparent
   );
   padding: 64px;
@@ -227,7 +233,7 @@
 .ExternalInputModal-searchForm {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--puck-space-3);
   flex-grow: 1;
 }
 
@@ -239,49 +245,50 @@
 
 .ExternalInputModal-search {
   display: flex;
-  background: var(--puck-color-white);
-  border-width: 1px;
+  background: var(--puck-color-surface);
+  border-width: var(--puck-border-width-regular);
   border-style: solid;
-  border-color: var(--puck-color-grey-09);
-  border-radius: 4px;
+  border-color: var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
   flex-grow: 1;
-  transition: border-color 50ms ease-in;
+  transition: border-color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .ExternalInputModal-search:focus-within {
-  border-color: var(--puck-color-grey-05);
-  outline: 2px solid var(--puck-color-azure-05);
+  border-color: var(--puck-color-text-muted);
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
   transition: none;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ExternalInputModal-search:hover {
-    border-color: var(--puck-color-grey-05);
+    border-color: var(--puck-color-text-muted);
     transition: none;
   }
 }
 
 .ExternalInputModal-searchIcon {
   align-items: center;
-  background: var(--puck-color-grey-12);
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-  border-inline-end: 1px solid var(--puck-color-grey-09);
-  color: var(--puck-color-grey-07);
+  background: var(--puck-color-surface-muted);
+  border-bottom-left-radius: var(--puck-radius-m);
+  border-top-left-radius: var(--puck-radius-m);
+  border-inline-end: var(--puck-border-width-regular) solid
+    var(--puck-color-border);
+  color: var(--puck-color-text-subtle);
   display: flex;
   justify-content: center;
-  padding: 12px 15px;
-  transition: color 50ms ease-in;
+  padding: var(--puck-space-3) 15px;
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .ExternalInputModal-search:focus-within .ExternalInputModal-searchIcon {
-  color: var(--puck-color-grey-04);
+  color: var(--puck-color-text-strong);
   transition: none;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .ExternalInputModal-search:hover .ExternalInputModal-searchIcon {
-    color: var(--puck-color-grey-04);
+    color: var(--puck-color-text-strong);
     transition: none;
   }
 }
@@ -298,11 +305,11 @@
 
 .ExternalInputModal-searchInput {
   border: none;
-  border-radius: 4px;
-  background: var(--puck-color-white);
+  border-radius: var(--puck-radius-m);
+  background: var(--puck-color-surface);
   font-family: inherit;
-  font-size: 14px;
-  padding: 12px 15px;
+  font-size: var(--puck-font-size-xxs);
+  padding: var(--puck-space-3) 15px;
   width: 100%;
 }
 
@@ -312,7 +319,7 @@
 
 .ExternalInputModal-searchActions {
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   height: 44px;
   width: 100%;
 }
@@ -328,21 +335,21 @@
 }
 
 .ExternalInputModal-footerContainer {
-  background-color: var(--puck-color-grey-12);
-  border-top: 1px solid var(--puck-color-grey-09);
-  color: var(--puck-color-grey-04);
-  padding: 16px;
+  background-color: var(--puck-color-surface-muted);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
+  color: var(--puck-color-text-strong);
+  padding: var(--puck-space-4);
 }
 
 .ExternalInputModal-footer {
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: var(--puck-font-weight-medium);
+  font-size: var(--puck-font-size-xxs);
   text-align: right;
 }
 
 .ExternalInputModal-field {
-  color: var(--puck-color-grey-04);
-  margin: 16px;
-  margin-bottom: 12px;
+  color: var(--puck-color-text-strong);
+  margin: var(--puck-space-4);
+  margin-bottom: var(--puck-space-3);
   display: block;
 }

--- a/packages/core/components/ExternalInput/styles.module.css
+++ b/packages/core/components/ExternalInput/styles.module.css
@@ -144,7 +144,7 @@
 .ExternalInputModal-table {
   border-collapse: unset;
   border-spacing: 0px;
-  color: var(--puck-color-grey-02);
+  color: var(--puck-color-text);
   position: relative;
   z-index: 0;
   min-width: 100%;

--- a/packages/core/components/Heading/styles.module.css
+++ b/packages/core/components/Heading/styles.module.css
@@ -1,18 +1,18 @@
 .Heading {
   display: block;
-  color: var(--puck-color-black);
-  font-weight: 700;
+  color: var(--puck-color-text);
+  font-weight: var(--puck-font-weight-bold);
   margin: 0;
 }
 
 .Heading b {
-  font-weight: 700;
+  font-weight: var(--puck-font-weight-bold);
 }
 
 .Heading--xxxxl {
   font-size: var(--puck-font-size-xxxxl);
-  letter-spacing: 0.08ch;
-  font-weight: 800;
+  letter-spacing: var(--puck-letter-spacing-heading);
+  font-weight: var(--puck-font-weight-heavy);
 }
 
 .Heading--xxxl {

--- a/packages/core/components/IconButton/IconButton.module.css
+++ b/packages/core/components/IconButton/IconButton.module.css
@@ -2,35 +2,37 @@
   align-items: center;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--puck-radius-m);
   color: currentColor;
   display: flex;
   font-family: var(--puck-font-family);
   justify-content: center;
-  padding: 4px;
-  transition: background-color 50ms ease-in, color 50ms ease-in;
+  padding: var(--puck-space-1);
+  transition:
+    background-color var(--puck-duration-fast) var(--puck-ease-standard),
+    color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .IconButton--active {
-  color: var(--puck-color-azure-04);
+  color: var(--puck-color-interactive);
 }
 
 .IconButton:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: -2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: calc(var(--puck-border-width-focus) * -1);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .IconButton:hover:not(.IconButton--disabled) {
-    background: var(--puck-color-grey-10);
-    color: var(--puck-color-azure-04);
+    background: var(--puck-color-border-muted);
+    color: var(--puck-color-interactive);
     cursor: pointer;
     transition: none;
   }
 }
 
 .IconButton:active {
-  background: var(--puck-color-azure-11);
+  background: var(--puck-color-interactive-subtle);
   transition: none;
 }
 
@@ -45,5 +47,5 @@
 }
 
 .IconButton--disabled {
-  color: var(--puck-color-grey-07);
+  color: var(--puck-color-text-subtle);
 }

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -1,5 +1,9 @@
 .LayerTree {
-  color: var(--puck-color-grey-03);
+  --puck-layer-tree-text: var(--puck-color-grey-03);
+  --puck-layer-tree-component-icon: var(--puck-color-rose-07);
+  --puck-layer-tree-zone-icon: var(--puck-color-grey-08);
+
+  color: var(--puck-layer-tree-text);
   font-family: var(--puck-font-family);
   font-size: var(--puck-font-size-xxs);
   margin: 0;
@@ -109,11 +113,11 @@
 }
 
 .Layer-icon {
-  color: var(--puck-color-rose-07);
+  color: var(--puck-layer-tree-component-icon);
   margin-top: var(--puck-space-1);
 }
 
 .Layer-zoneIcon {
-  color: var(--puck-color-grey-08);
+  color: var(--puck-layer-tree-zone-icon);
   margin-top: var(--puck-space-1);
 }

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -9,27 +9,27 @@
 }
 
 .LayerTree-zoneTitle {
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   font-size: var(--puck-font-size-xxxs);
   text-transform: uppercase;
 }
 
 .LayerTree-helper {
   text-align: center;
-  color: var(--puck-color-grey-07);
-  margin: 8px 4px;
+  color: var(--puck-color-text-subtle);
+  margin: var(--puck-space-2) var(--puck-space-1);
 }
 
 .Layer {
   position: relative;
-  border: 1px solid transparent;
-  border-radius: 4px;
+  border: var(--puck-border-width-regular) solid transparent;
+  border-radius: var(--puck-radius-m);
 }
 
 .Layer-inner {
-  border: 1px solid transparent;
-  border-radius: 4px;
-  transition: color 50ms ease-in;
+  border: var(--puck-border-width-regular) solid transparent;
+  border-radius: var(--puck-radius-m);
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .Layer--containsZone > .Layer-inner {
@@ -40,38 +40,38 @@
   align-items: center;
   background: none;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--puck-radius-m);
   color: inherit;
   cursor: pointer;
   display: flex;
   font: inherit;
-  padding-inline-start: 12px;
-  padding-inline-end: 4px;
+  padding-inline-start: var(--puck-space-3);
+  padding-inline-end: var(--puck-space-1);
   width: 100%;
 }
 
 .Layer-clickable:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
   position: relative;
   z-index: 1;
 }
 
 @media (hover: hover) and (pointer: fine) {
   .Layer:not(.Layer--isSelected) > .Layer-inner:hover {
-    border-color: var(--puck-color-azure-10);
-    background: var(--puck-color-azure-11);
-    color: var(--puck-color-azure-04);
+    border-color: var(--puck-color-interactive-soft);
+    background: var(--puck-color-interactive-subtle);
+    color: var(--puck-color-interactive);
     transition: none;
   }
 }
 
 .Layer--isSelected {
-  border-color: var(--puck-color-azure-08);
+  border-color: var(--puck-color-selection-border);
 }
 
 .Layer--isSelected > .Layer-inner {
-  background: var(--puck-color-azure-10);
+  background: var(--puck-color-interactive-soft);
 }
 
 .Layer--isSelected > .Layer-inner > .Layer-clickable > .Layer-chevron,
@@ -81,7 +81,7 @@
 
 .Layer-zones {
   display: none;
-  margin-inline-start: 12px;
+  margin-inline-start: var(--puck-space-3);
 }
 
 .Layer--isSelected > .Layer-zones,
@@ -90,15 +90,15 @@
 }
 
 .Layer-zones > .LayerTree {
-  margin-inline-start: 12px;
+  margin-inline-start: var(--puck-space-3);
 }
 
 .Layer-title,
 .LayerTree-zoneTitle {
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   align-items: center;
-  margin: 8px 4px;
+  margin: var(--puck-space-2) var(--puck-space-1);
   overflow-x: hidden;
 }
 
@@ -110,10 +110,10 @@
 
 .Layer-icon {
   color: var(--puck-color-rose-07);
-  margin-top: 4px;
+  margin-top: var(--puck-space-1);
 }
 
 .Layer-zoneIcon {
   color: var(--puck-color-grey-08);
-  margin-top: 4px;
+  margin-top: var(--puck-space-1);
 }

--- a/packages/core/components/Loader/styles.module.css
+++ b/packages/core/components/Loader/styles.module.css
@@ -12,8 +12,8 @@
 
 .Loader {
   background: transparent;
-  border-radius: 100%;
-  border: 2px solid currentColor;
+  border-radius: var(--puck-radius-round);
+  border: var(--puck-border-width-focus) solid currentColor;
   border-bottom-color: transparent;
   display: inline-block;
   animation: loader-animation 1s 0s infinite linear;

--- a/packages/core/components/MenuBar/styles.module.css
+++ b/packages/core/components/MenuBar/styles.module.css
@@ -1,10 +1,10 @@
 .MenuBar {
-  background-color: var(--puck-color-white);
-  border-bottom: 1px solid var(--puck-color-grey-09);
+  background-color: var(--puck-color-surface);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
   display: none;
   left: 0;
   margin-top: 1px;
-  padding: 8px 16px;
+  padding: var(--puck-space-2) var(--puck-space-4);
   position: absolute;
   right: 0;
   top: 100%;
@@ -30,7 +30,7 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 16px;
+  gap: var(--puck-space-2) var(--puck-space-4);
   justify-content: flex-end;
 }
 

--- a/packages/core/components/Modal/styles.module.css
+++ b/packages/core/components/Modal/styles.module.css
@@ -1,5 +1,5 @@
 .Modal {
-  background: color-mix(in srgb, var(--puck-color-black) 75%, transparent);
+  background: var(--puck-color-overlay-backdrop);
   display: none;
   justify-content: center;
   align-items: center;
@@ -19,9 +19,9 @@
 .Modal-inner {
   width: 100%;
   max-width: 1024px;
-  border-radius: 8px;
+  border-radius: var(--puck-radius-l);
   overflow: hidden;
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
   display: flex;
   flex-direction: column;
   max-height: 90dvh;

--- a/packages/core/components/OutlineList/styles.module.css
+++ b/packages/core/components/OutlineList/styles.module.css
@@ -1,4 +1,6 @@
 .OutlineList {
+  --puck-outline-list-connector: var(--puck-color-grey-08);
+
   color: var(--puck-color-text);
   font-family: var(--puck-font-family);
   margin: 0;
@@ -8,7 +10,7 @@
 }
 
 .OutlineList::before {
-  background: var(--puck-color-grey-08);
+  background: var(--puck-outline-list-connector);
   position: absolute;
   left: -1px;
   top: 0px;
@@ -28,7 +30,7 @@
 }
 
 .OutlineListItem::before {
-  background: var(--puck-color-grey-08);
+  background: var(--puck-outline-list-connector);
   position: absolute;
   left: -17px;
   top: 9px;

--- a/packages/core/components/OutlineList/styles.module.css
+++ b/packages/core/components/OutlineList/styles.module.css
@@ -1,8 +1,8 @@
 .OutlineList {
-  color: var(--puck-color-grey-03);
+  color: var(--puck-color-text);
   font-family: var(--puck-font-family);
   margin: 0;
-  padding-inline-start: 16px;
+  padding-inline-start: var(--puck-space-4);
   position: relative;
   list-style: none;
 }
@@ -24,7 +24,7 @@
 
 .OutlineListItem {
   position: relative;
-  margin-bottom: 4px;
+  margin-bottom: var(--puck-space-1);
 }
 
 .OutlineListItem::before {
@@ -44,26 +44,26 @@
 
 .OutlineListItem--clickable {
   cursor: pointer;
-  transition: color 50ms ease-in;
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .OutlineListItem--clickable:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .OutlineListItem--clickable:hover {
-    color: var(--puck-color-azure-04);
+    color: var(--puck-color-interactive);
     transition: none;
   }
 }
 
 .OutlineListItem--clickable:active {
-  color: var(--puck-color-azure-03);
+  color: var(--puck-color-interactive-hover);
   transition: none;
 }
 
 .OutlineListItem > .OutlineList {
-  margin: 8px 0;
+  margin: var(--puck-space-2) 0;
 }

--- a/packages/core/components/Puck/components/Canvas/styles.module.css
+++ b/packages/core/components/Puck/components/Canvas/styles.module.css
@@ -1,5 +1,5 @@
 .PuckCanvas {
-  background: var(--puck-color-grey-11);
+  background: var(--puck-color-surface-subtle);
   display: flex;
   grid-area: editor;
   flex-direction: column;
@@ -40,8 +40,8 @@
 }
 
 .PuckCanvas-root {
-  background: white;
-  outline: 1px solid var(--puck-color-grey-09);
+  background: var(--puck-color-surface);
+  outline: var(--puck-border-width-regular) solid var(--puck-color-border);
   box-sizing: content-box;
   min-width: 321px;
   position: absolute;
@@ -75,7 +75,7 @@
   display: flex;
   height: 100%;
   justify-content: center;
-  transition: opacity 250ms ease-out;
+  transition: opacity var(--puck-duration-slow) var(--puck-ease-exit);
   opacity: 0;
 }
 

--- a/packages/core/components/Puck/components/Canvas/styles.module.css
+++ b/packages/core/components/Puck/components/Canvas/styles.module.css
@@ -71,7 +71,7 @@
 
 .PuckCanvas-loader {
   align-items: center;
-  color: var(--puck-color-grey-06);
+  color: var(--puck-color-text-subtle);
   display: flex;
   height: 100%;
   justify-content: center;

--- a/packages/core/components/Puck/components/Fields/styles.module.css
+++ b/packages/core/components/Puck/components/Fields/styles.module.css
@@ -8,7 +8,7 @@
 }
 
 .PuckFields-loadingOverlay {
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
@@ -24,7 +24,7 @@
 
 .PuckFields-loadingOverlayInner {
   display: flex;
-  padding: 16px;
+  padding: var(--puck-space-4);
   position: sticky;
   top: 0;
 }
@@ -34,13 +34,13 @@
 }
 
 .PuckFields--wrapFields .PuckFields-field {
-  color: var(--puck-color-grey-04);
-  padding: 16px;
-  padding-bottom: 12px;
+  color: var(--puck-color-text-strong);
+  padding: var(--puck-space-4);
+  padding-bottom: var(--puck-space-3);
   display: block;
 }
 
 .PuckFields--wrapFields .PuckFields-field + .PuckFields-field {
-  border-top: 1px solid var(--puck-color-grey-09);
-  margin-top: 8px;
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
+  margin-top: var(--puck-space-2);
 }

--- a/packages/core/components/Puck/components/Header/styles.module.css
+++ b/packages/core/components/Puck/components/Header/styles.module.css
@@ -1,7 +1,7 @@
 .PuckHeader {
-  background: var(--puck-color-white);
-  border-bottom: 1px solid var(--puck-color-grey-09);
-  color: var(--puck-color-black);
+  background: var(--puck-color-surface);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
+  color: var(--puck-color-text);
   grid-area: header;
   position: relative;
   max-width: 100vw;
@@ -29,7 +29,7 @@
 
 @media (min-width: 638px) {
   .PuckHeader-inner {
-    border-left: 1px solid var(--puck-color-grey-09);
+    border-left: var(--puck-border-width-regular) solid var(--puck-color-border);
   }
 
   .PuckHeader--hidePlugins .PuckHeader-inner {
@@ -38,15 +38,15 @@
 }
 
 .PuckHeader-toggle {
-  color: var(--puck-color-grey-05);
+  color: var(--puck-color-text-muted);
   display: flex;
-  margin-inline-start: -4px;
+  margin-inline-start: calc(var(--puck-space-1) * -1);
   padding-top: 2px;
 }
 
 .PuckHeader--rightSideBarVisible .PuckHeader-rightSideBarToggle,
 .PuckHeader--leftSideBarVisible .PuckHeader-leftSideBarToggle {
-  color: var(--puck-color-black);
+  color: var(--puck-color-text);
 }
 
 .PuckHeader-rightSideBarToggle,
@@ -74,17 +74,17 @@
 
 .PuckHeader-tools {
   display: flex;
-  gap: 16px;
+  gap: var(--puck-space-4);
   justify-content: flex-end;
 }
 
 .PuckHeader-menuButton {
-  color: var(--puck-color-grey-05);
-  margin-inline-start: -4px;
+  color: var(--puck-color-text-muted);
+  margin-inline-start: calc(var(--puck-space-1) * -1);
 }
 
 .PuckHeader--menuOpen .PuckHeader-menuButton {
-  color: var(--puck-color-black);
+  color: var(--puck-color-text);
 }
 
 @media (min-width: 638px) {

--- a/packages/core/components/Puck/components/Layout/styles.module.css
+++ b/packages/core/components/Puck/components/Layout/styles.module.css
@@ -17,7 +17,7 @@
  */
 
 .Puck {
-  --puck-space-px: 16px;
+  --puck-space-px: var(--puck-space-4);
   font-family: var(--puck-font-family);
   overflow-x: hidden;
 }
@@ -49,14 +49,15 @@
     --puck-user-right-side-bar-width,
     var(--puck-side-bar-width)
   );
-  background-color: var(--puck-color-grey-12);
+  background-color: var(--puck-color-surface-muted);
   display: grid;
   grid-template-areas: "header" "editor" "left" "right" "sidenav";
   grid-template-columns: var(--puck-frame-width);
   grid-template-rows: min-content auto 0 0 var(--puck-side-nav-width);
   height: 100%;
   position: relative;
-  transition: grid-template-rows 150ms ease-in;
+  transition: grid-template-rows var(--puck-duration-medium)
+    var(--puck-ease-standard);
   z-index: 0;
   overflow: hidden;
 }
@@ -190,8 +191,8 @@
 }
 
 .PuckLayout-nav {
-  border-top: 1px solid var(--puck-color-grey-09);
-  background-color: var(--puck-color-grey-12);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
+  background-color: var(--puck-color-surface-muted);
   grid-area: sidenav;
   overflow: hidden;
   width: 100%;
@@ -200,7 +201,7 @@
 @media (min-width: 638px) {
   .PuckLayout-nav {
     border-top: 0;
-    border-right: 1px solid var(--puck-color-grey-09);
+    border-right: var(--puck-border-width-regular) solid var(--puck-color-border);
     box-sizing: border-box;
   }
 }

--- a/packages/core/components/Puck/components/Nav/styles.module.css
+++ b/packages/core/components/Puck/components/Nav/styles.module.css
@@ -8,14 +8,14 @@
   margin: 0;
   padding: 0;
   overflow-x: auto;
-  gap: 8px;
+  gap: var(--puck-space-2);
 }
 
 @media (min-width: 638px) {
   .Nav-list {
     padding-top: 32px;
     flex-direction: column;
-    gap: 16px;
+    gap: var(--puck-space-4);
     width: 100%;
   }
 }
@@ -25,8 +25,9 @@
   display: flex;
   justify-content: center;
   margin-inline-start: auto;
-  padding: 4px 16px;
-  border-inline-start: 1px solid var(--puck-color-grey-09);
+  padding: var(--puck-space-1) var(--puck-space-4);
+  border-inline-start: var(--puck-border-width-regular) solid
+    var(--puck-color-border);
 }
 
 @media (min-width: 638px) {
@@ -40,11 +41,11 @@
   align-items: center;
   color: var(--puck-color-grey-03);
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   text-decoration: none;
   cursor: pointer;
-  border-radius: 4px;
-  padding: 8px 4px;
+  border-radius: var(--puck-radius-m);
+  padding: var(--puck-space-2) var(--puck-space-1);
   width: 64px;
   box-sizing: border-box;
 }
@@ -56,11 +57,11 @@
 }
 
 .NavItem:first-of-type {
-  padding-left: 16px;
+  padding-left: var(--puck-space-4);
 }
 
 .NavItem:last-of-type {
-  padding-right: 16px;
+  padding-right: var(--puck-space-4);
 }
 
 @media (min-width: 638px) {
@@ -71,9 +72,9 @@
 }
 
 .NavItem-link {
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-radius: 0;
+  border-top: var(--puck-border-width-strong) solid transparent;
+  border-bottom: var(--puck-border-width-strong) solid transparent;
+  border-radius: var(--puck-radius-none);
   flex-direction: column;
   font-size: var(--puck-font-size-xxxs);
 }
@@ -81,40 +82,40 @@
 @media (min-width: 638px) {
   .NavItem-link {
     border: 0;
-    border-left: 4px solid transparent;
-    border-right: 4px solid transparent;
+    border-left: var(--puck-border-width-strong) solid transparent;
+    border-right: var(--puck-border-width-strong) solid transparent;
   }
 }
 
 .NavItem-linkIcon {
-  height: 24px;
-  width: 24px;
+  height: var(--puck-icon-size-l);
+  width: var(--puck-icon-size-l);
 }
 
 .NavItem--active > .NavItem-link {
-  background-color: var(--puck-color-azure-10);
-  color: var(--puck-color-azure-04);
-  font-weight: 600;
+  background-color: var(--puck-color-interactive-soft);
+  color: var(--puck-color-interactive);
+  font-weight: var(--puck-font-weight-semibold);
 }
 
 .NavItem--active > .NavItem-link {
   background-color: transparent;
-  border-top-color: var(--puck-color-azure-04);
+  border-top-color: var(--puck-color-interactive);
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-  font-weight: 600;
+  font-weight: var(--puck-font-weight-semibold);
 }
 
 @media (min-width: 638px) {
   .NavItem--active > .NavItem-link {
     border-top-color: transparent;
-    border-right-color: var(--puck-color-azure-04);
+    border-right-color: var(--puck-color-interactive);
   }
 }
 
 .NavItem:not(.NavItem--active) > .NavItem-link:hover {
-  background-color: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
+  background-color: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
 }
 
 @media (min-width: 638px) {

--- a/packages/core/components/Puck/components/Nav/styles.module.css
+++ b/packages/core/components/Puck/components/Nav/styles.module.css
@@ -39,7 +39,7 @@
 .NavItem-link {
   text-align: center;
   align-items: center;
-  color: var(--puck-color-grey-03);
+  color: var(--puck-color-text-strong);
   display: flex;
   gap: var(--puck-space-2);
   text-decoration: none;

--- a/packages/core/components/Puck/components/Sidebar/styles.module.css
+++ b/packages/core/components/Puck/components/Sidebar/styles.module.css
@@ -1,5 +1,6 @@
 .Sidebar {
-  border-block-start: 1px solid var(--puck-color-grey-09);
+  border-block-start: var(--puck-border-width-regular) solid
+    var(--puck-color-border);
   position: relative;
   display: none;
   flex-direction: column;
@@ -11,26 +12,28 @@
 }
 
 .Sidebar--left {
-  background: var(--puck-color-grey-12);
+  background: var(--puck-color-surface-muted);
   grid-area: left;
 }
 
 @media (min-width: 766px) {
   .Sidebar--left {
     border-block-start: 0;
-    border-inline-end: 1px solid var(--puck-color-grey-09);
+    border-inline-end: var(--puck-border-width-regular) solid
+      var(--puck-color-border);
   }
 }
 
 .Sidebar--right {
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
   grid-area: right;
 }
 
 @media (min-width: 766px) {
   .Sidebar--right {
     border-block-start: 0;
-    border-inline-start: 1px solid var(--puck-color-grey-09);
+    border-inline-start: var(--puck-border-width-regular) solid
+      var(--puck-color-border);
   }
 }
 

--- a/packages/core/components/RichTextEditor/styles.module.css
+++ b/packages/core/components/RichTextEditor/styles.module.css
@@ -17,13 +17,13 @@
 .RichTextEditor :global(.rich-text blockquote) {
   margin: 1em 0;
   padding: 0 1em;
-  border-left: 4px solid var(--puck-color-grey-09);
+  border-left: var(--puck-border-width-strong) solid var(--puck-color-border);
 }
 
 .RichTextEditor :global(.rich-text code) {
-  background-color: var(--puck-color-grey-11);
-  padding: 4px 8px;
-  border-radius: 4px;
+  background-color: var(--puck-color-surface-subtle);
+  padding: var(--puck-space-1) var(--puck-space-2);
+  border-radius: var(--puck-radius-m);
 }
 
 .RichTextEditor :global(.rich-text p:empty::before) {
@@ -32,7 +32,7 @@
 
 .RichTextEditor :global(.rich-text pre code) {
   display: block;
-  padding: 8px 12px;
+  padding: var(--puck-space-2) var(--puck-space-3);
 }
 
 .RichTextEditor :global(.rich-text > *:first-child),
@@ -48,11 +48,11 @@
 }
 
 .RichTextEditor--editor {
-  background: var(--puck-color-white);
-  border-width: 1px;
+  background: var(--puck-color-surface);
+  border-width: var(--puck-border-width-regular);
   border-style: solid;
-  border-color: var(--puck-color-grey-09);
-  border-radius: 4px;
+  border-color: var(--puck-color-border);
+  border-radius: var(--puck-radius-m);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -60,7 +60,7 @@
   font-size: var(--puck-font-size-xxs);
   resize: vertical;
   text-align: initial;
-  transition: border-color 50ms ease-in;
+  transition: border-color var(--puck-duration-fast) var(--puck-ease-standard);
   width: 100%;
   max-width: 100%;
   min-height: 128px;
@@ -74,12 +74,12 @@
 .RichTextEditor--editor :global(.rich-text:not(:has(.ProseMirror))),
 .RichTextEditor--editor :global(.rich-text .ProseMirror) {
   height: 100%;
-  padding: 12px 15px;
+  padding: var(--puck-space-3) 15px;
 }
 
 .RichTextEditor--editor :global(.rich-text ul),
 .RichTextEditor--editor :global(.rich-text ol) {
-  padding-left: 24px;
+  padding-left: var(--puck-space-5);
 }
 
 .RichTextEditor--editor :global(.rich-text li) {
@@ -87,7 +87,7 @@
 }
 
 .RichTextEditor--editor :global(.rich-text p) {
-  margin-block: 12px;
+  margin-block: var(--puck-space-3);
 }
 
 .RichTextEditor--editor :global(.rich-text ul) {
@@ -99,13 +99,13 @@
 }
 
 .RichTextEditor--editor:focus-within {
-  border-color: var(--puck-color-grey-05);
-  outline: 2px solid var(--puck-color-azure-05);
+  border-color: var(--puck-color-text-muted);
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
   transition: none;
 }
 
 .RichTextEditor--editor.RichTextEditor--disabled {
-  background: var(--puck-color-grey-11);
+  background: var(--puck-color-surface-subtle);
 }
 
 .RichTextEditor:not(:focus-within):not(.RichTextEditor--isActive)
@@ -115,12 +115,13 @@
 }
 
 .RichTextEditor-menu {
-  border-bottom: 1px solid var(--puck-color-grey-10);
+  border-bottom: var(--puck-border-width-regular) solid
+    var(--puck-color-border-muted);
   position: sticky;
   top: 0;
   z-index: 1;
 }
 
 .RichTextEditor--disabled .RichTextEditor-menu {
-  border-bottom: 1px solid var(--puck-color-grey-09);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
 }

--- a/packages/core/components/RichTextMenu/components/Control/styles.module.css
+++ b/packages/core/components/RichTextMenu/components/Control/styles.module.css
@@ -1,9 +1,9 @@
 .Control :global(.lucide) {
-  height: 18px;
-  width: 18px;
+  height: var(--puck-icon-size-m);
+  width: var(--puck-icon-size-m);
 }
 
 .Control--inline :global(.lucide) {
-  height: 16px;
-  width: 16px;
+  height: var(--puck-icon-size-s);
+  width: var(--puck-icon-size-s);
 }

--- a/packages/core/components/RichTextMenu/styles.module.css
+++ b/packages/core/components/RichTextMenu/styles.module.css
@@ -1,4 +1,7 @@
 .RichTextMenu {
+  --puck-rich-text-menu-icon: var(--puck-color-grey-08);
+  --puck-rich-text-menu-inline-separator: var(--puck-color-grey-05);
+
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
@@ -33,7 +36,7 @@
 }
 
 .RichTextMenu--inline .RichTextMenu-group {
-  color: var(--puck-color-grey-08);
+  color: var(--puck-rich-text-menu-icon);
   gap: 0px;
   flex-wrap: nowrap;
 }
@@ -43,5 +46,5 @@
 }
 
 .RichTextMenu--inline .RichTextMenu-group + .RichTextMenu-group {
-  border-left: var(--puck-border-width-hairline) solid var(--puck-color-grey-05); /* Match actionbar separator */
+  border-left: var(--puck-border-width-hairline) solid var(--puck-rich-text-menu-inline-separator); /* Match actionbar separator */
 }

--- a/packages/core/components/RichTextMenu/styles.module.css
+++ b/packages/core/components/RichTextMenu/styles.module.css
@@ -5,10 +5,10 @@
 }
 
 .RichTextMenu--form {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-top-left-radius: var(--puck-radius-m);
+  border-top-right-radius: var(--puck-radius-m);
   padding: 6px 6px;
-  background-color: var(--puck-color-grey-12);
+  background-color: var(--puck-color-surface-muted);
   position: relative;
   scrollbar-width: none;
   overflow-x: auto;
@@ -39,9 +39,9 @@
 }
 
 .RichTextMenu-group + .RichTextMenu-group {
-  border-left: 1px solid var(--puck-color-grey-10);
+  border-left: var(--puck-border-width-regular) solid var(--puck-color-border-muted);
 }
 
 .RichTextMenu--inline .RichTextMenu-group + .RichTextMenu-group {
-  border-left: 0.5px solid var(--puck-color-grey-05); /* Match actionbar separator */
+  border-left: var(--puck-border-width-hairline) solid var(--puck-color-grey-05); /* Match actionbar separator */
 }

--- a/packages/core/components/Select/styles.module.css
+++ b/packages/core/components/Select/styles.module.css
@@ -1,4 +1,6 @@
 .Select {
+  --puck-select-action-bar-active: var(--puck-color-azure-07);
+
   position: relative;
   z-index: 1;
 }
@@ -54,7 +56,7 @@
   &.Select--hasOptions .Select-button:hover,
   &.Select--hasValue .Select-button {
     background: none;
-    color: var(--puck-color-azure-07);
+    color: var(--puck-select-action-bar-active);
   }
 }
 

--- a/packages/core/components/Select/styles.module.css
+++ b/packages/core/components/Select/styles.module.css
@@ -7,12 +7,12 @@
   align-items: center;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--puck-radius-m);
   display: flex;
   justify-content: center;
   gap: 0px;
   height: 100%;
-  padding: 4px;
+  padding: var(--puck-space-1);
   padding-right: 2px;
 }
 
@@ -31,23 +31,23 @@
 }
 
 .Select--standalone .Select-buttonIcon :global(.lucide) {
-  height: 18px;
-  width: 18px;
+  height: var(--puck-icon-size-m);
+  width: var(--puck-icon-size-m);
 }
 
 .Select--actionBar .Select-buttonIcon :global(.lucide) {
-  height: 16px;
-  width: 16px;
+  height: var(--puck-icon-size-s);
+  width: var(--puck-icon-size-s);
 }
 
 .Select--hasOptions:not(.Select--disabled) .Select-button:hover,
 .Select--hasValue .Select-button {
-  background: var(--puck-color-grey-10);
-  color: var(--puck-color-azure-04);
+  background: var(--puck-color-border-muted);
+  color: var(--puck-color-interactive);
 }
 
 .Select--disabled .Select-button {
-  color: var(--puck-color-grey-07);
+  color: var(--puck-color-text-subtle);
 }
 
 .Select--actionBar {
@@ -59,42 +59,42 @@
 }
 
 .Select-items {
-  background: white;
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 8px;
+  background: var(--puck-color-surface);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-l);
   margin: 10px 8px;
   margin-left: 0;
-  padding: 4px;
+  padding: var(--puck-space-1);
   z-index: 2;
   list-style: none;
 }
 
 .SelectItem {
   background: transparent;
-  border-radius: 4px;
+  border-radius: var(--puck-radius-m);
   border: none;
-  color: var(--puck-color-grey-04);
+  color: var(--puck-color-text-strong);
   cursor: pointer;
   display: flex;
-  gap: 8px;
+  gap: var(--puck-space-2);
   align-items: center;
   font-size: var(--puck-font-size-xxs);
   margin: 0;
-  padding: 8px 12px;
+  padding: var(--puck-space-2) var(--puck-space-3);
   width: 100%;
 }
 
 .SelectItem--isSelected {
-  background: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
-  font-weight: 500;
+  background: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
+  font-weight: var(--puck-font-weight-medium);
 }
 
 .SelectItem--isSelected .SelectItem-icon {
-  color: var(--puck-color-azure-04);
+  color: var(--puck-color-interactive);
 }
 
 .SelectItem:hover {
-  background: var(--puck-color-azure-11);
-  color: var(--puck-color-azure-04);
+  background: var(--puck-color-interactive-subtle);
+  color: var(--puck-color-interactive);
 }

--- a/packages/core/components/SidebarSection/styles.module.css
+++ b/packages/core/components/SidebarSection/styles.module.css
@@ -2,7 +2,7 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  color: var(--puck-color-black);
+  color: var(--puck-color-text);
 }
 
 .SidebarSection:last-of-type {
@@ -10,10 +10,10 @@
 }
 
 .SidebarSection-title {
-  background: var(--puck-color-white);
-  padding: 16px;
-  border-bottom: 1px solid var(--puck-color-grey-09);
-  border-top: 1px solid var(--puck-color-grey-09);
+  background: var(--puck-color-surface);
+  padding: var(--puck-space-4);
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-top: var(--puck-border-width-regular) solid var(--puck-color-border);
   overflow-x: auto;
 }
 
@@ -22,7 +22,7 @@
 }
 
 .SidebarSection-content:last-child {
-  padding-bottom: 4px;
+  padding-bottom: var(--puck-space-1);
 }
 
 .SidebarSection:last-of-type .SidebarSection-content {
@@ -33,50 +33,50 @@
 .SidebarSection-breadcrumbLabel {
   background: none;
   border: 0;
-  border-radius: 2px;
-  color: var(--puck-color-azure-04);
+  border-radius: var(--puck-radius-xs);
+  color: var(--puck-color-interactive);
   cursor: pointer;
   font: inherit;
   flex-shrink: 0;
   padding: 0;
-  transition: color 50ms ease-in;
+  transition: color var(--puck-duration-fast) var(--puck-ease-standard);
 }
 
 .SidebarSection-breadcrumbLabel:focus-visible {
-  outline: 2px solid var(--puck-color-azure-05);
-  outline-offset: 2px;
+  outline: var(--puck-border-width-focus) solid var(--puck-color-focus-ring);
+  outline-offset: var(--puck-border-width-focus);
 }
 
 @media (hover: hover) and (pointer: fine) {
   .SidebarSection-breadcrumbLabel:hover {
-    color: var(--puck-color-azure-03);
+    color: var(--puck-color-interactive-hover);
     transition: none;
   }
 }
 
 .SidebarSection-breadcrumbLabel:active {
-  color: var(--puck-color-azure-02);
+  color: var(--puck-color-interactive-active);
   transition: none;
 }
 
 .SidebarSection-breadcrumbs {
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
 }
 
 .SidebarSection-breadcrumb {
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: var(--puck-space-1);
 }
 
 .SidebarSection-heading {
-  padding-inline-end: 16px;
+  padding-inline-end: var(--puck-space-4);
 }
 
 .SidebarSection-loadingOverlay {
-  background: var(--puck-color-white);
+  background: var(--puck-color-surface);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/packages/core/components/ViewportControls/styles.module.css
+++ b/packages/core/components/ViewportControls/styles.module.css
@@ -1,4 +1,10 @@
 .ViewportControls {
+  --puck-viewport-toggle-bg: var(--puck-color-grey-02);
+  --puck-viewport-toggle-border: var(--puck-color-grey-04);
+  --puck-viewport-toggle-text: var(--puck-color-grey-11);
+  --puck-viewport-toggle-hover-text: var(--puck-color-azure-07);
+  --puck-viewport-toggle-expanded-bg: var(--puck-color-grey-03);
+
   position: relative;
 }
 
@@ -17,11 +23,11 @@
 
 .ViewportControls--fullScreen .ViewportControls-toggleButton {
   align-items: center;
-  background-color: var(--puck-color-grey-02);
-  border: var(--puck-border-width-regular) solid var(--puck-color-grey-04);
+  background-color: var(--puck-viewport-toggle-bg);
+  border: var(--puck-border-width-regular) solid var(--puck-viewport-toggle-border);
   border-radius: var(--puck-radius-pill);
   cursor: pointer;
-  color: var(--puck-color-grey-11);
+  color: var(--puck-viewport-toggle-text);
   display: flex;
   justify-content: center;
   width: 42px;
@@ -30,13 +36,13 @@
 }
 
 .ViewportControls--fullScreen .ViewportControls-toggleButton:hover {
-  background-color: var(--puck-color-grey-02);
+  background-color: var(--puck-viewport-toggle-bg);
   border: var(--puck-border-width-regular) solid var(--puck-color-interactive);
-  color: var(--puck-color-azure-07);
+  color: var(--puck-viewport-toggle-hover-text);
 }
 
 .ViewportControls--isExpanded .ViewportControls-toggleButton {
-  background-color: var(--puck-color-grey-03);
+  background-color: var(--puck-viewport-toggle-expanded-bg);
 }
 
 .ViewportControls-actions {

--- a/packages/core/components/ViewportControls/styles.module.css
+++ b/packages/core/components/ViewportControls/styles.module.css
@@ -6,8 +6,8 @@
   border-radius: 32px;
   display: flex;
   position: absolute;
-  bottom: 12px;
-  right: 12px;
+  bottom: var(--puck-space-3);
+  right: var(--puck-space-3);
   overflow: hidden;
 }
 
@@ -18,8 +18,8 @@
 .ViewportControls--fullScreen .ViewportControls-toggleButton {
   align-items: center;
   background-color: var(--puck-color-grey-02);
-  border: 1px solid var(--puck-color-grey-04);
-  border-radius: 30px;
+  border: var(--puck-border-width-regular) solid var(--puck-color-grey-04);
+  border-radius: var(--puck-radius-pill);
   cursor: pointer;
   color: var(--puck-color-grey-11);
   display: flex;
@@ -31,7 +31,7 @@
 
 .ViewportControls--fullScreen .ViewportControls-toggleButton:hover {
   background-color: var(--puck-color-grey-02);
-  border: 1px solid var(--puck-color-azure-04);
+  border: var(--puck-border-width-regular) solid var(--puck-color-interactive);
   color: var(--puck-color-azure-07);
 }
 
@@ -54,9 +54,9 @@
 }
 
 .ViewportControls--fullScreen .ViewportControls-actionsInner {
-  background: var(--puck-color-grey-11);
-  border: 1px solid var(--puck-color-grey-09);
-  border-radius: 30px;
+  background: var(--puck-color-surface-subtle);
+  border: var(--puck-border-width-regular) solid var(--puck-color-border);
+  border-radius: var(--puck-radius-pill);
   margin-left: none;
   margin-right: none;
   padding-right: 42px;
@@ -64,7 +64,7 @@
 
 .ViewportControls--fullScreen .ViewportControls-actionsInner {
   transform: translateX(100%);
-  transition: transform 150ms ease-in-out;
+  transition: transform var(--puck-duration-medium) var(--puck-ease-emphasized);
 }
 
 .ViewportControls--fullScreen.ViewportControls--isExpanded
@@ -73,9 +73,10 @@
 }
 
 .ViewportControls-divider {
-  border-inline-end: 1px solid var(--puck-color-grey-09);
-  margin-bottom: 8px;
-  margin-top: 8px;
+  border-inline-end: var(--puck-border-width-regular) solid
+    var(--puck-color-border);
+  margin-bottom: var(--puck-space-2);
+  margin-top: var(--puck-space-2);
 }
 
 .ViewportControls-zoomSelect {
@@ -88,7 +89,7 @@
   border: 0;
   font-size: var(--puck-font-size-xxxs);
   padding: 0;
-  padding-left: 8px;
+  padding-left: var(--puck-space-2);
   width: 96px;
 }
 
@@ -117,5 +118,5 @@
 }
 
 .ViewportButton--isActive .ViewportButton-inner {
-  color: var(--puck-color-azure-04);
+  color: var(--puck-color-interactive);
 }

--- a/packages/core/plugins/blocks/styles.module.css
+++ b/packages/core/plugins/blocks/styles.module.css
@@ -1,5 +1,5 @@
 .BlocksPlugin {
-  padding: 16px;
+  padding: var(--puck-space-4);
   height: 100%;
   overflow-y: auto;
   box-sizing: border-box;

--- a/packages/core/plugins/fields/styles.module.css
+++ b/packages/core/plugins/fields/styles.module.css
@@ -1,20 +1,20 @@
 .FieldsPlugin {
-  background: white;
+  background: var(--puck-color-surface);
   height: 100%;
   overflow-y: auto;
 }
 
 .FieldsPlugin-header {
-  border-bottom: 1px solid var(--puck-color-grey-09);
-  font-weight: 600;
-  padding-bottom: 8px;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 8px;
+  border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
+  font-weight: var(--puck-font-weight-semibold);
+  padding-bottom: var(--puck-space-2);
+  padding-left: var(--puck-space-4);
+  padding-right: var(--puck-space-4);
+  padding-top: var(--puck-space-2);
 }
 
 @media (min-width: 638px) {
   .FieldsPlugin-header {
-    padding: 16px;
+    padding: var(--puck-space-4);
   }
 }

--- a/packages/core/plugins/outline/styles.module.css
+++ b/packages/core/plugins/outline/styles.module.css
@@ -1,5 +1,5 @@
 .OutlinePlugin {
-  padding: 16px;
+  padding: var(--puck-space-4);
   height: 100%;
   overflow-y: auto;
   box-sizing: border-box;

--- a/packages/core/styles/tokens.css
+++ b/packages/core/styles/tokens.css
@@ -1,0 +1,109 @@
+:root {
+  /*
+   * Semantic colors
+   */
+
+  --puck-color-surface: var(--puck-color-white);
+  --puck-color-surface-muted: var(--puck-color-grey-12);
+  --puck-color-surface-subtle: var(--puck-color-grey-11);
+  --puck-color-border: var(--puck-color-grey-09);
+  --puck-color-border-muted: var(--puck-color-grey-10);
+  --puck-color-text: var(--puck-color-black);
+  --puck-color-text-strong: var(--puck-color-grey-04);
+  --puck-color-text-muted: var(--puck-color-grey-05);
+  --puck-color-text-subtle: var(--puck-color-grey-07);
+  --puck-color-text-inverse: var(--puck-color-white);
+  --puck-color-interactive: var(--puck-color-azure-04);
+  --puck-color-interactive-hover: var(--puck-color-azure-03);
+  --puck-color-interactive-active: var(--puck-color-azure-02);
+  --puck-color-interactive-soft: var(--puck-color-azure-10);
+  --puck-color-interactive-subtle: var(--puck-color-azure-11);
+  --puck-color-interactive-subtle-hover: var(--puck-color-azure-12);
+  --puck-color-focus-ring: var(--puck-color-azure-05);
+  --puck-color-selection-bg: color-mix(
+    in srgb,
+    var(--puck-color-azure-09) 30%,
+    transparent
+  );
+  --puck-color-selection-border: var(--puck-color-azure-08);
+  --puck-color-disabled-bg: var(--puck-color-grey-07);
+  --puck-color-disabled-text: var(--puck-color-grey-03);
+  --puck-color-overlay-backdrop: color-mix(
+    in srgb,
+    var(--puck-color-black) 75%,
+    transparent
+  );
+  --puck-color-danger: var(--puck-color-red-04);
+
+  /*
+   * Spacing
+   */
+
+  --puck-space-1: 4px;
+  --puck-space-2: 8px;
+  --puck-space-3: 12px;
+  --puck-space-4: 16px;
+  --puck-space-5: 24px;
+  --puck-space-px: var(--puck-space-4);
+
+  /*
+   * Radius
+   */
+
+  --puck-radius-none: 0;
+  --puck-radius-xs: 2px;
+  --puck-radius-s: 3px;
+  --puck-radius-m: 4px;
+  --puck-radius-l: 8px;
+  --puck-radius-pill: 30px;
+  --puck-radius-round: 100%;
+
+  /*
+   * Border widths
+   */
+
+  --puck-border-width-hairline: 0.5px;
+  --puck-border-width-regular: 1px;
+  --puck-border-width-focus: 2px;
+  --puck-border-width-strong: 4px;
+
+  /*
+   * Motion
+   */
+
+  --puck-duration-fast: 50ms;
+  --puck-duration-medium: 150ms;
+  --puck-duration-slow: 250ms;
+  --puck-ease-standard: ease-in;
+  --puck-ease-emphasized: ease-in-out;
+  --puck-ease-exit: ease-out;
+
+  /*
+   * Typography
+   */
+
+  --puck-font-weight-regular: 400;
+  --puck-font-weight-medium: 500;
+  --puck-font-weight-semibold: 600;
+  --puck-font-weight-bold: 700;
+  --puck-font-weight-heavy: 800;
+  --puck-letter-spacing-ui: 0.05ch;
+  --puck-letter-spacing-heading: 0.08ch;
+
+  /*
+   * Icon sizing
+   */
+
+  --puck-icon-size-s: 16px;
+  --puck-icon-size-m: 18px;
+  --puck-icon-size-l: 24px;
+
+  /*
+   * Functional variables
+   */
+
+  --space-m-unitless: 24;
+  --puck-user-left-side-bar-width: var(--puck-side-bar-width);
+  --puck-user-right-side-bar-width: var(--puck-side-bar-width);
+  --min-empty-height: 128px;
+}


### PR DESCRIPTION
Closes #139

## Description

This PR adds a CSS theming API.

## TODO

- [x] Initial theming pass
- [x] Component themes
- [ ] Tokens are prefixed based on intent (i.e.`-color-`)
- [x] Audit items addressed
- [x] Add documentation

## Acceptance criteria

1. The developer can update the core theme and impact the entire UI
2. The developer can update the theme of a particular component
3. The developer can update the theme of interactive components for different states
4. When updating the theme, the developer can update color, spacing, typography, and border radius

## Claude audit of current progress

Here's the full audit of inconsistencies in the token system:

### 1. Semantic naming contradictions

#### `--puck-color-text-strong` is weaker than `--puck-color-text`

The text scale orders like: `text` (black) > `text-strong` (grey-04) > `text-muted` (grey-05) > `text-subtle` (grey-07). "Strong" implies MORE emphasis than the base, but grey-04 is lighter than black. This is the secondary body text color — a name like `text-secondary` would be clearer. Every other modifier in the system (`-muted`, `-subtle`) correctly indicates a step DOWN from the base.

#### `--puck-color-interactive-soft` is stronger than `--puck-color-interactive-subtle`

`-soft` (azure-10, darker) sits between `-subtle` (azure-11) and the core selection colors — it's the MORE visible one. But "soft" in English implies gentler/less visible than "subtle." The naming is inverted. A natural reading would put the scale as: `interactive > soft > subtle > subtle-hover`, with soft being lighter. Consider swapping the names or using something like `-subtle-active`.

#### Surface and text modifier directions are inverted

For text: `muted` (grey-05) is MORE visible than `subtle` (grey-07). Good — muted > subtle.
For surfaces: `muted` (grey-12 / #fafafa) is LIGHTER than `subtle` (grey-11 / #f5f5f5). So `muted` is LESS visible than `subtle`. The same modifier words mean opposite relative intensities depending on whether you're looking at text or surfaces.

---

### 2. Tokens used for wrong semantic role

#### `--puck-color-text-muted` used as a border color (5 places)

This means overriding `--puck-color-text-muted` to change help text color also changes input focus/hover borders — a surprising side effect.

| File | Line | Usage |
|---|---|---|
| `AutoField/styles.module.css` | 66, 72, 78 | Input hover/focus `border-color` |
| `RichTextEditor/styles.module.css` | 102 | Editor focus `border-color` |
| `ExternalInput/styles.module.css` | 258, 265 | Search focus/hover `border-color` |

These should use a dedicated token like `--puck-color-border-strong` or `--puck-color-border-hover`.

#### `--puck-color-border-muted` used as a background (2 places)

| File | Line | Usage |
|---|---|---|
| `IconButton/IconButton.module.css` | 27 | Hover `background` |
| `Select/styles.module.css` | 47 | Hover `background` |

These are hover backgrounds using grey-10, which happens to be border-muted's value. Should be a surface or interactive token instead.

---

### 3. Unused or dead tokens

- **`--puck-color-danger`**: Defined as `red-04` but used nowhere in any CSS. Either wire it up to delete/destructive actions or remove it.
- **`--puck-color-overlay-backdrop`**: Only used in `Modal/styles.module.css`. Fine — single-use is acceptable for a global token, just noting it.
- **`--puck-radius-round`**: Used only in `Loader/styles.module.css`. Same — acceptable.

---

### 4. Hardcoded `15px` — the gap in the spacing scale

Seven instances across input components:

| File | Line |
|---|---|
| `AutoField/styles.module.css` | 36 |
| `AutoField/fields/ArrayField/styles.module.css` | 120, 189 |
| `AutoField/fields/ObjectField/styles.module.css` | 17 |
| `ExternalInput/styles.module.css` | 280, 312 |
| `RichTextEditor/styles.module.css` | 77 |

All are horizontal padding on text inputs/fields. The spacing scale jumps 12→16px with no 15px stop. This is either intentional padding compensation (e.g. `16px - 1px border`) or design debt. Either way it's the one systematic hardcoded value remaining.

---

### 5. Easing naming

- `--puck-ease-standard: ease-in` — `ease-in` accelerates FROM rest (objects leaving). Most systems call their standard easing `ease-out` (decelerating INTO rest) or `ease-in-out`.
- `--puck-ease-exit: ease-out` — `ease-out` decelerates (approaching rest), which is conventionally an ENTER/appear motion, not exit.

The names and values are swapped relative to convention. At 50ms durations the visual difference is negligible, but the API will be confusing to anyone coming from Material/Apple HIG conventions.

---

### 6. Unprefixed CSS variables on `:root`

These pollute the consumer's global CSS namespace:

| Variable | File | Purpose |
|---|---|---|
| `--space-m-unitless` | tokens.css | Line-height calculation base |
| `--min-empty-height` | tokens.css | DropZone minimum height |
| `--line-height-reset` | typography.css | Line-height 1 |
| `--line-height-xs` through `--line-height-xl` | typography.css | Computed line heights |
| `--line-height-base` | typography.css | Default line height |
| `--fallback-font-stack` | typography.css | System font fallback |

---

### 7. Component token naming inconsistency

The component-level tokens don't follow a consistent pattern:

| Pattern | Examples |
|---|---|
| Full component name | `--puck-action-bar-*`, `--puck-layer-tree-*`, `--puck-outline-list-*` |
| Abbreviated | `--puck-draggable-*` (not `draggable-component`) |
| Sub-element scoped | `--puck-viewport-toggle-*` (not `viewport-controls`) |
| Includes parent context | `--puck-select-action-bar-active` |

---

### 8. The `--puck-space-px` dual identity

Defined globally as `var(--puck-space-4)` in tokens.css, then also set at the component level in `Puck/Layout/styles.module.css` (`.Puck { --puck-space-px: var(--puck-space-4) }`). The component-level assignment is redundant — it was there before tokens.css existed. A user overriding `--puck-space-px` on `:root` would have it immediately overridden again by the component rule.

---

### Summary by severity

| # | Issue | Impact |
|---|---|---|
| **Naming** | `text-strong` is weaker than `text` | Confusing API for consumers |
| **Naming** | `interactive-soft` is stronger than `interactive-subtle` | Inverted naming intuition |
| **Naming** | Surface modifier directions inverted vs text modifiers | Mental model mismatch |
| **Semantic** | `text-muted` used for borders (5x) | Unexpected side-effects on override |
| **Semantic** | `border-muted` used for backgrounds (2x) | Unexpected side-effects on override |
| **Gap** | `15px` hardcoded (7x) | Not representable in spacing scale |
| **Naming** | Easing names inverted vs convention | Confusing for new contributors |
| **Hygiene** | `danger` token unused | Dead API surface |
| **Hygiene** | 6 unprefixed `:root` variables | Namespace pollution |
| **Hygiene** | Component token naming patterns vary | Inconsistent public API |
| **Hygiene** | `--puck-space-px` redundant component override | Blocks user customization |

## Changes made

- TBD

## How to test

- TBD