### PR TITLE
fix(core): prevent unbounded cache growth in resolveAllData

### DIFF
--- a/packages/core/lib/__tests__/resolve-all-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-all-data.spec.tsx
@@ -1,5 +1,6 @@
 import { ComponentData, Config, Data, RootData } from "../../types";
 import { resolveAllData } from "../resolve-all-data";
+import { cache } from "../resolve-component-data";
 
 const item4 = {
   type: "ComponentWithResolveProps",
@@ -363,5 +364,15 @@ describe("resolve-data", () => {
       item1_2.props.id
     );
     expect(receivedParentById[item1_2_1.props.id]?.props.prop).toBe("Resolved");
+  });
+
+  it("should not write to the shared module-level cache", async () => {
+    cache.lastChange = {};
+
+    await resolveAllData(data, config);
+
+    // Entries should live in a local cache that is garbage collected once
+    // resolveAllData returns, not accumulate in the shared cache.
+    expect(cache.lastChange).toEqual({});
   });
 });

--- a/packages/core/lib/resolve-all-data.ts
+++ b/packages/core/lib/resolve-all-data.ts
@@ -8,7 +8,10 @@ import {
   Metadata,
   RootData,
 } from "../types";
-import { resolveComponentData } from "./resolve-component-data";
+import {
+  ResolveDataCache,
+  resolveComponentData,
+} from "./resolve-component-data";
 import { groupZonesByComponent } from "./group-zones-by-component";
 import { defaultData } from "./data/default-data";
 import { toComponent } from "./data/to-component";
@@ -27,6 +30,12 @@ export async function resolveAllData<
   const defaultedData = defaultData(data);
 
   const zonesByComponent = groupZonesByComponent(defaultedData);
+
+  // Use a local cache so entries are garbage collected when this function
+  // returns, rather than accumulating in the shared module-level cache. This
+  // prevents unbounded memory growth when resolving many pages with unique
+  // component IDs.
+  const cacheStore: ResolveDataCache = { lastChange: {} };
 
   let resolvedZones: Record<string, Content> = {};
 
@@ -48,7 +57,8 @@ export async function resolveAllData<
         () => {},
         "force",
         parent,
-        root
+        root,
+        cacheStore
       )
     ).node as T;
 

--- a/packages/core/lib/resolve-component-data.ts
+++ b/packages/core/lib/resolve-component-data.ts
@@ -12,9 +12,11 @@ import { toComponent } from "./data/to-component";
 import { getChanged } from "./get-changed";
 import { deepEqual } from "fast-equals";
 
-export const cache: {
+export type ResolveDataCache = {
   lastChange: Record<string, any>;
-} = { lastChange: {} };
+};
+
+export const cache: ResolveDataCache = { lastChange: {} };
 
 export const resolveComponentData = async <
   T extends ComponentData | RootDataWithProps
@@ -26,7 +28,8 @@ export const resolveComponentData = async <
   onResolveEnd?: (item: T) => void,
   trigger: ResolveDataTrigger = "replace",
   parent: ComponentData | null = null,
-  root: RootData = { props: {} }
+  root: RootData = { props: {} },
+  cacheStore: ResolveDataCache = cache
 ) => {
   const configForItem =
     "type" in item && item.type !== "root"
@@ -46,7 +49,7 @@ export const resolveComponentData = async <
       item: oldItem = null,
       resolved = {},
       parentId: oldParentId = null,
-    } = cache.lastChange[id] || {};
+    } = cacheStore.lastChange[id] || {};
     // Skip inserted nodes for "move" trigger
     // This is done this way to mitigate race conditions on insertion
     const isRootOrInserted = oldParentId === null;
@@ -107,7 +110,8 @@ export const resolveComponentData = async <
                   onResolveEnd,
                   trigger,
                   itemAsComponentData,
-                  root
+                  root,
+                  cacheStore
                 )
               ).node
           )
@@ -121,7 +125,7 @@ export const resolveComponentData = async <
     onResolveEnd(resolvedItem);
   }
 
-  cache.lastChange[id] = {
+  cacheStore.lastChange[id] = {
     item: item,
     resolved: itemWithResolvedChildren,
     parentId: parent?.props.id,


### PR DESCRIPTION
Closes #1459

## Description

`resolveComponentData` writes resolved entries to a module-level cache keyed by component ID. `resolveAllData` always resolves with the `"force"` trigger, so the cache is never read to skip work there — it only accumulates one entry per unique component ID and never frees them. When resolving many pages with unique IDs in a long-lived shared runtime (e.g. batch rendering thousands of pages), this grows memory unbounded.

The fix makes the cache injectable and gives `resolveAllData` its own local cache, so its entries are garbage collected once the call returns. The editor's shared-cache behaviour is unchanged.

## Changes made

- `resolveComponentData` accepts an optional `cacheStore` param (defaults to the shared module-level `cache`), and a `ResolveDataCache` type is exported.
- `resolveAllData` passes a fresh local cache, so it no longer writes to the shared cache.
- Added a test asserting `resolveAllData` does not pollute the shared cache.

## How to test

Call `resolveAllData` repeatedly with distinct component IDs and confirm the module-level `cache.lastChange` stays empty (covered by the new test), and that resolved output is unchanged.
