### PR TITLE
fix: show overlay portal outline only in edit mode

### DIFF
--- a/packages/core/components/Puck/__tests__/index.tsx
+++ b/packages/core/components/Puck/__tests__/index.tsx
@@ -274,4 +274,26 @@ describe("Puck", () => {
       PUCK_STYLE_SOURCE_VALUE
     );
   });
+
+  it("exposes the preview mode on the canvas entry element", async () => {
+    render(<Puck config={config} data={{}} iframe={{ enabled: false }} />);
+
+    await flush();
+
+    const entry = document.querySelector("[data-puck-entry]");
+
+    expect(entry?.getAttribute("data-puck-preview-mode")).toBe("edit");
+
+    const { appStore } = getInternal();
+
+    act(() => {
+      appStore
+        .getState()
+        .dispatch({ type: "setUi", ui: { previewMode: "interactive" } });
+    });
+
+    await flush();
+
+    expect(entry?.getAttribute("data-puck-preview-mode")).toBe("interactive");
+  });
 });

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -1,6 +1,6 @@
 import { DropZoneEditPure, DropZonePure } from "../../../DropZone";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
-import { RefObject, useCallback, useEffect, useRef, useMemo } from "react";
+import { RefObject, useEffect, useRef, useMemo, memo } from "react";
 import { useAppStore } from "../../../../store";
 import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
 import styles from "./styles.module.css";
@@ -10,6 +10,7 @@ import { Render } from "../../../Render";
 import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
 import { useSlots } from "../../../../lib/use-slots";
 import { useRichtextProps } from "../../../RichTextEditor/lib/use-richtext-props";
+import { getFrame } from "../../../../lib/get-frame";
 
 const getClassName = getClassNameFactory("PuckPreview", styles);
 
@@ -68,44 +69,40 @@ const useBubbleIframeEvents = (ref: RefObject<HTMLIFrameElement | null>) => {
   }, [status]);
 };
 
+const Page = memo(({ config, ...pageProps }: { config: any } & PageProps) => {
+  const propsWithSlots = useSlots(
+    config,
+    { type: "root", props: pageProps },
+    DropZoneEditPure
+  );
+
+  const richtextProps = useRichtextProps(config.root?.fields ?? {}, pageProps);
+
+  return config.root?.render ? (
+    config.root?.render({
+      id: "puck-root",
+      ...propsWithSlots,
+      ...richtextProps,
+    })
+  ) : (
+    <>{propsWithSlots.children}</>
+  );
+});
+
+Page.displayName = "Page";
+
 export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const dispatch = useAppStore((s) => s.dispatch);
   const root = useAppStore((s) => s.state.data.root);
   const config = useAppStore((s) => s.config);
+  const status = useAppStore((s) => s.status);
   const setStatus = useAppStore((s) => s.setStatus);
   const iframe = useAppStore((s) => s.iframe);
   const overrides = useAppStore((s) => s.overrides);
   const metadata = useAppStore((s) => s.metadata);
+  const previewMode = useAppStore((s) => s.state.ui.previewMode);
   const renderData = useAppStore((s) =>
     s.state.ui.previewMode === "edit" ? null : s.state.data
-  );
-
-  const Page = useCallback<React.FC<PageProps>>(
-    (pageProps) => {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const propsWithSlots = useSlots(
-        config,
-        { type: "root", props: pageProps },
-        DropZoneEditPure
-      );
-
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const richtextProps = useRichtextProps(
-        config.root?.fields ?? {},
-        pageProps
-      );
-
-      return config.root?.render ? (
-        config.root?.render({
-          id: "puck-root",
-          ...propsWithSlots,
-          ...richtextProps,
-        })
-      ) : (
-        <>{propsWithSlots.children}</>
-      );
-    },
-    [config]
   );
 
   const Frame = useMemo(() => overrides.iframe, [overrides]);
@@ -117,9 +114,18 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
 
   useBubbleIframeEvents(ref);
 
