### PR TITLE
fix: don't lazy load the rich text render on every re-render

### DIFF
--- a/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
+++ b/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
@@ -8,6 +8,12 @@ import {
 import { RichTextRenderFallback } from "../components/RenderFallback";
 import { mapDeep } from "./mapDeep";
 
+const RichTextRender = lazy(() =>
+  import("../components/Render").then((m) => ({
+    default: m.RichTextRender,
+  }))
+);
+
 type RichtextPath = {
   path: string[];
   field: RichtextField;
@@ -59,12 +65,6 @@ export function useRichtextProps(
 
   const richtextProps = useMemo(() => {
     if (!richtextKeys?.length) return {};
-
-    const RichTextRender = lazy(() =>
-      import("../components/Render").then((m) => ({
-        default: m.RichTextRender,
-      }))
-    );
 
     let result = { ...props };
 


### PR DESCRIPTION
Closes #1648

## Description

This PR fixes an issue where switching to interactive mode while using rich text would sometimes crash the editor.

I'm not 100% sure why this was happening yet, but I think it was because we were lazily loading the rich text renderer within `useRichtextProps`.

This meant that, somehow, when switching to interactive mode, React rendered `Render`, which in turn called the hook and hit Suspense. For some reason, React decided not to show the fallback in that case and instead retried rendering the tree. This hit the lazy import again, creating a new instance of the import and causing Suspense to repeat the same behavior. This resulted in an infinite loop.

## Changes made

- Moved the lazy import to the module level to avoid re-importing it every time.

## How to test

- Navigate to the demo page.
- Click the hero.
- Switch to interactive mode.