### PR TITLE
fix: add engines field to core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,9 @@
     }
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "lint": "eslint \"**/*.ts*\"",
     "build": "rm -rf dist && tsup bundle/index.ts bundle/rsc.tsx bundle/no-external.ts bundle/internal.ts",


### PR DESCRIPTION
Closes #1574

## Description

`engines` is defined in the root `package.json`, but that isn't published with `@puckeditor/core`, so the installed library doesn't declare its Node requirement. Since 0.21.x, core requires Node 20+ (via happy-dom), so users on older Node get an unclear error rather than an engines warning.

## Changes made

- Added `engines.node: ">=20.0.0"` to `packages/core/package.json`, matching the root.
