### PR TITLE
Add dictionary

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -29,6 +29,7 @@ export function Editor() {
 | ----------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------ | ------------ |
 | [`config`](#config)                                               | `config: { components: {} }`                       | [Config](/docs/api-reference/configuration/config)                       | Required     |
 | [`data`](#data)                                                   | `data: {}`                                         | [Data](/docs/api-reference/data-model/data)                              | Required     |
+| [`dictionary`](#dictionary)                                       | `dictionary: { "header-publish": "Publicar" }`     | [Dictionary](/docs/api-reference/dictionary)                             | -            |
 | [`dnd`](#dnd)                                                     | `dnd: {}`                                          | [DndConfig](#dnd-params)                                                 | -            |
 | [`children`](#children)                                           | `children: <Puck.Preview />`                       | ReactNode                                                                | -            |
 | [`fieldTransforms`](#fieldtransforms)                             | `fieldTransforms: {text: () => <div />}`           | [FieldTransforms](/docs/api-reference/field-transforms)                  | -            |
@@ -113,6 +114,21 @@ export function Editor() {
     <Puck /*...*/>
       <Puck.Preview />
     </Puck>
+  );
+}
+```
+
+### `dictionary`
+
+Override Puck's default UI strings, or add your own. See the [`Dictionary` docs](/docs/api-reference/dictionary) for a full list of supported messages.
+
+```tsx {4} copy
+export function Editor() {
+  return (
+    <Puck
+      dictionary={{ "header-publish": "Save" }}
+      // ...
+    />
   );
 }
 ```

--- a/apps/docs/pages/docs/api-reference/dictionary.mdx
+++ b/apps/docs/pages/docs/api-reference/dictionary.mdx
@@ -1,0 +1,172 @@
+---
+title: Dictionary
+---
+
+# Dictionary
+
+The dictionary defines the text strings used throughout Puck's UI.
+
+Use this to implement [localization](/docs/integrating-puck/localization) or to override default messages:
+
+```tsx showLineNumbers copy
+const dictionary = {
+  "header-publish": "Save",
+};
+
+<Puck dictionary={dictionary} />;
+```
+
+When a default string contains a template variable (e.g. `{count}`), you can use that to position the variable in your string:
+
+```tsx showLineNumbers copy
+const dictionary = {
+  "field-external-result-singular": "Total: {count}",
+  "field-external-result-plural": "Total: {count}",
+};
+```
+
+The dictionary also accepts your own keys, which you can read from the [internal Puck API](/docs/api-reference/puck-api#dictionary). See [Custom strings](/docs/integrating-puck/localization#custom-strings).
+
+## Tokens
+
+Tokens follow a `{area}-{name}-{variant}` format.
+
+Many tokens set an element's HTML `title` attribute, a tooltip that only appears on hover, rather than always-visible text. These are marked _(tooltip)_ below.
+
+### Header
+
+| Token                        | Default                  | Used for                         |
+| ---------------------------- | ------------------------ | -------------------------------- |
+| `header-publish`             | `"Publish"`              | Publish button                   |
+| `header-undo`                | `"undo"`                 | Undo button (tooltip)            |
+| `header-redo`                | `"redo"`                 | Redo button (tooltip)            |
+| `header-toggle-leftsidebar`  | `"Toggle left sidebar"`  | Sidebar toggle (tooltip)         |
+| `header-toggle-rightsidebar` | `"Toggle right sidebar"` | Sidebar toggle (tooltip)         |
+| `header-toggle-menubar`      | `"Toggle menu bar"`      | Mobile menu bar toggle (tooltip) |
+
+### Actions
+
+| Token                 | Default           | Used for                       |
+| --------------------- | ----------------- | ------------------------------ |
+| `action-selectparent` | `"Select parent"` | Component action bar (tooltip) |
+| `action-duplicate`    | `"Duplicate"`     | Component action bar (tooltip) |
+| `action-delete`       | `"Delete"`        | Component action bar (tooltip) |
+
+### Labels
+
+| Token             | Default       | Used for                                                |
+| ----------------- | ------------- | ------------------------------------------------------- |
+| `label-page`      | `"Page"`      | Breadcrumbs, fields panel title, header title fallback  |
+| `label-component` | `"Component"` | Outline and breadcrumbs, for unresolved component types |
+
+### Outline
+
+| Token              | Default      | Used for               |
+| ------------------ | ------------ | ---------------------- |
+| `outline-empty`    | `"No items"` | Empty zone             |
+| `outline-collapse` | `"Collapse"` | Layer toggle (tooltip) |
+| `outline-expand`   | `"Expand"`   | Layer toggle (tooltip) |
+
+### Drawer
+
+| Token                      | Default              | Used for                                      |
+| -------------------------- | -------------------- | --------------------------------------------- |
+| `drawer-category-collapse` | `"Collapse {title}"` | Category toggle (tooltip)                     |
+| `drawer-category-expand`   | `"Expand {title}"`   | Category toggle (tooltip)                     |
+| `drawer-category-other`    | `"Other"`            | Default category for uncategorized components |
+
+### Canvas
+
+| Token             | Default                         | Used for                                           |
+| ----------------- | ------------------------------- | -------------------------------------------------- |
+| `canvas-noconfig` | `"No configuration for {type}"` | Placeholder for components missing from the config |
+
+### Fields
+
+| Token            | Default       | Used for                            |
+| ---------------- | ------------- | ----------------------------------- |
+| `field-readonly` | `"Read-only"` | Read-only field lock icon (tooltip) |
+
+#### Array field
+
+| Token                       | Default           | Used for              |
+| --------------------------- | ----------------- | --------------------- |
+| `field-arrayitem-summary`   | `"Item #{index}"` | Item default label    |
+| `field-arrayitem-duplicate` | `"Duplicate"`     | Item action (tooltip) |
+| `field-arrayitem-delete`    | `"Delete"`        | Item action (tooltip) |
+
+#### External field
+
+| Token                            | Default             | Used for                         |
+| -------------------------------- | ------------------- | -------------------------------- |
+| `field-external-selectdata`      | `"Select data"`     | Trigger button and modal heading |
+| `field-external-search`          | `"Search"`          | Modal search                     |
+| `field-external-togglefilters`   | `"Toggle filters"`  | Modal filter toggle (tooltip)    |
+| `field-external-item`            | `"External item"`   | Selected item default label      |
+| `field-external-result-singular` | `"{count} result"`  | Modal footer                     |
+| `field-external-result-plural`   | `"{count} results"` | Modal footer                     |
+
+#### Rich text field
+
+| Token                                | Default             | Used for                    |
+| ------------------------------------ | ------------------- | --------------------------- |
+| `field-richtext-bold`                | `"Bold"`            | Formatting button (tooltip) |
+| `field-richtext-italic`              | `"Italic"`          | Formatting button (tooltip) |
+| `field-richtext-underline`           | `"Underline"`       | Formatting button (tooltip) |
+| `field-richtext-strikethrough`       | `"Strikethrough"`   | Formatting button (tooltip) |
+| `field-richtext-blockquote`          | `"Blockquote"`      | Formatting button (tooltip) |
+| `field-richtext-code-inline`         | `"Inline code"`     | Formatting button (tooltip) |
+| `field-richtext-code-block`          | `"Code block"`      | Formatting button (tooltip) |
+| `field-richtext-list-bullet`         | `"Bullet list"`     | Formatting button (tooltip) |
+| `field-richtext-list-ordered`        | `"Ordered list"`    | Formatting button (tooltip) |
+| `field-richtext-horizontalrule`      | `"Horizontal rule"` | Formatting button (tooltip) |
+| `field-richtext-align-left`          | `"Align left"`      | Alignment button (tooltip)  |
+| `field-richtext-align-center`        | `"Align center"`    | Alignment button (tooltip)  |
+| `field-richtext-align-right`         | `"Align right"`     | Alignment button (tooltip)  |
+| `field-richtext-align-justify`       | `"Justify"`         | Alignment button (tooltip)  |
+| `field-richtext-select`              | `"Select"`          | Select control (tooltip)    |
+| `field-richtext-headingselect-1`     | `"Heading 1"`       | Heading select option       |
+| `field-richtext-headingselect-2`     | `"Heading 2"`       | Heading select option       |
+| `field-richtext-headingselect-3`     | `"Heading 3"`       | Heading select option       |
+| `field-richtext-headingselect-4`     | `"Heading 4"`       | Heading select option       |
+| `field-richtext-headingselect-5`     | `"Heading 5"`       | Heading select option       |
+| `field-richtext-headingselect-6`     | `"Heading 6"`       | Heading select option       |
+| `field-richtext-alignselect-left`    | `"Left"`            | Alignment select option     |
+| `field-richtext-alignselect-center`  | `"Center"`          | Alignment select option     |
+| `field-richtext-alignselect-right`   | `"Right"`           | Alignment select option     |
+| `field-richtext-alignselect-justify` | `"Justify"`         | Alignment select option     |
+| `field-richtext-listselect-bullet`   | `"Bullet list"`     | List select option          |
+| `field-richtext-listselect-ordered`  | `"Ordered list"`    | List select option          |
+
+### Viewport controls
+
+| Token                     | Default                        | Used for                                |
+| ------------------------- | ------------------------------ | --------------------------------------- |
+| `viewport-zoom-in`        | `"Zoom viewport in"`           | Zoom button (tooltip)                   |
+| `viewport-zoom-out`       | `"Zoom viewport out"`          | Zoom button (tooltip)                   |
+| `viewport-zoom-auto`      | `"{zoom}% (Auto)"`             | Auto zoom select option                 |
+| `viewport-toggle-menu`    | `"Toggle viewport menu"`       | Menu toggle (tooltip)                   |
+| `viewport-switch`         | `"Switch to {label} viewport"` | Viewport button (tooltip)               |
+| `viewport-switch-default` | `"Switch viewport"`            | Viewport button, if unlabeled (tooltip) |
+
+### Plugin bar
+
+| Token               | Default        | Used for                             |
+| ------------------- | -------------- | ------------------------------------ |
+| `plugin-blocks`     | `"Blocks"`     | Sidebar tab and legacy section title |
+| `plugin-outline`    | `"Outline"`    | Sidebar tab                          |
+| `plugin-fields`     | `"Fields"`     | Sidebar tab                          |
+| `plugin-components` | `"Components"` | Legacy sidebar section title         |
+
+### Layout
+
+| Token             | Default      | Used for                      |
+| ----------------- | ------------ | ----------------------------- |
+| `layout-maximize` | `"maximize"` | Mobile panel toggle (tooltip) |
+| `layout-minimize` | `"minimize"` | Mobile panel toggle (tooltip) |
+
+### Loader
+
+| Token            | Default     | Used for                     |
+| ---------------- | ----------- | ---------------------------- |
+| `loader-loading` | `"loading"` | Loading spinner (aria-label) |

--- a/apps/docs/pages/docs/api-reference/plugins/blocks-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/blocks-plugin.mdx
@@ -20,4 +20,42 @@ export function Editor() {
 
 ## Params
 
-This plugin does not accept any params.
+| Param             | Example           | Type      | Status |
+| ----------------- | ----------------- | --------- | ------ |
+| [`icon`](#icon)   | `icon: <Box />`   | ReactNode | -      |
+| [`label`](#label) | `label: "Blocks"` | String    | -      |
+
+## Optional params
+
+### `icon`
+
+React node displayed alongside `label` in the plugin rail. Defaults to a hammer icon.
+
+```tsx copy
+import { Puck, blocksPlugin } from "@puckeditor/core";
+import { Box } from "lucide-react";
+
+const blocks = blocksPlugin({
+  icon: <Box />,
+});
+
+export function Editor() {
+  return <Puck plugins={[blocks]} />;
+}
+```
+
+### `label`
+
+Label shown in the plugin rail. Defaults to `"Blocks"`.
+
+```tsx copy
+import { Puck, blocksPlugin } from "@puckeditor/core";
+
+const blocks = blocksPlugin({
+  label: "Components",
+});
+
+export function Editor() {
+  return <Puck plugins={[blocks]} />;
+}
+```

--- a/apps/docs/pages/docs/api-reference/plugins/fields-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/fields-plugin.mdx
@@ -20,9 +20,11 @@ export function Editor() {
 
 ## Params
 
-| Param            | Example                  | Type              | Status |
-| ---------------- | ------------------------ | ----------------- | ------ |
-| `desktopSideBar` | `desktopSideBar: "left"` | "left" \| "right" | -      |
+| Param                               | Example                  | Type              | Status |
+| ----------------------------------- | ------------------------ | ----------------- | ------ |
+| [`desktopSideBar`](#desktopsidebar) | `desktopSideBar: "left"` | "left" \| "right" | -      |
+| [`icon`](#icon)                     | `icon: <FormInput />`    | ReactNode         | -      |
+| [`label`](#label)                   | `label: "Fields"`        | String            | -      |
 
 ## Optional params
 
@@ -34,4 +36,37 @@ Display the plugin in the left or right sidebar on desktop. This field is `"righ
 const fields = fieldsPlugin({
   desktopSideBar: "left",
 });
+```
+
+### `icon`
+
+React node displayed alongside `label` in the plugin rail. Defaults to a form input icon.
+
+```tsx copy
+import { Puck, fieldsPlugin } from "@puckeditor/core";
+import { Form } from "lucide-react";
+
+const fields = fieldsPlugin({
+  icon: <Form />,
+});
+
+export function Editor() {
+  return <Puck plugins={[fields]} />;
+}
+```
+
+### `label`
+
+Label shown in the plugin rail. Defaults to `"Fields"`.
+
+```tsx copy
+import { Puck, fieldsPlugin } from "@puckeditor/core";
+
+const fields = fieldsPlugin({
+  label: "Properties",
+});
+
+export function Editor() {
+  return <Puck plugins={[fields]} />;
+}
 ```

--- a/apps/docs/pages/docs/api-reference/plugins/legacy-side-bar-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/legacy-side-bar-plugin.mdx
@@ -18,4 +18,41 @@ export function Editor() {
 
 ## Params
 
-This plugin does not accept any params.
+| Param                                 | Example                         | Type   | Status |
+| ------------------------------------- | ------------------------------- | ------ | ------ |
+| [`componentsLabel`](#componentslabel) | `componentsLabel: "Components"` | String | -      |
+| [`outlineLabel`](#outlinelabel)       | `outlineLabel: "Outline"`       | String | -      |
+
+## Optional params
+
+### `componentsLabel`
+
+Title shown above the component drawer section. Defaults to `"Components"`.
+
+```tsx
+import { Puck, legacySideBarPlugin } from "@puckeditor/core";
+
+const legacySideBar = legacySideBarPlugin({
+  componentsLabel: "Components",
+});
+
+export function Editor() {
+  return <Puck plugins={[legacySideBar]} />;
+}
+```
+
+### `outlineLabel`
+
+Title shown above the outline section. Defaults to `"Outline"`.
+
+```tsx
+import { Puck, legacySideBarPlugin } from "@puckeditor/core";
+
+const legacySideBar = legacySideBarPlugin({
+  outlineLabel: "Layers",
+});
+
+export function Editor() {
+  return <Puck plugins={[legacySideBar]} />;
+}
+```

--- a/apps/docs/pages/docs/api-reference/plugins/outline-plugin.mdx
+++ b/apps/docs/pages/docs/api-reference/plugins/outline-plugin.mdx
@@ -20,4 +20,42 @@ export function Editor() {
 
 ## Params
 
-This plugin does not accept any params.
+| Param             | Example            | Type      | Status |
+| ----------------- | ------------------ | --------- | ------ |
+| [`icon`](#icon)   | `icon: <Layers />` | ReactNode | -      |
+| [`label`](#label) | `label: "Outline"` | String    | -      |
+
+## Optional params
+
+### `icon`
+
+React node displayed alongside `label` in the plugin rail. Defaults to a layers icon.
+
+```tsx
+import { Puck, outlinePlugin } from "@puckeditor/core";
+import { ListTree } from "lucide-react";
+
+const outline = outlinePlugin({
+  icon: <ListTree />,
+});
+
+export function Editor() {
+  return <Puck plugins={[outline]} />;
+}
+```
+
+### `label`
+
+Label shown in the plugin rail. Defaults to `"Outline"`.
+
+```tsx
+import { Puck, outlinePlugin } from "@puckeditor/core";
+
+const outline = outlinePlugin({
+  label: "Layers",
+});
+
+export function Editor() {
+  return <Puck plugins={[outline]} />;
+}
+```

--- a/apps/docs/pages/docs/api-reference/puck-api.mdx
+++ b/apps/docs/pages/docs/api-reference/puck-api.mdx
@@ -20,6 +20,7 @@ import { Callout } from "nextra/components";
 | Param                                                             | Example                                            | Type                                                           |
 | ----------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
 | [`appState`](#appstate)                                           | `{ data: {}, ui: {} }`                             | [AppState](/docs/api-reference/data-model/app-state)           |
+| [`dictionary`](#dictionary)                                       | `{ "header-publish": "Publish" }`                  | [Dictionary](/docs/api-reference/dictionary)                   |
 | [`dispatch`](#dispatchaction)                                     | `(action: PuckAction) => void`                     | Function                                                       |
 | [`getItemBySelector`](#getitembyselectorselector)                 | `() => ({ type: "Heading", props: {} })`           | Function                                                       |
 | [`getItemById`](#getitembyidid)                                   | `() => ({ type: "Heading", props: {} })`           | Function                                                       |
@@ -39,6 +40,10 @@ The current [application state](/docs/api-reference/data-model/app-state) for th
 console.log(appState.data);
 // { content: [], root: {}, zones: {} }
 ```
+
+### `dictionary`
+
+The [`dictionary`](/docs/api-reference/dictionary) object passed to [`<Puck>`](/docs/api-reference/components/puck#dictionary).
 
 ### `dispatch(action)`
 

--- a/apps/docs/pages/docs/integrating-puck/_meta.js
+++ b/apps/docs/pages/docs/integrating-puck/_meta.js
@@ -11,6 +11,7 @@ const menu = {
   "data-migration": {},
   styling: {},
   viewports: {},
+  localization: {},
   "feature-toggling": {},
 };
 

--- a/apps/docs/pages/docs/integrating-puck/localization.mdx
+++ b/apps/docs/pages/docs/integrating-puck/localization.mdx
@@ -1,0 +1,228 @@
+# Localization
+
+Puck's default UI uses US English. Use the [`dictionary`](/docs/api-reference/dictionary) prop to translate or reword Puck-owned strings.
+
+See the [Dictionary API reference](/docs/api-reference/dictionary) for the full list of strings and their defaults.
+
+## Translating Puck strings
+
+To translate strings, provide a dictionary object with the keys you want to change and their corresponding translations.
+
+```tsx showLineNumbers copy {6-10}
+import { Puck } from "@puckeditor/core";
+
+export function Editor() {
+  return (
+    <Puck
+      dictionary={{
+        "header-publish": "Publicar", // "Publish" button
+        "field-richtext-bold": "Negrita", // "Bold" rich text control
+        "viewport-switch": "Cambiar a {label}", // Viewport tooltip
+      }}
+      config={config}
+      data={data}
+    />
+  );
+}
+```
+
+## Switching languages at runtime
+
+Puck reacts to any changes in the `dictionary` prop, so you can swap the object at runtime to change the language of the UI.
+
+```tsx {10,14,17} showLineNumbers copy
+import { useState } from "react";
+import { Puck } from "@puckeditor/core";
+
+const dictionaries = {
+  en: {},
+  es: { "header-publish": "Publicar" },
+};
+
+export function Editor() {
+  const [locale, setLocale] = useState<"en" | "es">("en");
+
+  return (
+    <>
+      <button onClick={() => setLocale(locale === "en" ? "es" : "en")}>
+        Toggle language
+      </button>
+      <Puck dictionary={dictionaries[locale]} config={config} data={data} />
+    </>
+  );
+}
+```
+
+If you already use a library like [`react-i18next`](https://react.i18next.com/) or [`next-intl`](https://next-intl.dev/), resolve your strings into a plain object and feed that object into `dictionary`.
+
+```tsx showLineNumbers copy {7-13}
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export function Editor() {
+  const { t } = useTranslation();
+
+  const dictionary = useMemo(
+    () => ({
+      "header-publish": t("header-publish"),
+      "field-richtext-bold": t("field-richtext-bold"),
+    }),
+    [t]
+  );
+
+  return <Puck dictionary={dictionary} config={config} data={data} />;
+}
+```
+
+## Translating user-defined labels
+
+The dictionary only covers strings owned by the editor. Labels defined by your app should be translated where they are configured:
+
+- Custom plugin labels via the plugin [`label`](/docs/api-reference/plugin#label)
+- Viewport labels via the [`viewports.label`](/docs/api-reference/components/puck#label) prop
+- Component labels, root label, category titles and field labels via the [`config`](/docs/api-reference/components/puck#config) prop
+
+### Plugins
+
+Your own plugins define their own [`label`](/docs/api-reference/plugin#label); translate it before passing the plugin to Puck.
+
+```tsx showLineNumbers copy
+import { useMemo } from "react";
+import { Puck } from "@puckeditor/core";
+
+export function Editor({ locale }) {
+  const labels = translations[locale];
+
+  const plugins = useMemo(
+    () => [
+      {
+        name: "my-plugin",
+        icon: <SomeIcon />,
+        label: labels.plugins.myPlugin,
+        render: () => <MyPanel />,
+      },
+    ],
+    [labels]
+  );
+
+  return <Puck config={config} data={data} plugins={plugins} />;
+}
+```
+
+### Viewports
+
+Viewport names are labels in the [`viewports`](/docs/api-reference/components/puck#viewports) prop.
+
+```tsx showLineNumbers copy
+import { useMemo } from "react";
+import { Puck, type Viewports } from "@puckeditor/core";
+
+export function Editor({ locale }) {
+  const labels = translations[locale];
+
+  const viewports: Viewports = useMemo(
+    () => [
+      { width: 360, icon: "Smartphone", label: labels.viewports.small },
+      { width: 768, icon: "Tablet", label: labels.viewports.medium },
+      { width: 1280, icon: "Monitor", label: labels.viewports.large },
+    ],
+    [labels]
+  );
+
+  return <Puck config={config} data={data} viewports={viewports} />;
+}
+```
+
+### Config
+
+Component labels, root label, category titles and field labels come from your [`config`](/docs/api-reference/components/puck#config) prop. Update the config when the locale changes, in the same way you update the dictionary.
+
+```tsx showLineNumbers copy
+import { useMemo } from "react";
+import { Puck } from "@puckeditor/core";
+
+export function Editor() {
+  const labels = translations["en"];
+
+  const localizedConfig = useMemo(
+    () => {
+      components: {
+        HeadingBlock: {
+          label: labels.components.HeadingBlock,
+          fields: {
+            title: { label: labels.fields.title },
+          },
+          render: (props) => <h1>{props.title}</h1>,
+        },
+      }
+    },
+    [labels]
+  );
+
+  return <Puck config={localizedConfig} data={data} />;
+}
+```
+
+## Interpolating values
+
+Some messages have dynamic values that can be interpolated into the string.
+
+Use `{key}` in the string to interpolate a value supplied by Puck.
+
+```tsx
+// Interpolates the viewport `label` value into the string.
+<Puck dictionary={{ "viewport-switch": "Cambiar a {label}" }} />
+```
+
+See the [Dictionary API reference](/docs/api-reference/dictionary) for the full list of strings that support interpolation and their corresponding keys.
+
+## Hiding a string
+
+Set a key to an empty string to render nothing for that message.
+
+```tsx
+// Hides the page label entirely.
+<Puck dictionary={{ "label-page": "" }} />
+```
+
+## Custom strings
+
+Puck supports adding your own keys to the dictionary to use them through the [internal Puck API](/docs/api-reference/puck-api#dictionary).
+
+```tsx showLineNumbers copy
+import { Puck, createUsePuck } from "@puckeditor/core";
+
+const usePuck = createUsePuck();
+
+const HeaderActions = ({ children }) => {
+  const savedMsg = usePuck((s) => s.dictionary["saved-state"]);
+
+  return (
+    <div>
+      <span>{savedMsg}</span>
+      {children}
+    </div>
+  );
+};
+
+export function Editor() {
+  return (
+    <Puck
+      dictionary={{ "saved-state": "Saved" }}
+      overrides={{
+        fieldTypes: {
+          headerActions: { render: HeaderActions },
+        },
+      }}
+      config={config}
+      data={data}
+    />
+  );
+}
+```
+
+## Further reading
+
+- [`Dictionary` API reference](/docs/api-reference/dictionary)
+- [`dictionary` prop](/docs/api-reference/components/puck#dictionary)
+- [`PuckApi.dictionary`](/docs/api-reference/puck-api#dictionary)

--- a/packages/core/components/AutoField/FieldLabel.tsx
+++ b/packages/core/components/AutoField/FieldLabel.tsx
@@ -5,6 +5,7 @@ import styles from "./styles.module.css";
 import { ReactNode, useMemo } from "react";
 import { Lock } from "lucide-react";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("Input", styles);
 
@@ -24,6 +25,8 @@ export const FieldLabel = ({
   className?: string;
 }) => {
   const El = el;
+  const readOnlyLabel = useMessage("field-readonly");
+
   return (
     <El className={className}>
       <div className={getClassName("label")}>
@@ -31,7 +34,7 @@ export const FieldLabel = ({
         {label}
 
         {readOnly && (
-          <div className={getClassName("disabledIcon")} title="Read-only">
+          <div className={getClassName("disabledIcon")} title={readOnlyLabel}>
             <Lock size="12" />
           </div>
         )}

--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -30,6 +30,7 @@ import { defaultSlots } from "../../../../lib/data/default-slots";
 import { getDeep } from "../../../../lib/data/get-deep";
 import { SubField } from "../../subfield";
 import { setDeep } from "../../../../lib/data/set-deep";
+import { useMessage } from "../../../../lib/use-message";
 
 const getClassName = getClassNameFactory("ArrayField", styles);
 const getClassNameItem = getClassNameFactory("ArrayFieldItem", styles);
@@ -50,13 +51,17 @@ const ItemSummaryInner = ({
     return getDeep(s, path);
   });
 
+  const fallbackSummary = useMessage("field-arrayitem-summary", {
+    index: originalIndex,
+  });
+
   const itemSummary = useMemo(() => {
     if (data && field.getItemSummary) {
       return field.getItemSummary(data, index);
     }
 
-    return `Item #${originalIndex}`;
-  }, [data, field, originalIndex, index]);
+    return fallbackSummary;
+  }, [data, field, originalIndex, index, fallbackSummary]);
 
   return itemSummary;
 };
@@ -350,6 +355,9 @@ export const ArrayField = ({
     setUi(mapArrayStateToUi(newArrayState), false);
   }, [numItems]);
 
+  const duplicateLabel = useMessage("field-arrayitem-duplicate");
+  const deleteLabel = useMessage("field-arrayitem-delete");
+
   if (field.type !== "array" || !field.arrayFields) {
     return null;
   }
@@ -485,7 +493,7 @@ export const ArrayField = ({
 
                               updateValue(existingValue);
                             }}
-                            title="Duplicate"
+                            title={duplicateLabel}
                           >
                             <Copy size={16} />
                           </IconButton>
@@ -507,7 +515,7 @@ export const ArrayField = ({
 
                               updateValue(existingValue);
                             }}
-                            title="Delete"
+                            title={deleteLabel}
                           >
                             <Trash size={16} />
                           </IconButton>

--- a/packages/core/components/AutoField/fields/ExternalField/index.tsx
+++ b/packages/core/components/AutoField/fields/ExternalField/index.tsx
@@ -7,6 +7,7 @@ import type {
 import { ExternalInput } from "../../../ExternalInput";
 import { Link } from "lucide-react";
 import { useDeepField } from "../../lib/use-deep-field";
+import { useMessage } from "../../../../lib/use-message";
 
 export const ExternalField = ({
   field,
@@ -23,6 +24,8 @@ export const ExternalField = ({
   // DEPRECATED
   const validField = field as ExternalFieldType;
   const deprecatedField = field as ExternalFieldWithAdaptor;
+
+  const selectDataLabel = useMessage("field-external-selectdata");
 
   useEffect(() => {
     if (deprecatedField.adaptor) {
@@ -50,7 +53,7 @@ export const ExternalField = ({
 
           placeholder: deprecatedField.adaptor?.name
             ? `Select from ${deprecatedField.adaptor.name}`
-            : validField.placeholder || "Select data",
+            : validField.placeholder || selectDataLabel,
           mapProp: deprecatedField.adaptor?.mapProp || validField.mapProp,
           mapRow: validField.mapRow,
           fetchList: deprecatedField.adaptor?.fetchList

--- a/packages/core/components/ComponentList/index.tsx
+++ b/packages/core/components/ComponentList/index.tsx
@@ -2,6 +2,7 @@ import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { ReactNode, useEffect } from "react";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { Drawer } from "../Drawer";
 
@@ -56,6 +57,13 @@ const ComponentList = ({
 
   const contentId = `puck-drawer-category-${id}`;
 
+  const collapseTitle = useMessage("drawer-category-collapse", {
+    title: title ?? "",
+  });
+  const expandTitle = useMessage("drawer-category-expand", {
+    title: title ?? "",
+  });
+
   return (
     <div className={getClassName({ isExpanded: expanded })}>
       {title && (
@@ -75,11 +83,7 @@ const ComponentList = ({
               },
             })
           }
-          title={
-            expanded
-              ? `Collapse${title ? ` ${title}` : ""}`
-              : `Expand${title ? ` ${title}` : ""}`
-          }
+          title={expanded ? collapseTitle : expandTitle}
         >
           <div>{title}</div>
           <div className={getClassName("titleIcon")}>

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -37,6 +37,7 @@ import { useOnDragFinished } from "../../lib/dnd/use-on-drag-finished";
 import { LoadedRichTextMenu } from "../RichTextMenu";
 import type { NodeHandle } from "../../store/slices/nodes";
 import { assignRefs } from "../../lib/assign-refs";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("DraggableComponent", styles);
 
@@ -707,15 +708,19 @@ export const DraggableComponent = ({
     setDragAxis(autoDragAxis);
   }, [ref, userDragAxis, autoDragAxis]);
 
+  const selectParentLabel = useMessage("action-selectparent");
+  const duplicateLabel = useMessage("action-duplicate");
+  const deleteLabel = useMessage("action-delete");
+
   const parentAction = useMemo(
     () =>
       ctx?.areaId &&
       ctx?.areaId !== "root" && (
-        <ActionBar.Action onClick={onSelectParent} label="Select parent">
+        <ActionBar.Action onClick={onSelectParent} label={selectParentLabel}>
           <CornerLeftUp size={16} />
         </ActionBar.Action>
       ),
-    [ctx?.areaId]
+    [ctx?.areaId, selectParentLabel]
   );
 
   const nextContextValue = useMemo<DropZoneContext>(
@@ -799,12 +804,15 @@ export const DraggableComponent = ({
                   )}
 
                   {permissions.duplicate && (
-                    <ActionBar.Action onClick={onDuplicate} label="Duplicate">
+                    <ActionBar.Action
+                      onClick={onDuplicate}
+                      label={duplicateLabel}
+                    >
                       <Copy className={getClassName("actionsAction")} />
                     </ActionBar.Action>
                   )}
                   {permissions.delete && (
-                    <ActionBar.Action onClick={onDelete} label="Delete">
+                    <ActionBar.Action onClick={onDelete} label={deleteLabel}>
                       <Trash className={getClassName("actionsAction")} />
                     </ActionBar.Action>
                   )}

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -47,6 +47,7 @@ import { useSlots } from "../../lib/use-slots";
 import { ContextSlotRender, SlotRenderPure } from "../SlotRender";
 import { expandNode } from "../../lib/data/flatten-node";
 import { useFieldTransformsTracked } from "../../lib/field-transforms/use-field-transforms-tracked";
+import { useMessage } from "../../lib/use-message";
 import { getInlineTextTransform } from "../../lib/field-transforms/default-transforms/inline-text-transform";
 import { getSlotTransform } from "../../lib/field-transforms/default-transforms/slot-transform";
 import { getRichTextTransform } from "../../lib/field-transforms/default-transforms/rich-text-transform";
@@ -180,7 +181,12 @@ const DropZoneChild = ({
     (s) => s.selectedItem?.props.id === componentId || false
   );
 
-  let label = componentConfig?.label ?? item?.type.toString() ?? "Component";
+  const componentLabel = useMessage("label-component");
+  const noConfigMessage = useMessage("canvas-noconfig", {
+    type: item?.type?.toString() ?? "",
+  });
+
+  let label = componentConfig?.label ?? item?.type.toString() ?? componentLabel;
 
   const defaultsProps = useMemo(
     () => ({
@@ -231,7 +237,7 @@ const DropZoneChild = ({
     ? componentConfig.render
     : () => (
         <div style={{ padding: 48, textAlign: "center" }}>
-          No configuration for {item.type}
+          {noConfigMessage}
         </div>
       );
 

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -13,11 +13,23 @@ import { Modal } from "../Modal";
 import { Heading } from "../Heading";
 import { Loader } from "../Loader";
 import { Button } from "../Button";
-import { AutoField, AutoFieldPrivate, FieldLabel } from "../AutoField";
+import { AutoField, FieldLabel } from "../AutoField";
 import { IconButton } from "../IconButton";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("ExternalInput", styles);
 const getClassNameModal = getClassNameFactory("ExternalInputModal", styles);
+
+const DefaultFooter = ({ count }: { count: number }) => {
+  const singular = useMessage("field-external-result-singular", { count });
+  const plural = useMessage("field-external-result-plural", { count });
+
+  return (
+    <span className={getClassNameModal("footer")}>
+      {count === 1 ? singular : plural}
+    </span>
+  );
+};
 
 const dataCache: Record<string, any> = {};
 
@@ -107,9 +119,7 @@ export const ExternalInput = ({
       field.renderFooter ? (
         field.renderFooter(props)
       ) : (
-        <span className={getClassNameModal("footer")}>
-          {props.items.length} result{props.items.length === 1 ? "" : "s"}
-        </span>
+        <DefaultFooter count={props.items.length} />
       ),
     [field.renderFooter]
   );
@@ -117,6 +127,11 @@ export const ExternalInput = ({
   useEffect(() => {
     search(searchQuery, filters);
   }, []);
+
+  const externalItemLabel = useMessage("field-external-item");
+  const searchLabel = useMessage("field-external-search");
+  const toggleFiltersLabel = useMessage("field-external-togglefilters");
+  const selectDataLabel = useMessage("field-external-selectdata");
 
   return (
     <div
@@ -139,7 +154,7 @@ export const ExternalInput = ({
             field.getItemSummary ? (
               field.getItemSummary(value)
             ) : (
-              "External item"
+              externalItemLabel
             )
           ) : (
             <>
@@ -180,7 +195,7 @@ export const ExternalInput = ({
               <div className={getClassNameModal("searchForm")}>
                 <label className={getClassNameModal("search")}>
                   <span className={getClassNameModal("searchIconText")}>
-                    Search
+                    {searchLabel}
                   </span>
                   <div className={getClassNameModal("searchIcon")}>
                     <Search size="18" />
@@ -199,13 +214,13 @@ export const ExternalInput = ({
                 </label>
                 <div className={getClassNameModal("searchActions")}>
                   <Button type="submit" loading={isLoading} fullWidth>
-                    Search
+                    {searchLabel}
                   </Button>
                   {hasFilterFields && (
                     <div className={getClassNameModal("searchActionIcon")}>
                       <IconButton
                         type="button"
-                        title="Toggle filters"
+                        title={toggleFiltersLabel}
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
@@ -220,7 +235,7 @@ export const ExternalInput = ({
               </div>
             ) : (
               <Heading rank="2" size="xs">
-                {field.placeholder || "Select data"}
+                {field.placeholder || selectDataLabel}
               </Heading>
             )}
           </div>

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import { ZoneStoreContext } from "../DropZone/context";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 import { useContextStore } from "../../lib/use-context-store";
 import { NodeIndex, ZoneIndex } from "../../types/Internal";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -83,6 +84,7 @@ const buildLayerNode = ({
   zoneCompound,
   zones,
   zonesByParent,
+  componentFallbackLabel = "Component",
 }: {
   config: Config;
   itemId: string;
@@ -91,9 +93,11 @@ const buildLayerNode = ({
   zoneCompound: string;
   zones: ZoneIndex;
   zonesByParent: Record<string, string[]>;
+  componentFallbackLabel?: string;
 }): LayerNodeTree => {
   const nodeData = nodes[itemId];
-  const componentType = nodeData?.data.type?.toString() || "Component";
+  const componentType =
+    nodeData?.data.type?.toString() || componentFallbackLabel;
   const label = config.components[componentType]?.label ?? componentType;
   const childZoneCompounds = zonesByParent[itemId] || [];
 
@@ -105,6 +109,7 @@ const buildLayerNode = ({
         zoneCompound: childZoneCompound,
         zones,
         zonesByParent,
+        componentFallbackLabel,
       })
     ),
     componentType,
@@ -122,6 +127,7 @@ export const buildLayerTree = ({
   zoneCompound,
   zones,
   zonesByParent = getZonesByParent(zones),
+  componentFallbackLabel = "Component",
 }: {
   config: Config;
   label?: string;
@@ -129,6 +135,7 @@ export const buildLayerTree = ({
   zoneCompound: string;
   zones: ZoneIndex;
   zonesByParent?: Record<string, string[]>;
+  componentFallbackLabel?: string;
 }): LayerZoneTree => {
   const contentIds = zones[zoneCompound]?.contentIds ?? [];
 
@@ -142,6 +149,7 @@ export const buildLayerTree = ({
         zoneCompound,
         zones,
         zonesByParent,
+        componentFallbackLabel,
       })
     ),
     label: getZoneLabel(zoneCompound, nodes, config, label),
@@ -204,6 +212,9 @@ const Layer = forwardRef(function Layer(
   );
   const containsZone = node.childZones.length > 0;
 
+  const collapseLabel = useMessage("outline-collapse");
+  const expandLabel = useMessage("outline-expand");
+
   const setItemSelector = useCallback(
     (itemSelector: ItemSelector | null) => {
       dispatch({ type: "setUi", ui: { itemSelector } });
@@ -254,7 +265,7 @@ const Layer = forwardRef(function Layer(
           {containsZone && (
             <div
               className={getClassNameLayer("chevron")}
-              title={isSelected ? "Collapse" : "Expand"}
+              title={isSelected ? collapseLabel : expandLabel}
             >
               <ChevronDown size="12" />
             </div>
@@ -345,10 +356,12 @@ const StaticLayerTreeItems = ({
   selectedPathIds: Set<string>;
   tree: LayerZoneTree;
 }) => {
+  const noItemsLabel = useMessage("outline-empty");
+
   return (
     <ul className={getClassName()}>
       {tree.items.length === 0 && (
-        <div className={getClassName("helper")}>No items</div>
+        <div className={getClassName("helper")}>{noItemsLabel}</div>
       )}
       {tree.items.map((node) => (
         <Layer
@@ -377,6 +390,7 @@ const VirtualizedLayerTreeItems = ({
   tree: LayerZoneTree;
 }) => {
   const listRef = useRef<HTMLUListElement | null>(null);
+  const noItemsLabel = useMessage("outline-empty");
   const virtualizer = useVirtualizer({
     count: tree.items.length,
     estimateSize: (index) => getEstimatedRowHeight(tree.items[index].itemId),
@@ -448,7 +462,7 @@ const VirtualizedLayerTreeItems = ({
   return (
     <ul className={getClassName()} ref={listRef}>
       {tree.items.length === 0 && (
-        <div className={getClassName("helper")}>No items</div>
+        <div className={getClassName("helper")}>{noItemsLabel}</div>
       )}
       {renderedItems}
     </ul>

--- a/packages/core/components/Loader/index.tsx
+++ b/packages/core/components/Loader/index.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import { getClassNameFactory } from "../../lib";
 import styles from "./styles.module.css";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("Loader", styles);
 
@@ -12,6 +13,8 @@ export const Loader = ({
   color?: string;
   size?: number;
 } & JSX.IntrinsicAttributes) => {
+  const loadingLabel = useMessage("loader-loading");
+
   return (
     <span
       className={getClassName()}
@@ -20,7 +23,7 @@ export const Loader = ({
         height: size,
         color,
       }}
-      aria-label="loading"
+      aria-label={loadingLabel}
       {...props}
     />
   );

--- a/packages/core/components/MenuBar/index.tsx
+++ b/packages/core/components/MenuBar/index.tsx
@@ -8,6 +8,7 @@ import type { Data } from "../../types";
 
 import styles from "./styles.module.css";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("MenuBar", styles);
 
@@ -26,6 +27,9 @@ export function MenuBar<UserData extends Data>({
   const forward = useAppStore((s) => s.history.forward);
   const hasFuture = useAppStore((s) => s.history.hasFuture());
   const hasPast = useAppStore((s) => s.history.hasPast());
+
+  const undoLabel = useMessage("header-undo");
+  const redoLabel = useMessage("header-redo");
 
   return (
     <div
@@ -48,7 +52,7 @@ export function MenuBar<UserData extends Data>({
         <div className={getClassName("history")}>
           <IconButton
             type="button"
-            title="undo"
+            title={undoLabel}
             disabled={!hasPast}
             onClick={back}
           >
@@ -56,7 +60,7 @@ export function MenuBar<UserData extends Data>({
           </IconButton>
           <IconButton
             type="button"
-            title="redo"
+            title={redoLabel}
             disabled={!hasFuture}
             onClick={forward}
           >

--- a/packages/core/components/Puck/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/core/components/Puck/__tests__/__snapshots__/index.tsx.snap
@@ -18,6 +18,7 @@ exports[`Puck should generate the correct state on mount 1`] = `
       "render": [Function],
     },
   },
+  "dictionary": {},
   "dispatch": [Function],
   "fieldTransforms": {},
   "fields": {

--- a/packages/core/components/Puck/__tests__/dictionary.spec.tsx
+++ b/packages/core/components/Puck/__tests__/dictionary.spec.tsx
@@ -1,0 +1,257 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Config } from "../../../types";
+
+jest.mock("../styles.module.css");
+jest.mock("@dnd-kit/react");
+
+// Default to desktop so the header (and its Publish button) renders.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+const originalConsoleError = console.error;
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation((...args: unknown[]) => {
+    if (
+      args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+    ) {
+      return;
+    }
+
+    originalConsoleError(...(args as Parameters<typeof console.error>));
+  });
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+import { Puck } from "../index";
+
+const config: Config = {
+  components: {},
+};
+
+// Flush any queued state updates.
+const flush = () => act(async () => {});
+
+afterEach(() => cleanup());
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+describe("Puck dictionary prop", () => {
+  it("renders the default messages when no dictionary is provided", async () => {
+    render(<Puck config={config} data={{}} iframe={{ enabled: false }} />);
+
+    await flush();
+
+    // "Publish" appears in both the header and the menu bar.
+    expect(screen.getAllByText("Publish").length).toBeGreaterThan(0);
+  });
+
+  it("overrides a provided key and falls back for unprovided keys", async () => {
+    render(
+      <Puck
+        config={config}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{ "header-publish": "Publicar" }}
+      />
+    );
+
+    await flush();
+
+    // The provided key is overridden...
+    expect(screen.getAllByText("Publicar").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Publish")).not.toBeInTheDocument();
+
+    // ...and an unprovided key still shows its default.
+    expect(screen.getByTitle("Toggle left sidebar")).toBeInTheDocument();
+  });
+
+  it("reacts to a changed dictionary prop", async () => {
+    const { rerender } = render(
+      <Puck
+        config={config}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{ "header-publish": "Publicar" }}
+      />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Publicar").length).toBeGreaterThan(0);
+
+    rerender(
+      <Puck
+        config={config}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{ "header-publish": "Veröffentlichen" }}
+      />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Veröffentlichen").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Publicar")).not.toBeInTheDocument();
+  });
+
+  it("honors an explicit empty string instead of falling back (?? not falsy)", async () => {
+    const { rerender } = render(
+      <Puck
+        config={config}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{ "header-publish": "" }}
+      />
+    );
+
+    await flush();
+
+    // The empty string is used, so the default text is NOT rendered...
+    expect(screen.queryByText("Publish")).not.toBeInTheDocument();
+    // ...but the rest of the chrome still renders (an unprovided default key).
+    expect(screen.getByTitle("Toggle left sidebar")).toBeInTheDocument();
+
+    // An omitted/undefined key falls back to the default.
+    rerender(
+      <Puck
+        config={config}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{}}
+      />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Publish").length).toBeGreaterThan(0);
+  });
+
+  it("re-resolves field labels when the config prop changes, in both directions", async () => {
+    // Simulates config-level localization (e.g. the demo's translateConfig):
+    // the same config shape with different field labels per language.
+    const makeConfig = (labels: { title: string; links: string }): Config => ({
+      root: {
+        render: ({ children }: any) => <div>Root{children}</div>,
+        fields: {
+          title: { type: "text", label: labels.title },
+          links: {
+            type: "array",
+            label: labels.links,
+            arrayFields: { url: { type: "text" } },
+          },
+        },
+      },
+      components: {},
+    });
+
+    const en = { title: "Title", links: "Links" };
+    const es = { title: "Título", links: "Enlaces" };
+
+    const { rerender } = render(
+      <Puck config={makeConfig(en)} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    // The fields panel renders in both the desktop sidebar and the mobile
+    // fields tab, so labels can legitimately appear more than once.
+    expect(screen.getAllByText("Title").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Links").length).toBeGreaterThan(0);
+
+    rerender(
+      <Puck config={makeConfig(es)} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Título").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Enlaces").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Title")).toHaveLength(0);
+
+    // Swapping BACK must also update — this used to get stuck because the
+    // fields slice cached the resolved fields and never watched the config.
+    rerender(
+      <Puck config={makeConfig(en)} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Title").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Links").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Título")).toHaveLength(0);
+  });
+
+  it("interpolates {placeholder} tokens in messages", async () => {
+    // The component-list category accordion title is "Collapse {title}".
+    const categoryConfig: Config = {
+      components: { Heading: { render: () => <div>Heading</div> } },
+      categories: {
+        typography: { title: "Typography", components: ["Heading"] },
+      },
+    };
+
+    const { rerender } = render(
+      <Puck config={categoryConfig} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    // Default template "Collapse {title}" interpolated with the category title.
+    expect(screen.getByTitle("Collapse Typography")).toBeInTheDocument();
+
+    // An override keeps interpolating the {title} token.
+    rerender(
+      <Puck
+        config={categoryConfig}
+        data={{}}
+        iframe={{ enabled: false }}
+        dictionary={{ "drawer-category-collapse": "Cerrar {title}" }}
+      />
+    );
+
+    await flush();
+
+    expect(screen.getByTitle("Cerrar Typography")).toBeInTheDocument();
+  });
+});

--- a/packages/core/components/Puck/__tests__/resolve-fields-config.spec.tsx
+++ b/packages/core/components/Puck/__tests__/resolve-fields-config.spec.tsx
@@ -1,0 +1,211 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Config } from "../../../types";
+
+jest.mock("../styles.module.css");
+jest.mock("@dnd-kit/react");
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+const originalConsoleError = console.error;
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation((...args: unknown[]) => {
+    if (
+      args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+    ) {
+      return;
+    }
+
+    originalConsoleError(...(args as Parameters<typeof console.error>));
+  });
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+import { Puck } from "../index";
+
+const flush = () => act(async () => {});
+
+afterEach(() => cleanup());
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+describe("resolved fields react to config changes", () => {
+  it("re-resolves resolveFields output when swapping back to the original config object", async () => {
+    // Mirrors config-level localization: a stable module-level config for the
+    // default language, and a translated copy created per swap. Swapping BACK
+    // reuses the original object identity — this used to get stuck.
+    const rootFields: any = {
+      myText: { type: "text" },
+      items: { type: "array", arrayFields: { url: { type: "text" } } },
+    };
+
+    const baseConfig: Config = {
+      root: {
+        fields: rootFields,
+        // withLayout-style resolver: closure over the ORIGINAL fields
+        resolveFields: (() => ({ ...rootFields })) as any,
+        render: ({ children }: any) => <div>Root{children}</div>,
+      },
+      components: {},
+    };
+
+    const translations: Record<string, string> = {
+      myText: "Texto",
+      items: "Elementos",
+    };
+
+    const translateConfig = (base: Config): Config => {
+      const translate = (fields: Record<string, any>) =>
+        Object.fromEntries(
+          Object.entries(fields).map(([key, field]) => [
+            key,
+            translations[key] ? { ...field, label: translations[key] } : field,
+          ])
+        );
+
+      const original = (base.root as any).resolveFields;
+
+      return {
+        ...base,
+        root: {
+          ...base.root,
+          fields: translate((base.root as any).fields),
+          resolveFields: (async (data: any, params: any) =>
+            translate(await original(data, params))) as any,
+        } as any,
+      };
+    };
+
+    const { rerender } = render(
+      <Puck config={baseConfig} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("myText").length).toBeGreaterThan(0);
+
+    rerender(
+      <Puck
+        config={translateConfig(baseConfig)}
+        data={{}}
+        iframe={{ enabled: false }}
+      />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Texto").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("myText")).toHaveLength(0);
+
+    // Swap BACK — same module object identity as at mount
+    rerender(
+      <Puck config={baseConfig} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("myText").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Texto")).toHaveLength(0);
+  });
+
+  it("discards a stale resolveFields run that completes after a config swap", async () => {
+    // The race: a resolveFields run starts under config A, the config swaps to
+    // B and re-resolves, then A's slow async resolver completes LAST. Its
+    // result must be discarded — otherwise it clobbers B's fields.
+    const releaseStale: Array<() => void> = [];
+
+    const staleConfig: Config = {
+      root: {
+        fields: { myText: { type: "text", label: "Texto" } },
+        resolveFields: (async (_: any, { fields }: any) => {
+          // Held open until the test releases it
+          await new Promise<void>((resolve) => releaseStale.push(resolve));
+          return fields;
+        }) as any,
+        render: ({ children }: any) => <div>Root{children}</div>,
+      },
+      components: {},
+    };
+
+    const freshConfig: Config = {
+      root: {
+        fields: { myText: { type: "text", label: "Title" } },
+        resolveFields: (async (_: any, { fields }: any) => fields) as any,
+        render: ({ children }: any) => <div>Root{children}</div>,
+      },
+      components: {},
+    };
+
+    const { rerender } = render(
+      <Puck config={staleConfig} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    // The sync reset already shows the stale config's default label, while its
+    // async resolver is still in flight (gated).
+    expect(screen.getAllByText("Texto").length).toBeGreaterThan(0);
+    expect(releaseStale.length).toBeGreaterThan(0);
+
+    // Swap config while the stale resolver is still pending
+    rerender(
+      <Puck config={freshConfig} data={{}} iframe={{ enabled: false }} />
+    );
+
+    await flush();
+
+    expect(screen.getAllByText("Title").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Texto")).toHaveLength(0);
+
+    // Now let the STALE run complete — it must not clobber the fresh fields
+    await act(async () => {
+      releaseStale.forEach((release) => release());
+    });
+
+    await flush();
+
+    expect(screen.getAllByText("Title").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Texto")).toHaveLength(0);
+  });
+});

--- a/packages/core/components/Puck/components/Header/index.tsx
+++ b/packages/core/components/Puck/components/Header/index.tsx
@@ -15,6 +15,7 @@ import { Config, Overrides, UserGenerics } from "../../../../types";
 import { DefaultOverride } from "../../../DefaultOverride";
 import { usePropsContext } from "../..";
 import { getClassNameFactory } from "../../../../lib";
+import { useMessage } from "../../../../lib/use-message";
 import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("PuckHeader", styles);
@@ -125,6 +126,12 @@ const HeaderInner = <
     [dispatch, leftSideBarVisible, rightSideBarVisible]
   );
 
+  const publishLabel = useMessage("header-publish");
+  const pageLabel = useMessage("label-page");
+  const toggleLeftLabel = useMessage("header-toggle-leftsidebar");
+  const toggleRightLabel = useMessage("header-toggle-rightsidebar");
+  const toggleMenuLabel = useMessage("header-toggle-menubar");
+
   return (
     <CustomHeader
       actions={
@@ -137,7 +144,7 @@ const HeaderInner = <
               }}
               icon={<Globe size="14px" />}
             >
-              Publish
+              {publishLabel}
             </Button>
           </CustomHeaderActions>
         </>
@@ -158,7 +165,7 @@ const HeaderInner = <
                 onClick={() => {
                   toggleSidebars("left");
                 }}
-                title="Toggle left sidebar"
+                title={toggleLeftLabel}
               >
                 <PanelLeft focusable="false" />
               </IconButton>
@@ -169,7 +176,7 @@ const HeaderInner = <
                 onClick={() => {
                   toggleSidebars("right");
                 }}
-                title="Toggle right sidebar"
+                title={toggleRightLabel}
               >
                 <PanelRight focusable="false" />
               </IconButton>
@@ -177,7 +184,7 @@ const HeaderInner = <
           </div>
           <div className={getClassName("title")}>
             <Heading rank="2" size="xs">
-              {headerTitle || rootTitle || "Page"}
+              {headerTitle || rootTitle || pageLabel}
               {headerPath && (
                 <>
                   {" "}
@@ -193,7 +200,7 @@ const HeaderInner = <
                 onClick={() => {
                   return setMenuOpen(!menuOpen);
                 }}
-                title="Toggle menu bar"
+                title={toggleMenuLabel}
               >
                 {menuOpen ? (
                   <ChevronUp focusable="false" />
@@ -216,7 +223,7 @@ const HeaderInner = <
                     }}
                     icon={<Globe size="14px" />}
                   >
-                    Publish
+                    {publishLabel}
                   </Button>
                 </CustomHeaderActions>
               )}

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -12,6 +12,7 @@ import { usePropsContext } from "../..";
 import styles from "./styles.module.css";
 import { useInjectUiCss } from "../../../../lib/use-inject-css";
 import { useAppStore, useAppStoreApi } from "../../../../store";
+import { useMessage } from "../../../../lib/use-message";
 import { DefaultOverride } from "../../../DefaultOverride";
 import { monitorHotkeys, useMonitorHotkeys } from "../../../../lib/use-hotkey";
 import { getFrame } from "../../../../lib/get-frame";
@@ -41,15 +42,16 @@ const useBrowserLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 const FieldSideBar = () => {
+  const pageLabel = useMessage("label-page");
   const title = useAppStore((s) =>
     s.selectedItem
       ? s.config.components[s.selectedItem.type]?.["label"] ??
         s.selectedItem.type.toString()
-      : s.config.root?.label || "Page"
+      : s.config.root?.label
   );
 
   return (
-    <SidebarSection noBorderTop showBreadcrumbs title={title}>
+    <SidebarSection noBorderTop showBreadcrumbs title={title || pageLabel}>
       <Fields />
     </SidebarSection>
   );
@@ -192,11 +194,19 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
     [plugins]
   );
 
+  // Localized labels for the built-in plugin tabs, passed into their factories.
+  const blocksLabel = useMessage("plugin-blocks");
+  const outlineLabel = useMessage("plugin-outline");
+  const fieldsLabel = useMessage("plugin-fields");
+
   const pluginItems = useMemo(() => {
     const details: Record<string, MenuItem & { render: () => ReactElement }> =
       {};
 
-    const defaultPlugins: PluginInternal[] = [blocksPlugin(), outlinePlugin()];
+    const defaultPlugins: PluginInternal[] = [
+      blocksPlugin({ label: blocksLabel }),
+      outlinePlugin({ label: outlineLabel }),
+    ];
 
     const isLegacy = (plugin: PluginInternal) =>
       plugin.name === "legacy-side-bar" ? -1 : 0;
@@ -209,7 +219,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
     ].sort((a, b) => isLegacy(a) - isLegacy(b));
 
     if (!plugins?.some((p) => p.name === "fields")) {
-      combinedPlugins.push(fieldsPlugin());
+      combinedPlugins.push(fieldsPlugin({ label: fieldsLabel }));
     }
 
     combinedPlugins?.forEach((plugin) => {
@@ -249,7 +259,15 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
     });
 
     return details;
-  }, [plugins, currentPlugin, appStoreApi, leftSideBarVisible]);
+  }, [
+    plugins,
+    currentPlugin,
+    appStoreApi,
+    leftSideBarVisible,
+    blocksLabel,
+    outlineLabel,
+    fieldsLabel,
+  ]);
 
   useEffect(() => {
     if (!currentPlugin) {
@@ -265,6 +283,10 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
   const mobilePanelExpanded = useAppStore(
     (s) => s.state.ui.mobilePanelExpanded ?? false
   );
+
+  // Title follows the icon/action: collapse when expanded, expand otherwise.
+  const maximizeLabel = useMessage("layout-maximize");
+  const minimizeLabel = useMessage("layout-minimize");
 
   return (
     <div
@@ -306,7 +328,11 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
                         mobilePanelHeightMode === "toggle" && (
                           <IconButton
                             type="button"
-                            title="maximize"
+                            title={
+                              mobilePanelExpanded
+                                ? minimizeLabel
+                                : maximizeLabel
+                            }
                             onClick={() => {
                               setUi({
                                 mobilePanelExpanded: !mobilePanelExpanded,

--- a/packages/core/components/Puck/components/Outline/index.tsx
+++ b/packages/core/components/Puck/components/Outline/index.tsx
@@ -1,5 +1,6 @@
 import { buildLayerTree, LayerTree } from "../../../LayerTree";
 import { useAppStore } from "../../../../store";
+import { useMessage } from "../../../../lib/use-message";
 import { useMemo } from "react";
 import { findZonesForArea } from "../../../../lib/data/find-zones-for-area";
 import { useShallow } from "zustand/react/shallow";
@@ -10,6 +11,7 @@ export const Outline = () => {
   const nodes = useAppStore((s) => s.state.indexes.nodes);
   const zones = useAppStore((s) => s.state.indexes.zones);
   const selectedId = useAppStore((s) => s.selectedItem?.props.id || null);
+  const componentFallbackLabel = useMessage("label-component");
 
   const rootZones = useAppStore(
     useShallow((s) => findZonesForArea(s.state, "root"))
@@ -34,9 +36,10 @@ export const Outline = () => {
           nodes,
           zoneCompound,
           zones,
+          componentFallbackLabel,
         })
       ),
-    [config, nodes, rootZones, zones]
+    [config, nodes, rootZones, zones, componentFallbackLabel]
   );
 
   const Wrapper = useMemo(() => outlineOverride || "div", [outlineOverride]);

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -28,6 +28,7 @@ import type {
   Metadata,
   AsFieldProps,
   DefaultComponentProps,
+  Dictionary,
 } from "../../types";
 
 import { PuckAction } from "../../reducer";
@@ -88,6 +89,7 @@ type PuckProps<
   };
   initialHistory?: InitialHistory;
   metadata?: Metadata;
+  dictionary?: Dictionary;
   height?: CSSProperties["height"];
   _experimentalFullScreenCanvas?: boolean;
   _experimentalVirtualization?: boolean;
@@ -124,6 +126,7 @@ function PuckProvider<
     iframe: _iframe,
     initialHistory: _initialHistory,
     metadata,
+    dictionary,
     onAction,
     fieldTransforms,
     _experimentalFullScreenCanvas,
@@ -266,6 +269,7 @@ function PuckProvider<
         _experimentalVirtualization: !!_experimentalVirtualization,
         onAction,
         metadata,
+        dictionary: dictionary || {},
         fieldTransforms: loadedFieldTransforms,
       };
     },
@@ -281,6 +285,7 @@ function PuckProvider<
       _experimentalVirtualization,
       onAction,
       metadata,
+      dictionary,
       loadedFieldTransforms,
     ]
   );

--- a/packages/core/components/RichTextMenu/controls/AlignCenter.tsx
+++ b/packages/core/components/RichTextMenu/controls/AlignCenter.tsx
@@ -1,9 +1,11 @@
 import { AlignCenter as AlignCenterIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function AlignCenter() {
   const { editor, editorState } = useControlContext();
+  const alignCenterLabel = useMessage("field-richtext-align-center");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function AlignCenter() {
       }}
       disabled={!editorState?.canAlignCenter}
       active={editorState?.isAlignCenter}
-      title="Align center"
+      title={alignCenterLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/AlignJustify.tsx
+++ b/packages/core/components/RichTextMenu/controls/AlignJustify.tsx
@@ -1,9 +1,11 @@
 import { AlignJustify as AlignJustifyIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function AlignJustify() {
   const { editor, editorState } = useControlContext();
+  const alignJustifyLabel = useMessage("field-richtext-align-justify");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function AlignJustify() {
       }}
       disabled={!editorState?.canAlignJustify}
       active={editorState?.isAlignJustify}
-      title="Justify"
+      title={alignJustifyLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/AlignLeft.tsx
+++ b/packages/core/components/RichTextMenu/controls/AlignLeft.tsx
@@ -1,9 +1,11 @@
 import { AlignLeft as AlignLeftIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function AlignLeft() {
   const { editor, editorState } = useControlContext();
+  const alignLeftLabel = useMessage("field-richtext-align-left");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function AlignLeft() {
       }}
       disabled={!editorState?.canAlignLeft}
       active={editorState?.isAlignLeft}
-      title="Align left"
+      title={alignLeftLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/AlignRight.tsx
+++ b/packages/core/components/RichTextMenu/controls/AlignRight.tsx
@@ -1,9 +1,11 @@
 import { AlignRight as AlignRightIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function AlignRight() {
   const { editor, editorState } = useControlContext();
+  const alignRightLabel = useMessage("field-richtext-align-right");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function AlignRight() {
       }}
       disabled={!editorState?.canAlignRight}
       active={editorState?.isAlignRight}
-      title="Align right"
+      title={alignRightLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/AlignSelect/use-options.ts
+++ b/packages/core/components/RichTextMenu/controls/AlignSelect/use-options.ts
@@ -1,17 +1,30 @@
 import { useMemo } from "react";
 import { AlignCenter, AlignJustify, AlignLeft, AlignRight } from "lucide-react";
 import { RichtextField } from "../../../../types";
+import { useMessage } from "../../../../lib/use-message";
 
-const optionNodes: Record<string, { label: string; icon?: React.FC }> = {
-  left: { label: "Left", icon: AlignLeft },
-  center: { label: "Center", icon: AlignCenter },
-  right: { label: "Right", icon: AlignRight },
-  justify: { label: "Justify", icon: AlignJustify },
+const optionIcons: Record<string, React.FC | undefined> = {
+  left: AlignLeft,
+  center: AlignCenter,
+  right: AlignRight,
+  justify: AlignJustify,
 };
 
 export type AlignDirection = "left" | "center" | "right" | "justify";
 
 export const useAlignOptions = (fieldOptions: RichtextField["options"]) => {
+  const leftString = useMessage("field-richtext-alignselect-left");
+  const centerString = useMessage("field-richtext-alignselect-center");
+  const rightString = useMessage("field-richtext-alignselect-right");
+  const justifyString = useMessage("field-richtext-alignselect-justify");
+
+  const optionLabels: Record<AlignDirection, string> = {
+    left: leftString,
+    center: centerString,
+    right: rightString,
+    justify: justifyString,
+  };
+
   let blockOptions: AlignDirection[] = [];
 
   if (fieldOptions?.textAlign !== false) {
@@ -40,9 +53,9 @@ export const useAlignOptions = (fieldOptions: RichtextField["options"]) => {
     () =>
       blockOptions.map((item) => ({
         value: item,
-        label: optionNodes[item].label,
-        icon: optionNodes[item].icon,
+        label: optionLabels[item],
+        icon: optionIcons[item],
       })),
-    [blockOptions]
+    [blockOptions, optionLabels]
   );
 };

--- a/packages/core/components/RichTextMenu/controls/Blockquote.tsx
+++ b/packages/core/components/RichTextMenu/controls/Blockquote.tsx
@@ -1,9 +1,11 @@
 import { Quote as QuoteIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function Blockquote() {
   const { editor, editorState } = useControlContext();
+  const blockquoteLabel = useMessage("field-richtext-blockquote");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function Blockquote() {
       }}
       disabled={!editorState?.canBlockquote}
       active={editorState?.isBlockquote}
-      title="Blockquote"
+      title={blockquoteLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/Bold.tsx
+++ b/packages/core/components/RichTextMenu/controls/Bold.tsx
@@ -1,9 +1,11 @@
 import { Bold as BoldIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function Bold() {
   const { editor, editorState } = useControlContext();
+  const boldLabel = useMessage("field-richtext-bold");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function Bold() {
       }}
       disabled={!editorState?.canBold}
       active={editorState?.isBold}
-      title="Bold"
+      title={boldLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/BulletList.tsx
+++ b/packages/core/components/RichTextMenu/controls/BulletList.tsx
@@ -1,9 +1,11 @@
 import { List as ListIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function BulletList() {
   const { editor, editorState } = useControlContext();
+  const bulletListLabel = useMessage("field-richtext-list-bullet");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function BulletList() {
       }}
       disabled={!editorState?.canBulletList}
       active={editorState?.isBulletList}
-      title="Bullet list"
+      title={bulletListLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/CodeBlock.tsx
+++ b/packages/core/components/RichTextMenu/controls/CodeBlock.tsx
@@ -1,9 +1,11 @@
 import { SquareCode as SquareCodeIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function CodeBlock() {
   const { editor, editorState } = useControlContext();
+  const codeBlockLabel = useMessage("field-richtext-code-block");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function CodeBlock() {
       }}
       disabled={!editorState?.canCodeBlock}
       active={editorState?.isCodeBlock}
-      title="Code block"
+      title={codeBlockLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/HeadingSelect/use-options.ts
+++ b/packages/core/components/RichTextMenu/controls/HeadingSelect/use-options.ts
@@ -8,19 +8,36 @@ import {
   Heading6,
 } from "lucide-react";
 import { RichtextField } from "../../../../types";
+import { useMessage } from "../../../../lib/use-message";
 
-const optionNodes: Record<string, { label: string; icon?: React.FC }> = {
-  h1: { label: "Heading 1", icon: Heading1 },
-  h2: { label: "Heading 2", icon: Heading2 },
-  h3: { label: "Heading 3", icon: Heading3 },
-  h4: { label: "Heading 4", icon: Heading4 },
-  h5: { label: "Heading 5", icon: Heading5 },
-  h6: { label: "Heading 6", icon: Heading6 },
+const optionIcons: Record<string, React.FC | undefined> = {
+  h1: Heading1,
+  h2: Heading2,
+  h3: Heading3,
+  h4: Heading4,
+  h5: Heading5,
+  h6: Heading6,
 };
 
 export type HeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 export const useHeadingOptions = (fieldOptions: RichtextField["options"]) => {
+  const h1String = useMessage("field-richtext-headingselect-1");
+  const h2String = useMessage("field-richtext-headingselect-2");
+  const h3String = useMessage("field-richtext-headingselect-3");
+  const h4String = useMessage("field-richtext-headingselect-4");
+  const h5String = useMessage("field-richtext-headingselect-5");
+  const h6String = useMessage("field-richtext-headingselect-6");
+
+  const optionLabels: Record<HeadingElement, string> = {
+    h1: h1String,
+    h2: h2String,
+    h3: h3String,
+    h4: h4String,
+    h5: h5String,
+    h6: h6String,
+  };
+
   let blockOptions: HeadingElement[] = [];
 
   if (fieldOptions?.heading !== false) {
@@ -57,9 +74,9 @@ export const useHeadingOptions = (fieldOptions: RichtextField["options"]) => {
     () =>
       blockOptions.map((item) => ({
         value: item,
-        label: optionNodes[item].label,
-        icon: optionNodes[item].icon,
+        label: optionLabels[item],
+        icon: optionIcons[item],
       })),
-    [blockOptions]
+    [blockOptions, optionLabels]
   );
 };

--- a/packages/core/components/RichTextMenu/controls/HorizontalRule.tsx
+++ b/packages/core/components/RichTextMenu/controls/HorizontalRule.tsx
@@ -1,9 +1,11 @@
 import { Minus as MinusIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function HorizontalRule() {
   const { editor, editorState } = useControlContext();
+  const horizontalRuleLabel = useMessage("field-richtext-horizontalrule");
 
   return (
     <Control
@@ -13,7 +15,7 @@ export function HorizontalRule() {
         editor?.chain().focus().setHorizontalRule().run();
       }}
       disabled={!editorState?.canHorizontalRule}
-      title="Horizontal rule"
+      title={horizontalRuleLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/InlineCode.tsx
+++ b/packages/core/components/RichTextMenu/controls/InlineCode.tsx
@@ -1,9 +1,11 @@
 import { Code as CodeIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function InlineCode() {
   const { editor, editorState } = useControlContext();
+  const inlineCodeLabel = useMessage("field-richtext-code-inline");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function InlineCode() {
       }}
       disabled={!editorState?.canInlineCode}
       active={editorState?.isInlineCode}
-      title="Inline code"
+      title={inlineCodeLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/Italic.tsx
+++ b/packages/core/components/RichTextMenu/controls/Italic.tsx
@@ -1,9 +1,11 @@
 import { Italic as ItalicIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function Italic() {
   const { editor, editorState } = useControlContext();
+  const italicLabel = useMessage("field-richtext-italic");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function Italic() {
       }}
       disabled={!editorState?.canItalic}
       active={editorState?.isItalic}
-      title="Italic"
+      title={italicLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/ListSelect/use-options.ts
+++ b/packages/core/components/RichTextMenu/controls/ListSelect/use-options.ts
@@ -1,15 +1,24 @@
 import { useMemo } from "react";
 import { List, ListOrdered } from "lucide-react";
 import { RichtextField } from "../../../../types";
+import { useMessage } from "../../../../lib/use-message";
 
-const optionNodes: Record<string, { label: string; icon?: React.FC }> = {
-  ul: { label: "Bullet list", icon: List },
-  ol: { label: "Numbered list", icon: ListOrdered },
+const optionIcons: Record<string, React.FC | undefined> = {
+  ul: List,
+  ol: ListOrdered,
 };
 
 export type ListElement = "ol" | "ul";
 
 export const useListOptions = (fieldOptions: RichtextField["options"]) => {
+  const ulString = useMessage("field-richtext-listselect-bullet");
+  const olString = useMessage("field-richtext-listselect-ordered");
+
+  const optionLabels: Record<ListElement, string> = {
+    ul: ulString,
+    ol: olString,
+  };
+
   let blockOptions: ListElement[] = [];
 
   if (fieldOptions?.listItem !== false) {
@@ -20,9 +29,9 @@ export const useListOptions = (fieldOptions: RichtextField["options"]) => {
     () =>
       blockOptions.map((item) => ({
         value: item,
-        label: optionNodes[item].label,
-        icon: optionNodes[item].icon,
+        label: optionLabels[item],
+        icon: optionIcons[item],
       })),
-    [blockOptions]
+    [blockOptions, optionLabels]
   );
 };

--- a/packages/core/components/RichTextMenu/controls/OrderedList.tsx
+++ b/packages/core/components/RichTextMenu/controls/OrderedList.tsx
@@ -1,9 +1,11 @@
 import { ListOrdered as ListOrderedIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function OrderedList() {
   const { editor, editorState } = useControlContext();
+  const orderedListLabel = useMessage("field-richtext-list-ordered");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function OrderedList() {
       }}
       disabled={!editorState?.canOrderedList}
       active={editorState?.isOrderedList}
-      title="Ordered list"
+      title={orderedListLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/Strikethrough.tsx
+++ b/packages/core/components/RichTextMenu/controls/Strikethrough.tsx
@@ -1,9 +1,11 @@
 import { Strikethrough as StrikethroughIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function Strikethrough() {
   const { editor, editorState } = useControlContext();
+  const strikethroughLabel = useMessage("field-richtext-strikethrough");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function Strikethrough() {
       }}
       disabled={!editorState?.canStrike}
       active={editorState?.isStrike}
-      title="Strikethrough"
+      title={strikethroughLabel}
     />
   );
 }

--- a/packages/core/components/RichTextMenu/controls/Underline.tsx
+++ b/packages/core/components/RichTextMenu/controls/Underline.tsx
@@ -1,9 +1,11 @@
 import { Underline as UnderlineIcon } from "lucide-react";
 import { Control } from "../components/Control";
+import { useMessage } from "../../../lib/use-message";
 import { useControlContext } from "../lib/use-control-context";
 
 export function Underline() {
   const { editor, editorState } = useControlContext();
+  const underlineLabel = useMessage("field-richtext-underline");
 
   return (
     <Control
@@ -14,7 +16,7 @@ export function Underline() {
       }}
       disabled={!editorState?.canUnderline}
       active={editorState?.isUnderline}
-      title="Underline"
+      title={underlineLabel}
     />
   );
 }

--- a/packages/core/components/Select/index.tsx
+++ b/packages/core/components/Select/index.tsx
@@ -10,6 +10,7 @@ import { ChevronDown } from "lucide-react";
 import { getClassNameFactory } from "../../lib";
 import { IconButton } from "../IconButton";
 import { Action } from "../ActionBar";
+import { useMessage } from "../../lib/use-message";
 
 const getClassName = getClassNameFactory("Select", styles);
 const getItemClassName = getClassNameFactory("SelectItem", styles);
@@ -48,6 +49,7 @@ export const Select = ({
   disabled?: boolean;
 }) => {
   const [open, setOpen] = useState(false);
+  const selectLabel = useMessage("field-richtext-select");
 
   const hasOptions = options.length > 0;
   const isDisabled = disabled || !hasOptions;
@@ -66,7 +68,7 @@ export const Select = ({
       </Action>
     ) : (
       <IconButton
-        title="Select"
+        title={selectLabel}
         active={value !== defaultValue}
         disabled={isDisabled}
       >

--- a/packages/core/components/ViewportControls/index.tsx
+++ b/packages/core/components/ViewportControls/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { IconButton } from "../IconButton";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 import { ReactNode, SyntheticEvent, useEffect, useMemo, useState } from "react";
 import { getClassNameFactory } from "../../lib";
 
@@ -64,6 +65,34 @@ const defaultZoomOptions = [
   { label: "200%", value: 2 },
 ];
 
+const ViewportButton = ({
+  viewport,
+  isActive,
+  onClick,
+}: {
+  viewport: Viewport;
+  isActive: boolean;
+  onClick: (e: SyntheticEvent) => void;
+}) => {
+  // Resolve both unconditionally (rules of hooks), then pick based on label.
+  const switchTitle = useMessage("viewport-switch", {
+    label: viewport.label ?? "",
+  });
+  const switchDefaultTitle = useMessage("viewport-switch-default");
+
+  return (
+    <ActionButton
+      title={viewport.label ? switchTitle : switchDefaultTitle}
+      onClick={onClick}
+      isActive={isActive}
+    >
+      {typeof viewport.icon === "string"
+        ? icons[viewport.icon as keyof typeof icons] || viewport.icon
+        : viewport.icon || icons.Smartphone}
+    </ActionButton>
+  );
+};
+
 export const ViewportControls = ({
   autoZoom,
   zoom,
@@ -84,6 +113,10 @@ export const ViewportControls = ({
     (option) => option.value === autoZoom
   );
 
+  const autoZoomLabel = useMessage("viewport-zoom-auto", {
+    zoom: (autoZoom * 100).toFixed(0),
+  });
+
   const zoomOptions = useMemo(
     () =>
       [
@@ -93,13 +126,13 @@ export const ViewportControls = ({
           : [
               {
                 value: autoZoom,
-                label: `${(autoZoom * 100).toFixed(0)}% (Auto)`,
+                label: autoZoomLabel,
               },
             ]),
       ]
         .filter((a) => a.value <= autoZoom)
         .sort((a, b) => (a.value > b.value ? 1 : -1)),
-    [autoZoom]
+    [autoZoom, autoZoomLabel]
   );
 
   const [activeViewport, setActiveViewport] = useState(
@@ -112,6 +145,10 @@ export const ViewportControls = ({
 
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const zoomOutLabel = useMessage("viewport-zoom-out");
+  const zoomInLabel = useMessage("viewport-zoom-in");
+  const toggleMenuLabel = useMessage("viewport-toggle-menu");
+
   return (
     <div
       className={getClassName({ isExpanded, fullScreen })}
@@ -120,27 +157,19 @@ export const ViewportControls = ({
       <div className={getClassName("actions")}>
         <div className={getClassName("actionsInner")}>
           {viewports.map((viewport, i) => (
-            <ActionButton
+            <ViewportButton
               key={i}
-              title={
-                viewport.label
-                  ? `Switch to ${viewport.label} viewport`
-                  : "Switch viewport"
-              }
+              viewport={viewport}
               onClick={() => {
                 setActiveViewport(viewport.width);
                 onViewportChange(viewport);
               }}
               isActive={activeViewport === viewport.width}
-            >
-              {typeof viewport.icon === "string"
-                ? icons[viewport.icon as keyof typeof icons] || viewport.icon
-                : viewport.icon || icons.Smartphone}
-            </ActionButton>
+            />
           ))}
           <div className={getClassName("divider")} />
           <ActionButton
-            title="Zoom viewport out"
+            title={zoomOutLabel}
             disabled={zoom <= zoomOptions[0]?.value}
             onClick={(e) => {
               e.stopPropagation();
@@ -158,7 +187,7 @@ export const ViewportControls = ({
             <ZoomOut size={16} />
           </ActionButton>
           <ActionButton
-            title="Zoom viewport in"
+            title={zoomInLabel}
             disabled={zoom >= zoomOptions[zoomOptions.length - 1]?.value}
             onClick={(e) => {
               e.stopPropagation();
@@ -203,7 +232,7 @@ export const ViewportControls = ({
 
       <button
         className={getClassName("toggleButton")}
-        title="Toggle viewport menu"
+        title={toggleMenuLabel}
         onClick={() => setIsExpanded((s) => !s)}
       >
         {isExpanded ? <X size={16} /> : <Monitor size={16} />}

--- a/packages/core/lib/dictionary.ts
+++ b/packages/core/lib/dictionary.ts
@@ -1,0 +1,126 @@
+/**
+ * Default messages for every hard-coded string shown in the Puck editor UI.
+ *
+ * Tokens follow a `{area}-{name}-{variant}` structure, where hyphens only
+ * separate segments (compound words within a segment are concatenated, e.g.
+ * `field-arrayitem-summary`).
+ */
+export const defaultDictionary = {
+  // Header
+  "header-publish": "Publish",
+  "header-undo": "undo",
+  "header-redo": "redo",
+  "header-toggle-leftsidebar": "Toggle left sidebar",
+  "header-toggle-rightsidebar": "Toggle right sidebar",
+  "header-toggle-menubar": "Toggle menu bar",
+  // Component action bar
+  "action-selectparent": "Select parent",
+  "action-duplicate": "Duplicate",
+  "action-delete": "Delete",
+  // Fallback labels — shared by the breadcrumbs, fields panel and header
+  "label-page": "Page",
+  "label-component": "Component",
+  // Outline
+  "outline-empty": "No items",
+  "outline-collapse": "Collapse",
+  "outline-expand": "Expand",
+  // Drawer (component list)
+  "drawer-category-collapse": "Collapse {title}",
+  "drawer-category-expand": "Expand {title}",
+  "drawer-category-other": "Other",
+  // Canvas
+  "canvas-noconfig": "No configuration for {type}",
+  // Fields
+  "field-readonly": "Read-only",
+  "field-arrayitem-summary": "Item #{index}",
+  "field-arrayitem-duplicate": "Duplicate",
+  "field-arrayitem-delete": "Delete",
+  "field-external-selectdata": "Select data",
+  "field-external-search": "Search",
+  "field-external-togglefilters": "Toggle filters",
+  "field-external-item": "External item",
+  "field-external-result-singular": "{count} result",
+  "field-external-result-plural": "{count} results",
+  // Rich text field
+  "field-richtext-bold": "Bold",
+  "field-richtext-italic": "Italic",
+  "field-richtext-underline": "Underline",
+  "field-richtext-strikethrough": "Strikethrough",
+  "field-richtext-blockquote": "Blockquote",
+  "field-richtext-code-inline": "Inline code",
+  "field-richtext-code-block": "Code block",
+  "field-richtext-list-bullet": "Bullet list",
+  "field-richtext-list-ordered": "Ordered list",
+  "field-richtext-horizontalrule": "Horizontal rule",
+  "field-richtext-align-left": "Align left",
+  "field-richtext-align-center": "Align center",
+  "field-richtext-align-right": "Align right",
+  "field-richtext-align-justify": "Justify",
+  "field-richtext-select": "Select",
+  "field-richtext-headingselect-1": "Heading 1",
+  "field-richtext-headingselect-2": "Heading 2",
+  "field-richtext-headingselect-3": "Heading 3",
+  "field-richtext-headingselect-4": "Heading 4",
+  "field-richtext-headingselect-5": "Heading 5",
+  "field-richtext-headingselect-6": "Heading 6",
+  "field-richtext-alignselect-left": "Left",
+  "field-richtext-alignselect-center": "Center",
+  "field-richtext-alignselect-right": "Right",
+  "field-richtext-alignselect-justify": "Justify",
+  "field-richtext-listselect-bullet": "Bullet list",
+  "field-richtext-listselect-ordered": "Ordered list",
+  // Viewport controls
+  "viewport-zoom-in": "Zoom viewport in",
+  "viewport-zoom-out": "Zoom viewport out",
+  "viewport-zoom-auto": "{zoom}% (Auto)",
+  "viewport-toggle-menu": "Toggle viewport menu",
+  "viewport-switch": "Switch to {label} viewport",
+  "viewport-switch-default": "Switch viewport",
+  // Plugin bar
+  "plugin-blocks": "Blocks",
+  "plugin-outline": "Outline",
+  "plugin-fields": "Fields",
+  "plugin-components": "Components",
+  // Layout
+  "layout-maximize": "maximize",
+  "layout-minimize": "minimize",
+  // Loader
+  "loader-loading": "loading",
+} as const;
+
+export type DictionaryKey = keyof typeof defaultDictionary;
+
+/**
+ * Override any of Puck's built-in UI strings, or provide your own custom strings.
+ */
+export type Dictionary = Partial<
+  Record<DictionaryKey, string> & Record<string, string>
+>;
+
+/**
+ * Replace `{placeholder}` tokens in a template.
+ */
+const interpolate = (
+  template: string,
+  params: Record<string, string | number>
+): string =>
+  template.replace(/\{(\w+)\}/g, (match, key) =>
+    params[key] !== undefined ? String(params[key]) : match
+  );
+
+/**
+ * Resolve a message: the dictionary override if present, otherwise the built-in
+ * default, with optional `{placeholder}` interpolation.
+ *
+ * This is the single place message resolution happens. Components use `useMessage`
+ * to read messages reactively.
+ */
+export const getMessage = (
+  dictionary: Dictionary,
+  key: DictionaryKey,
+  params?: Record<string, string | number>
+): string => {
+  const message = dictionary[key] ?? defaultDictionary[key];
+
+  return params ? interpolate(message, params) : message;
+};

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useAppStore, useAppStoreApi } from "../store";
+import { useMessage } from "./use-message";
 import { ItemSelector } from "./data/get-item";
 
 export type Breadcrumb = {
@@ -14,6 +15,9 @@ export const useBreadcrumbs = (renderCount?: number) => {
   const path = useAppStore((s) => s.state.indexes.nodes[selectedId]?.path);
   const appStore = useAppStoreApi();
 
+  const pageLabel = useMessage("label-page");
+  const componentLabel = useMessage("label-component");
+
   return useMemo<Breadcrumb[]>(() => {
     const breadcrumbs =
       path?.map((zoneCompound) => {
@@ -21,7 +25,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
 
         if (componentId === "root") {
           return {
-            label: config?.root?.label || "Page",
+            label: config?.root?.label || pageLabel,
             selector: null,
           };
         }
@@ -34,7 +38,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
 
         const label = node
           ? config.components[node.data.type]?.label ?? node.data.type
-          : "Component";
+          : componentLabel;
 
         return {
           label,
@@ -52,5 +56,5 @@ export const useBreadcrumbs = (renderCount?: number) => {
     }
 
     return breadcrumbs;
-  }, [path, renderCount]);
+  }, [path, renderCount, pageLabel, componentLabel]);
 };

--- a/packages/core/lib/use-component-list.tsx
+++ b/packages/core/lib/use-component-list.tsx
@@ -1,11 +1,13 @@
 import { ReactNode, useEffect, useState } from "react";
 import { ComponentList } from "../components/ComponentList";
 import { useAppStore } from "../store";
+import { useMessage } from "./use-message";
 
 export const useComponentList = () => {
   const [componentList, setComponentList] = useState<ReactNode[]>();
   const config = useAppStore((s) => s.config);
   const uiComponentList = useAppStore((s) => s.state.ui.componentList);
+  const otherLabel = useMessage("drawer-category-other");
 
   useEffect(() => {
     if (Object.keys(uiComponentList).length > 0) {
@@ -31,7 +33,13 @@ export const useComponentList = () => {
             <ComponentList
               id={categoryKey}
               key={categoryKey}
-              title={category.title || categoryKey}
+              // Prefer the config title (reactive) over the ui snapshot, so
+              // updating `config.categories[x].title` shows new title immediately.
+              title={
+                config.categories?.[categoryKey]?.title ||
+                category.title ||
+                categoryKey
+              }
             >
               {category.components.map((componentName, i) => {
                 const componentConf = config.components[componentName] || {};
@@ -63,7 +71,7 @@ export const useComponentList = () => {
           <ComponentList
             id="other"
             key="other"
-            title={uiComponentList.other?.title || "Other"}
+            title={uiComponentList.other?.title || otherLabel}
           >
             {remainingComponents.map((componentName, i) => {
               const componentConf = config.components[componentName] || {};
@@ -83,7 +91,7 @@ export const useComponentList = () => {
 
       setComponentList(_componentList);
     }
-  }, [config.categories, config.components, uiComponentList]);
+  }, [config.categories, config.components, uiComponentList, otherLabel]);
 
   return componentList;
 };

--- a/packages/core/lib/use-message.ts
+++ b/packages/core/lib/use-message.ts
@@ -1,0 +1,16 @@
+import { useAppStore } from "../store";
+import { DictionaryKey, getMessage } from "./dictionary";
+
+/**
+ * Read a localized UI message from the store, reacting to changes in the
+ * `dictionary` prop.
+ *
+ * This is the only way components should read a message. It returns the
+ * override from the `dictionary` prop if provided, otherwise the built-in
+ * default. Pass `params` to fill `{placeholder}` tokens, e.g.
+ * `useMessage("viewport-switch", { label })`.
+ */
+export const useMessage = (
+  key: DictionaryKey,
+  params?: Record<string, string | number>
+) => useAppStore((s) => getMessage(s.dictionary, key, params));

--- a/packages/core/lib/use-puck.ts
+++ b/packages/core/lib/use-puck.ts
@@ -3,6 +3,7 @@ import {
   UserGenerics,
   ResolveDataTrigger,
   ComponentData,
+  Dictionary,
 } from "../types";
 import { createContext, useContext, useEffect, useState } from "react";
 import { AppStore, useAppStoreApi } from "../store";
@@ -49,6 +50,7 @@ export type UsePuckData<
     hasPast: boolean;
     hasFuture: boolean;
   };
+  dictionary: Dictionary;
 };
 
 export type PuckApi<UserConfig extends Config = Config> =
@@ -58,7 +60,13 @@ type UsePuckStore<UserConfig extends Config = Config> = PuckApi<UserConfig>;
 
 type PickedStore = Pick<
   AppStore,
-  "config" | "dispatch" | "selectedItem" | "permissions" | "history" | "state"
+  | "config"
+  | "dispatch"
+  | "selectedItem"
+  | "permissions"
+  | "history"
+  | "state"
+  | "dictionary"
 >;
 
 export const generateUsePuck = (
@@ -98,6 +106,7 @@ export const generateUsePuck = (
       if (!parentNode) return;
       return parentNode.data;
     },
+    dictionary: store.dictionary,
   };
 
   (storeData as any).__private = {
@@ -119,6 +128,7 @@ const convertToPickedStore = (store: AppStore): PickedStore => {
     permissions: store.permissions,
     history: store.history,
     selectedItem: store.selectedItem,
+    dictionary: store.dictionary,
   };
 };
 

--- a/packages/core/plugins/blocks/index.tsx
+++ b/packages/core/plugins/blocks/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Hammer } from "lucide-react";
 import { Plugin } from "../../types";
 import { Components } from "../../components/Puck/components/Components";
@@ -6,13 +7,20 @@ import { getClassNameFactory } from "../../lib";
 
 const getClassName = getClassNameFactory("BlocksPlugin", styles);
 
-export const blocksPlugin: () => Plugin = () => ({
+export type BlocksPluginProps = {
+  label?: string;
+  icon?: ReactNode;
+};
+
+export const blocksPlugin: (props?: BlocksPluginProps) => Plugin = (
+  props = {}
+) => ({
   name: "blocks",
-  label: "Blocks",
+  label: props.label ?? "Blocks",
   render: () => (
     <div className={getClassName()}>
       <Components />
     </div>
   ),
-  icon: <Hammer />,
+  icon: props.icon ?? <Hammer />,
 });

--- a/packages/core/plugins/fields/index.tsx
+++ b/packages/core/plugins/fields/index.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from "react";
 import { FormInput } from "lucide-react";
 import { useAppStore } from "../../store";
+import { useMessage } from "../../lib/use-message";
 import { PluginInternal } from "../../types/Internal";
 import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Fields } from "../../components/Puck/components/Fields";
@@ -9,22 +11,25 @@ import { getClassNameFactory } from "../../lib";
 const getClassName = getClassNameFactory("FieldsPlugin", styles);
 
 const CurrentTitle = () => {
+  const pageLabel = useMessage("label-page");
   const label = useAppStore((s) => {
     const selectedItem = s.selectedItem;
 
     return selectedItem
       ? s.config.components[selectedItem.type]?.label ?? selectedItem.type
-      : "Page";
+      : null;
   });
 
-  return label;
+  return label ?? pageLabel;
 };
 
 export const fieldsPlugin: (params?: {
   desktopSideBar?: "left" | "right";
-}) => PluginInternal = ({ desktopSideBar = "right" } = {}) => ({
+  label?: string;
+  icon?: ReactNode;
+}) => PluginInternal = ({ desktopSideBar = "right", label, icon } = {}) => ({
   name: "fields",
-  label: "Fields",
+  label: label ?? "Fields",
   render: () => (
     <div className={getClassName()}>
       <div className={getClassName("header")}>
@@ -35,6 +40,6 @@ export const fieldsPlugin: (params?: {
       <Fields />
     </div>
   ),
-  icon: <FormInput />,
+  icon: icon ?? <FormInput />,
   mobileOnly: desktopSideBar === "right",
 });

--- a/packages/core/plugins/legacy-side-bar/index.tsx
+++ b/packages/core/plugins/legacy-side-bar/index.tsx
@@ -2,17 +2,42 @@ import { Plugin } from "../../types";
 import { Components } from "../../components/Puck/components/Components";
 import { Outline } from "../../components/Puck/components/Outline";
 import { SidebarSection } from "../../components/SidebarSection";
+import { useMessage } from "../../lib/use-message";
 
-export const legacySideBarPlugin: () => Plugin = () => ({
-  name: "legacy-side-bar",
-  render: () => (
+const LegacySideBar = ({
+  outlineLabel,
+  componentsLabel,
+}: {
+  outlineLabel?: string;
+  componentsLabel?: string;
+}) => {
+  const componentsLabelMessage = useMessage("plugin-components");
+  const outlineLabelMessage = useMessage("plugin-outline");
+
+  const resolvedComponentsLabel = componentsLabel ?? componentsLabelMessage;
+  const resolvedOutlineLabel = outlineLabel ?? outlineLabelMessage;
+
+  return (
     <div style={{ overflowY: "auto" }}>
-      <SidebarSection title="Components" noBorderTop>
+      <SidebarSection title={resolvedComponentsLabel} noBorderTop>
         <Components />
       </SidebarSection>
-      <SidebarSection title="Outline">
+      <SidebarSection title={resolvedOutlineLabel}>
         <Outline />
       </SidebarSection>
     </div>
+  );
+};
+
+export const legacySideBarPlugin: (props?: {
+  outlineLabel?: string;
+  componentsLabel?: string;
+}) => Plugin = (props = {}) => ({
+  name: "legacy-side-bar",
+  render: () => (
+    <LegacySideBar
+      outlineLabel={props.outlineLabel}
+      componentsLabel={props.componentsLabel}
+    />
   ),
 });

--- a/packages/core/plugins/outline/index.tsx
+++ b/packages/core/plugins/outline/index.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Layers } from "lucide-react";
 import { Outline } from "../../components/Puck/components/Outline";
 import { Plugin } from "../../types";
@@ -6,13 +7,20 @@ import { getClassNameFactory } from "../../lib";
 
 const getClassName = getClassNameFactory("OutlinePlugin", styles);
 
-export const outlinePlugin: () => Plugin = () => ({
+export type OutlinePluginProps = {
+  label?: string;
+  icon?: ReactNode;
+};
+
+export const outlinePlugin: (props?: OutlinePluginProps) => Plugin = (
+  props = {}
+) => ({
   name: "outline",
-  label: "Outline",
+  label: props.label ?? "Outline",
   render: () => (
     <div className={getClassName()}>
       <Outline />
     </div>
   ),
-  icon: <Layers />,
+  icon: props.icon ?? <Layers />,
 });

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -36,6 +36,7 @@ import { toRoot } from "../lib/data/to-root";
 import { generateId } from "../lib/generate-id";
 import { defaultAppState } from "./default-app-state";
 import { FieldTransforms } from "../types/API/FieldTransforms";
+import type { Dictionary } from "../lib/dictionary";
 import type { Editor } from "@tiptap/react";
 
 export { defaultAppState };
@@ -88,6 +89,7 @@ export type AppStore<
   getComponentConfig: (type?: string) => ComponentConfig | null | undefined;
   onAction?: (action: PuckAction, newState: AppState, state: AppState) => void;
   metadata: Metadata;
+  dictionary: Dictionary;
   fields: FieldsSlice;
   history: HistorySlice;
   nodes: NodesSlice;
@@ -128,6 +130,7 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
       _experimentalFullScreenCanvas: false,
       _experimentalVirtualization: false,
       metadata: {},
+      dictionary: {},
       fieldTransforms: {},
       ...initialAppStore,
       fields: createFieldsSlice(set, get),

--- a/packages/core/store/slices/fields.ts
+++ b/packages/core/store/slices/fields.ts
@@ -40,7 +40,7 @@ export const useRegisterFieldsSlice = (
       const parentNode = node?.parentId ? nodes[node.parentId] : null;
       const parent = parentNode?.data || null;
 
-      const { getComponentConfig, state } = appStore.getState();
+      const { getComponentConfig, state, config } = appStore.getState();
 
       const componentConfig = getComponentConfig(componentData?.type);
 
@@ -87,6 +87,14 @@ export const useRegisterFieldsSlice = (
           return;
         }
 
+        // Abort if the config has changed during resolution — the fields were
+        // resolved against the old config, and the run triggered by the config
+        // change owns the result. Without this, a slow resolver started just
+        // before a config swap can land last and override the new fields.
+        if (appStore.getState().config !== config) {
+          return;
+        }
+
         appStore.setState({
           fields: {
             fields: newFields,
@@ -107,9 +115,23 @@ export const useRegisterFieldsSlice = (
   useEffect(() => {
     resolveFields(true);
 
-    return appStore.subscribe(
+    const unsubscribeData = appStore.subscribe(
       (s) => s.state.indexes.nodes[id || "root"],
       () => resolveFields()
     );
+
+    // The resolved fields are cached on this slice, so a config change (e.g.
+    // swapping to a config with translated labels) should re-resolve them
+    // otherwise the panel keeps serving the fields from the previous config
+    // until another component is selected or data happens to change.
+    const unsubscribeConfig = appStore.subscribe(
+      (s) => s.config,
+      () => resolveFields(true)
+    );
+
+    return () => {
+      unsubscribeData();
+      unsubscribeConfig();
+    };
   }, [id]);
 };

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -6,3 +6,4 @@ export * from "./Data";
 export * from "./Fields";
 export * from "./Props";
 export * from "./Utils";
+export type { Dictionary } from "../lib/dictionary";


### PR DESCRIPTION
Closes #1134

## Description

This PR adds the `dictionary` mentioned in the "Localization" issue. It allows for developers to override any of the strings surfaced to the user in the browser. These include visible and non visible strings.

## Changes made

- Introduced a new `dictionary` prop to the Puck component that expects a partial object with the strings that you wish to override. This prop is reactive and will update with any changes. The keys of the dictionary are prefixed by the section where they're used, and allow interpolation using `{value}`. Also allows for hiding strings by passing `""`.
- Introduced a `useMessage` hook that reads the values from the dictionary by key and interpolates any values on it.

## How to test

- Render the Puck component and override any of the keys specified in the [`dictionary`](https://github.com/puckeditor/puck/blob/f118fbe68509bb451fc1ad1152bce712c5efe474/packages/core/lib/dictionary.ts) component.
- Navigate to the editor
- Observe the strings changing

## TODO

- [x] Add documentation
- [x] Expose the dictionary object in the `usePuck` hook
- [x] Allow for users to provide additional custom keys to the `dictionary` object so they can decide if they need more strings.