+  // Expose the current preview mode on the canvas entry so CSS can hide
+  // editor-only styles (e.g. overlay portal outlines) while interactive.
+  useEffect(() => {
+    const entry = getFrame()?.querySelector("[data-puck-entry]");
+
+    entry?.setAttribute("data-puck-preview-mode", previewMode);
+  }, [previewMode, status, iframe.enabled]);
+
   const inner = !renderData ? (
     <Page
       {...rootProps}
+      config={config}
       puck={{
         renderDropZone: DropZonePure,
         isEditing: true,

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -10,7 +10,6 @@ import { Render } from "../../../Render";
 import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
 import { useSlots } from "../../../../lib/use-slots";
 import { useRichtextProps } from "../../../RichTextEditor/lib/use-richtext-props";
-import { getFrame } from "../../../../lib/get-frame";
 
 const getClassName = getClassNameFactory("PuckPreview", styles);
 
@@ -69,6 +68,22 @@ const useBubbleIframeEvents = (ref: RefObject<HTMLIFrameElement | null>) => {
   }, [status]);
 };
 
+const usePreviewModeAttribute = (ref: RefObject<HTMLIFrameElement | null>) => {
+  const previewMode = useAppStore((s) => s.state.ui.previewMode);
+  const status = useAppStore((s) => s.status);
+  const iframeEnabled = useAppStore((s) => s.iframe.enabled);
+
+  // Expose the current preview mode on the canvas entry so CSS can hide
+  // editor-only styles (e.g. overlay portal outlines) while interactive.
+  useEffect(() => {
+    const entry = iframeEnabled
+      ? ref.current?.contentDocument?.querySelector("[data-puck-entry]")
+      : ref.current;
+
+    entry?.setAttribute("data-puck-preview-mode", previewMode);
+  }, [previewMode, status, iframeEnabled]);
+};
+
 const Page = memo(({ config, ...pageProps }: { config: any } & PageProps) => {
   const propsWithSlots = useSlots(
     config,
@@ -95,12 +110,10 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const dispatch = useAppStore((s) => s.dispatch);
   const root = useAppStore((s) => s.state.data.root);
   const config = useAppStore((s) => s.config);
-  const status = useAppStore((s) => s.status);
   const setStatus = useAppStore((s) => s.setStatus);
   const iframe = useAppStore((s) => s.iframe);
   const overrides = useAppStore((s) => s.overrides);
   const metadata = useAppStore((s) => s.metadata);
-  const previewMode = useAppStore((s) => s.state.ui.previewMode);
   const renderData = useAppStore((s) =>
     s.state.ui.previewMode === "edit" ? null : s.state.data
   );
@@ -113,14 +126,7 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const ref = useRef<HTMLIFrameElement>(null);
 
   useBubbleIframeEvents(ref);
-
-  // Expose the current preview mode on the canvas entry so CSS can hide
-  // editor-only styles (e.g. overlay portal outlines) while interactive.
-  useEffect(() => {
-    const entry = getFrame()?.querySelector("[data-puck-entry]");
-
-    entry?.setAttribute("data-puck-preview-mode", previewMode);
-  }, [previewMode, status, iframe.enabled]);
+  usePreviewModeAttribute(ref);
 
   const inner = !renderData ? (
     <Page

--- a/packages/core/lib/overlay-portal/styles.css
+++ b/packages/core/lib/overlay-portal/styles.css
@@ -3,12 +3,15 @@
   pointer-events: auto !important;
 }
 
-[data-puck-overlay-portal]:hover {
+/* Render the outline only in edit mode */
+[data-puck-entry][data-puck-preview-mode="edit"]
+  [data-puck-overlay-portal]:hover {
   outline: 2px var(--puck-color-azure-09, #cfdff0) dashed;
   outline-offset: 2px;
 }
 
-[data-puck-overlay-portal]:focus-within {
+[data-puck-entry][data-puck-preview-mode="edit"]
+  [data-puck-overlay-portal]:focus-within {
   outline: 2px var(--puck-color-azure-07, #88b0da) dashed;
   outline-offset: 2px;
 }


### PR DESCRIPTION
Closes #1604

## Description

This PR fixes an issue where the overlay portal was rendering in interactive mode in the editor. This was happening because the styles for the overlay portal were too greedy and applied regardless of whether the editor was in edit or interactive mode.

One possible fix would be to pass a new prop to `registerOverlayPortal` with the `puck.isEditing` flag, but that would require an API change and more work on the user side. Instead, we can wire this in using HTML attributes so that it works automatically.

## Changes made

- The preview mode is now passed into the preview canvas through an HTML data attribute at the `data-puck-entry` level.
- Overlay portals now only add the hover outline when the preview mode on the HTML element is set to edit mode.

### Not related with the issue (refactor)
- Noticed the `Preview` component was defining a nested component with `useCallback`. This meant any time the config changed the whole preview needed to be remounted. I extracted it into its own component and passed in the config as a prop to avoid that, now it will only re-render if it changes.

## How to test

- Render Puck with an overlay portal.
- Navigate to the editor.
- Add the component with the portal to the canvas.
- Hover over it and verify that the portal outline appears.
- Switch to interactive mode (`Cmd + I`).
- Hover over it and verify that no portal outline appears.