### PR TITLE
release: v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 <!--__CHANGELOG_ENTRY__-->
 
+## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.2...v0.22.0) (2026-06-03)
+
+
+### Bug Fixes
+
+* don't select parent on quick drag ([88fa3ee](https://github.com/puckeditor/puck/commit/88fa3eebcbfc3053daad6945758a1f6a375f3a2d))
+* ignore next-env.d.ts in Next.js recipes ([ed7231b](https://github.com/puckeditor/puck/commit/ed7231bb2559764105537677936410143acd8332))
+* record history when moving a component to a different position ([26cf9e0](https://github.com/puckeditor/puck/commit/26cf9e0b872f66364a1e44533c678aefccd63ec7))
+* stop action bar from flashing in bottom on insertion ([8f15de5](https://github.com/puckeditor/puck/commit/8f15de54522d4ed81a3b79a914f6e48226ba6777))
+* use stable ID when rendering RichText on server ([b3f8fa8](https://github.com/puckeditor/puck/commit/b3f8fa8c63df26ea2d12973f6d2f069192c72d26))
+
+
+### Features
+
+* add iframe.syncHostStyles prop for controlling style sync ([1496ae3](https://github.com/puckeditor/puck/commit/1496ae34e48e2b3e92d2fe8461f98a2615b345d2))
+* expose root to resolveData API ([caeacf9](https://github.com/puckeditor/puck/commit/caeacf979cced77c476066bff23b819eb5333fdb))
+* load CSS dynamically if missing ([3c1f5e4](https://github.com/puckeditor/puck/commit/3c1f5e4fbf487de57a0c60eb12bd4a30703b665e))
+* remove remix recipe from create-puck-app ([d2c2761](https://github.com/puckeditor/puck/commit/d2c2761ed2c32a19eb8f28f89efa5b0b65802536))
+
+
+
+
 ## [0.21.2](https://github.com/puckeditor/puck/compare/v0.21.1...v0.21.2) (2026-04-01)
 
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,7 +17,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@puckeditor/core": "*",
+    "@puckeditor/core": "^0.22.0",
     "next": "^15.5.16",
     "next-sitemap": "^4.2.3",
     "nextra": "^3.3.1",

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
     "packages/plugin-emotion-cache",
     "packages/plugin-heading-analyzer"
   ],
-  "version": "0.21.2",
+  "version": "0.22.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "recipes/*",
     "packages/*"
   ],
-  "version": "0.21.2",
+  "version": "0.22.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/core",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "The open-source visual editor for React",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
@@ -105,8 +105,8 @@
   "dependencies": {
     "@dnd-kit/abstract": "0.4.0",
     "@dnd-kit/dom": "0.4.0",
-    "@dnd-kit/helpers": "0.4.0",
     "@dnd-kit/geometry": "0.4.0",
+    "@dnd-kit/helpers": "0.4.0",
     "@dnd-kit/react": "0.4.0",
     "@dnd-kit/state": "0.4.0",
     "@radix-ui/react-popover": "^1.1.15",

--- a/packages/create-puck-app/package.json
+++ b/packages/create-puck-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-puck-app",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",

--- a/packages/field-contentful/package.json
+++ b/packages/field-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/field-contentful",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.21.2",
+    "@puckeditor/core": "^0.22.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "contentful": "^10.8.6",

--- a/packages/plugin-emotion-cache/package.json
+++ b/packages/plugin-emotion-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-emotion-cache",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -24,7 +24,7 @@
   ],
   "devDependencies": {
     "@emotion/react": "^11.13.3",
-    "@puckeditor/core": "^0.21.2",
+    "@puckeditor/core": "^0.22.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.0.2",

--- a/packages/plugin-heading-analyzer/package.json
+++ b/packages/plugin-heading-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-heading-analyzer",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.21.2",
+    "@puckeditor/core": "^0.22.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",


### PR DESCRIPTION
Automated weekly release prep for v0.22.0.

On merge, this release is tagged and published to npm automatically.

## Changelog

## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.2...v0.22.0) (2026-06-03)


### Bug Fixes

* don't select parent on quick drag ([88fa3ee](https://github.com/puckeditor/puck/commit/88fa3eebcbfc3053daad6945758a1f6a375f3a2d))
* ignore next-env.d.ts in Next.js recipes ([ed7231b](https://github.com/puckeditor/puck/commit/ed7231bb2559764105537677936410143acd8332))
* record history when moving a component to a different position ([26cf9e0](https://github.com/puckeditor/puck/commit/26cf9e0b872f66364a1e44533c678aefccd63ec7))
* stop action bar from flashing in bottom on insertion ([8f15de5](https://github.com/puckeditor/puck/commit/8f15de54522d4ed81a3b79a914f6e48226ba6777))
* use stable ID when rendering RichText on server ([b3f8fa8](https://github.com/puckeditor/puck/commit/b3f8fa8c63df26ea2d12973f6d2f069192c72d26))


### Features

* add iframe.syncHostStyles prop for controlling style sync ([1496ae3](https://github.com/puckeditor/puck/commit/1496ae34e48e2b3e92d2fe8461f98a2615b345d2))
* expose root to resolveData API ([caeacf9](https://github.com/puckeditor/puck/commit/caeacf979cced77c476066bff23b819eb5333fdb))
* load CSS dynamically if missing ([3c1f5e4](https://github.com/puckeditor/puck/commit/3c1f5e4fbf487de57a0c60eb12bd4a30703b665e))
* remove remix recipe from create-puck-app ([d2c2761](https://github.com/puckeditor/puck/commit/d2c2761ed2c32a19eb8f28f89efa5b0b65802536))





## Reviewer checklist

- [ ] Changelog entries look right
- [ ] Version bump is the expected level (major/minor/patch)