### PR TITLE
fix: prevent inline editor from dropping first change

### DIFF
--- a/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
+++ b/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
@@ -3,7 +3,7 @@ import type { Extensions, JSONContent, Editor } from "@tiptap/react";
 import { useEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 import { UiState } from "../../../types";
-import { useAppStore, useAppStoreApi } from "../../../store";
+import { useAppStoreApi } from "../../../store";
 
 export function useSyncedEditor({
   content,
@@ -33,7 +33,6 @@ export function useSyncedEditor({
   const lastSyncedRef = useRef("");
   const editTimer = useRef<NodeJS.Timeout>(null);
   const isPending = !!editTimer.current;
-  const isFocused = useAppStore((s) => s.state.ui.field.focus === name);
 
   const resetTimer = (clearOn: string) => {
     if (editTimer.current) {
@@ -56,6 +55,8 @@ export function useSyncedEditor({
     immediatelyRender: false,
     parseOptions: { preserveWhitespace: "full" },
     onUpdate: ({ editor }) => {
+      const isFocused = appStoreApi.getState().state.ui.field.focus === name;
+
       // This can trigger during undo/redo history loads
       if (syncingRef.current || !isFocused) {
         return;

--- a/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
+++ b/packages/core/components/RichTextEditor/lib/use-synced-editor.ts
@@ -58,8 +58,6 @@ export function useSyncedEditor({
     onUpdate: ({ editor }) => {
       // This can trigger during undo/redo history loads
       if (syncingRef.current || !isFocused) {
-        appStoreApi.getState().setUi({ field: { focus: name } });
-
         return;
       }
 


### PR DESCRIPTION
Closes #1557

## Description

This PR fixes an issue where editing rich text inline when Puck first mounts drops the first update.

I'm still not 100% sure why, but the `setUi` call is causing the issue. My hypothesis is that when the editor mounts, it bails out and sets the inline field as the focused field. Then, when you click the inline field, the sidebar field mounts, sees that it is not the selected field, and bails out, but before doing so, it sets itself as the selected field.

Then, when you edit the field inline, the first call gets ignored because the focused field in state is the sidebar field. It then bails out and sets the inline field back as the focused field.

## Changes made

- Removed the `setUi` call from the bailout, as it was mistakenly stealing the focused state and making it impossible to write the first change to the inline field.
- Added a direct call to the app store to get the latest state, avoiding stale closures around the React rendering lifecycle.

## How to test

- Navigate to the demo.
- Select the inline field for the hero description.
- Press `Cmd + A`.
- Press `Cmd + B` to bold the text.
- Verify that the sidebar field also updates with the change.
- Verify that the `Go back` button rolls back the change.