### PR TITLE
fix: don't crash if tiptap is destroyed

### DIFF
--- a/packages/core/components/RichTextEditor/selector.ts
+++ b/packages/core/components/RichTextEditor/selector.ts
@@ -5,7 +5,7 @@ export const defaultEditorState = (
   readOnly: boolean
 ) => {
   const editor = ctx.editor;
-  if (!editor) return {};
+  if (!editor || editor.isDestroyed) return {};
 
   const canChain = () => editor.can().chain();
 


### PR DESCRIPTION
Closes #1688

## Description (by claude)

When a RichTextEditor component is moved to another place in the DOM (e.g. dragged to a different slot), React unmounts it and remounts it elsewhere. On unmount, Tiptap destroys the editor instance internally.

The problem: editor is not set to null immediately — the reference stays alive, but editor.isDestroyed becomes true. Meanwhile, useEditorState in the RichTextMenu can still fire the selector (defaultEditorState) one more time before it catches up.

The original guard was only if (!editor) return {} — so it passed the null check, then crashed when calling editor.isActive(...) or editor.can().chain() on the destroyed instance.


## Changes made

The fix adds || editor.isDestroyed so the selector bails out before touching any editor methods.

## How to test

- Manually test the code snippet from the issue with patch, the app do not crash anymore.
