### PR TITLE
chore: add aria-expanded to category buttons

### DIFF
--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -54,12 +54,16 @@ const ComponentList = ({
 
   const { expanded = true } = componentList[id] || {};
 
+  const contentId = `puck-drawer-category-${id}`;
+
   return (
     <div className={getClassName({ isExpanded: expanded })}>
       {title && (
         <button
           type="button"
           className={getClassName("title")}
+          aria-expanded={expanded}
+          aria-controls={contentId}
           onClick={() =>
             setUi({
               componentList: {
@@ -83,7 +87,7 @@ const ComponentList = ({
           </div>
         </button>
       )}
-      <div className={getClassName("content")}>
+      <div className={getClassName("content")} id={contentId}>
         <Drawer>
           {children ||
             Object.keys(config.components).map((componentKey) => {


### PR DESCRIPTION
Closes #1668

This PR adds aria-expanded to category buttons for accesibility.

## Changes made

- The Component list now sends down the expanded flag for each category in the `aria-expanded` attribute.
