### PR TITLE
Improve copying style failure message

### DIFF
--- a/packages/core/components/AutoFrame/index.tsx
+++ b/packages/core/components/AutoFrame/index.tsx
@@ -319,7 +319,13 @@ const CopyHostStyles = ({
           }
         };
         mirror.onerror = () => {
-          console.warn(`AutoFrame couldn't load a stylesheet`);
+          const href =
+            mirror instanceof HTMLLinkElement ? mirror.href : undefined;
+          console.warn(
+            `AutoFrame couldn't load a stylesheet${href ? `: ${href}` : ""}. ` +
+              `This can happen if the parent document's stylesheet is blocked by the iframe's CSP, ` +
+              `returns a non-2xx status, or fails to reach the network.`
+          );
           stylesLoaded = stylesLoaded + 1;
 
           if (stylesLoaded >= filtered.length) {


### PR DESCRIPTION
Closes #1651

## Description

This PR adds better logging when fetching styles fails while copying them to the iframe.

## Changes made

- Added a clearer message, as suggested in the issue.

## How to test

- Add a `link` element to the page with an `href` that points to an invalid URL, such as `https://example.com/css`.
- Navigate to the editor.
- Open DevTools.
- Verify that it shows a clearer message.