### PR TITLE
release: v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!--__CHANGELOG_ENTRY__-->
 
-## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.2...v0.22.0) (2026-06-24)
+## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.3...v0.22.0) (2026-06-24)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,14 @@
 ### Bug Fixes
 
 * capture first change in inline richtext field ([208b221](https://github.com/puckeditor/puck/commit/208b22140c0fcf85447ef9da2e838872aced0a77))
-* don't crash if tiptap is destroyed ([08eaa6b](https://github.com/puckeditor/puck/commit/08eaa6ba4440900c7258650fc7d6dec1be201f61))
-* don't crash richtext field when string is empty ([db71cea](https://github.com/puckeditor/puck/commit/db71cea7fea1052b41f417657660ed3ba47d3122))
 * don't lazy load the rich text render on every re-render ([497aedf](https://github.com/puckeditor/puck/commit/497aedfec5a0cd362ad9f19f2c03904d787c83ef))
-* don't select parent on quick drag ([88fa3ee](https://github.com/puckeditor/puck/commit/88fa3eebcbfc3053daad6945758a1f6a375f3a2d))
-* ignore next-env.d.ts in Next.js recipes ([ed7231b](https://github.com/puckeditor/puck/commit/ed7231bb2559764105537677936410143acd8332))
-* prevent canvas loader from blocking pointer events when hidden ([5ec4c5e](https://github.com/puckeditor/puck/commit/5ec4c5eb29ea06d00afef19d8851eb171208d323))
-* record history when moving a component to a different position ([26cf9e0](https://github.com/puckeditor/puck/commit/26cf9e0b872f66364a1e44533c678aefccd63ec7))
-* render empty string instead of literal when contentEditable fields receive nullish values ([3f4b053](https://github.com/puckeditor/puck/commit/3f4b053ea53624cc9552825f1beddb1fef2f5007))
 * show overlay portal outline only in edit mode ([31c3d21](https://github.com/puckeditor/puck/commit/31c3d217a3c4ad36bf77d8889c56ac9a538e36c1))
-* stop action bar from flashing in bottom on insertion ([8f15de5](https://github.com/puckeditor/puck/commit/8f15de54522d4ed81a3b79a914f6e48226ba6777))
-* unwrap propName in walkFields for nested slots ([a070d89](https://github.com/puckeditor/puck/commit/a070d8908cdfc85480dbeb4fc1557d1539e61b5c))
-* use aria-label for accessible name in IconButton ([b999e00](https://github.com/puckeditor/puck/commit/b999e00c2b29cf5ea67fc0ca2a1ae53b465a73f2))
-* use stable ID when rendering RichText on server ([b3f8fa8](https://github.com/puckeditor/puck/commit/b3f8fa8c63df26ea2d12973f6d2f069192c72d26))
-
+* use aria-expanded for accessible name in component category buttons ([f949417](https://github.com/puckeditor/puck/commit/f9494176c8c936faec6fc6d5ecbf7d5c5dce33fa))
 
 ### Features
 
 * add iframe.syncHostStyles prop for controlling style sync ([1496ae3](https://github.com/puckeditor/puck/commit/1496ae34e48e2b3e92d2fe8461f98a2615b345d2))
-* add themeing support with CSS variables ([d4c8bcf](https://github.com/puckeditor/puck/commit/d4c8bcf2dce09cc174ab405cf1d5cd39239a7c99))
+* add theming support with CSS variables ([d4c8bcf](https://github.com/puckeditor/puck/commit/d4c8bcf2dce09cc174ab405cf1d5cd39239a7c99))
 * expose root to resolveData API ([caeacf9](https://github.com/puckeditor/puck/commit/caeacf979cced77c476066bff23b819eb5333fdb))
 * load CSS dynamically if missing ([3c1f5e4](https://github.com/puckeditor/puck/commit/3c1f5e4fbf487de57a0c60eb12bd4a30703b665e))
 * remove remix recipe from create-puck-app ([d2c2761](https://github.com/puckeditor/puck/commit/d2c2761ed2c32a19eb8f28f89efa5b0b65802536))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 <!--__CHANGELOG_ENTRY__-->
 
+## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.2...v0.22.0) (2026-06-24)
+
+
+### Bug Fixes
+
+* capture first change in inline richtext field ([208b221](https://github.com/puckeditor/puck/commit/208b22140c0fcf85447ef9da2e838872aced0a77))
+* don't crash if tiptap is destroyed ([08eaa6b](https://github.com/puckeditor/puck/commit/08eaa6ba4440900c7258650fc7d6dec1be201f61))
+* don't crash richtext field when string is empty ([db71cea](https://github.com/puckeditor/puck/commit/db71cea7fea1052b41f417657660ed3ba47d3122))
+* don't lazy load the rich text render on every re-render ([497aedf](https://github.com/puckeditor/puck/commit/497aedfec5a0cd362ad9f19f2c03904d787c83ef))
+* don't select parent on quick drag ([88fa3ee](https://github.com/puckeditor/puck/commit/88fa3eebcbfc3053daad6945758a1f6a375f3a2d))
+* ignore next-env.d.ts in Next.js recipes ([ed7231b](https://github.com/puckeditor/puck/commit/ed7231bb2559764105537677936410143acd8332))
+* prevent canvas loader from blocking pointer events when hidden ([5ec4c5e](https://github.com/puckeditor/puck/commit/5ec4c5eb29ea06d00afef19d8851eb171208d323))
+* record history when moving a component to a different position ([26cf9e0](https://github.com/puckeditor/puck/commit/26cf9e0b872f66364a1e44533c678aefccd63ec7))
+* render empty string instead of literal when contentEditable fields receive nullish values ([3f4b053](https://github.com/puckeditor/puck/commit/3f4b053ea53624cc9552825f1beddb1fef2f5007))
+* show overlay portal outline only in edit mode ([31c3d21](https://github.com/puckeditor/puck/commit/31c3d217a3c4ad36bf77d8889c56ac9a538e36c1))
+* stop action bar from flashing in bottom on insertion ([8f15de5](https://github.com/puckeditor/puck/commit/8f15de54522d4ed81a3b79a914f6e48226ba6777))
+* unwrap propName in walkFields for nested slots ([a070d89](https://github.com/puckeditor/puck/commit/a070d8908cdfc85480dbeb4fc1557d1539e61b5c))
+* use aria-label for accessible name in IconButton ([b999e00](https://github.com/puckeditor/puck/commit/b999e00c2b29cf5ea67fc0ca2a1ae53b465a73f2))
+* use stable ID when rendering RichText on server ([b3f8fa8](https://github.com/puckeditor/puck/commit/b3f8fa8c63df26ea2d12973f6d2f069192c72d26))
+
+
+### Features
+
+* add iframe.syncHostStyles prop for controlling style sync ([1496ae3](https://github.com/puckeditor/puck/commit/1496ae34e48e2b3e92d2fe8461f98a2615b345d2))
+* add themeing support with CSS variables ([d4c8bcf](https://github.com/puckeditor/puck/commit/d4c8bcf2dce09cc174ab405cf1d5cd39239a7c99))
+* expose root to resolveData API ([caeacf9](https://github.com/puckeditor/puck/commit/caeacf979cced77c476066bff23b819eb5333fdb))
+* load CSS dynamically if missing ([3c1f5e4](https://github.com/puckeditor/puck/commit/3c1f5e4fbf487de57a0c60eb12bd4a30703b665e))
+* remove remix recipe from create-puck-app ([d2c2761](https://github.com/puckeditor/puck/commit/d2c2761ed2c32a19eb8f28f89efa5b0b65802536))
+
+
+
+
 ## [0.21.3](https://github.com/puckeditor/puck/compare/v0.21.2...v0.21.3) (2026-06-08)
 
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,7 +17,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@puckeditor/core": "*",
+    "@puckeditor/core": "^0.22.0",
     "next": "^15.5.16",
     "next-sitemap": "^4.2.3",
     "nextra": "^3.3.1",

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
     "packages/plugin-emotion-cache",
     "packages/plugin-heading-analyzer"
   ],
-  "version": "0.21.3",
+  "version": "0.22.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "recipes/*",
     "packages/*"
   ],
-  "version": "0.21.3",
+  "version": "0.22.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/core",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "The open-source visual editor for React",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
@@ -105,8 +105,8 @@
   "dependencies": {
     "@dnd-kit/abstract": "0.4.0",
     "@dnd-kit/dom": "0.4.0",
-    "@dnd-kit/helpers": "0.4.0",
     "@dnd-kit/geometry": "0.4.0",
+    "@dnd-kit/helpers": "0.4.0",
     "@dnd-kit/react": "0.4.0",
     "@dnd-kit/state": "0.4.0",
     "@radix-ui/react-popover": "^1.1.15",

--- a/packages/create-puck-app/package.json
+++ b/packages/create-puck-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-puck-app",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",

--- a/packages/field-contentful/package.json
+++ b/packages/field-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/field-contentful",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.21.3",
+    "@puckeditor/core": "^0.22.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "contentful": "^10.8.6",

--- a/packages/plugin-emotion-cache/package.json
+++ b/packages/plugin-emotion-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-emotion-cache",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -24,7 +24,7 @@
   ],
   "devDependencies": {
     "@emotion/react": "^11.13.3",
-    "@puckeditor/core": "^0.21.3",
+    "@puckeditor/core": "^0.22.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.0.2",

--- a/packages/plugin-heading-analyzer/package.json
+++ b/packages/plugin-heading-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-heading-analyzer",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.21.3",
+    "@puckeditor/core": "^0.22.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",


### PR DESCRIPTION
Automated weekly release prep for v0.22.0.

On merge, this release is tagged and published to npm automatically.

## Changelog

## [0.22.0](https://github.com/puckeditor/puck/compare/v0.21.2...v0.22.0) (2026-06-24)


### Bug Fixes

* capture first change in inline richtext field ([208b221](https://github.com/puckeditor/puck/commit/208b22140c0fcf85447ef9da2e838872aced0a77))
* don't lazy load the rich text render on every re-render ([497aedf](https://github.com/puckeditor/puck/commit/497aedfec5a0cd362ad9f19f2c03904d787c83ef))
* show overlay portal outline only in edit mode ([31c3d21](https://github.com/puckeditor/puck/commit/31c3d217a3c4ad36bf77d8889c56ac9a538e36c1))
* use aria-expanded for accessible name in component category buttons ([f949417](https://github.com/puckeditor/puck/commit/f9494176c8c936faec6fc6d5ecbf7d5c5dce33fa))


### Features

* add iframe.syncHostStyles prop for controlling style sync ([1496ae3](https://github.com/puckeditor/puck/commit/1496ae34e48e2b3e92d2fe8461f98a2615b345d2))
* add theming support with CSS variables ([d4c8bcf](https://github.com/puckeditor/puck/commit/d4c8bcf2dce09cc174ab405cf1d5cd39239a7c99))
* expose root to resolveData API ([caeacf9](https://github.com/puckeditor/puck/commit/caeacf979cced77c476066bff23b819eb5333fdb))
* load CSS dynamically if missing ([3c1f5e4](https://github.com/puckeditor/puck/commit/3c1f5e4fbf487de57a0c60eb12bd4a30703b665e))
* remove remix recipe from create-puck-app ([d2c2761](https://github.com/puckeditor/puck/commit/d2c2761ed2c32a19eb8f28f89efa5b0b65802536))





## Reviewer checklist

- [x] Changelog entries look right
- [x] Version bump is the expected level (major/minor/patch)