### PR TITLE
fix(core): allow overriding title type in root props

### DIFF
--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -4,7 +4,7 @@ import { ComponentData, ComponentMetadata, RootData } from "./Data";
 
 import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";
 import { AppState } from "./AppState";
-import { DefaultComponentProps, DefaultRootFieldProps } from "./Props";
+import { DefaultComponentProps, WithDefaultRootFieldProps } from "./Props";
 import { Permissions } from "./API";
 import { DropZoneProps } from "../components/DropZone/types";
 import {
@@ -233,7 +233,7 @@ export type ExtractConfigParams<UserConfig extends ConfigInternal> =
   >
     ? {
         props: PropsOrParams;
-        rootProps: RootProps & DefaultRootFieldProps;
+        rootProps: WithDefaultRootFieldProps<RootProps>;
         categoryNames: CategoryName;
         field: UserField extends { type: string } ? UserField : Field;
       }

--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -13,6 +13,14 @@ export type DefaultRootFieldProps = {
   title?: string;
 };
 
+/**
+ * Merge the default root field props into user-provided root props, letting
+ * the user's props take precedence. Using a plain intersection would turn an
+ * overridden `title` (e.g. `number`) into `never` (`number & string`).
+ */
+export type WithDefaultRootFieldProps<RootProps> = RootProps &
+  Omit<DefaultRootFieldProps, keyof RootProps>;
+
 export type DefaultRootRenderProps<
   Props extends DefaultComponentProps = DefaultRootFieldProps
 > = WithPuckProps<WithChildren<Props>>;

--- a/packages/core/types/Utils.tsx
+++ b/packages/core/types/Utils.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { Config, ExtractConfigParams } from "./Config";
-import { DefaultRootFieldProps, PuckContext } from "./Props";
+import { PuckContext, WithDefaultRootFieldProps } from "./Props";
 import { ComponentData, Data } from "./Data";
 import { PrivateAppState } from "./Internal";
 import { AppState } from "./AppState";
@@ -32,7 +32,7 @@ export type UserGenerics<
   UserConfig: UserConfig;
   UserParams: UserParams;
   UserProps: UserParams["props"];
-  UserRootProps: UserParams["rootProps"] & DefaultRootFieldProps;
+  UserRootProps: WithDefaultRootFieldProps<UserParams["rootProps"]>;
   UserData: UserData;
   UserAppState: UserAppState;
   UserPublicAppState: UserPublicAppState;


### PR DESCRIPTION
Closes #1263

## Description

Overriding `title` in root props with a non-string type (e.g. `title: number`) made `Puck` reject the `data` prop with a type error. The default root field props (`{ title?: string }`) were merged into user root props with a plain intersection, so `number & string` collapsed to `never`.

This introduces a `WithDefaultRootFieldProps` helper that omits any keys the user has already defined before merging, so user-provided prop types take precedence over the defaults.

## Changes made

- Added `WithDefaultRootFieldProps<RootProps>` in `types/Props.tsx`.
- Used it in `ExtractConfigParams` (`types/Config.tsx`) and `UserGenerics.UserRootProps` (`types/Utils.tsx`) in place of the plain `& DefaultRootFieldProps` intersection.

## How to test

```tsx
type FooRootProps = { title: number };
type FooComponents = { Box: { size: number } };

const testData = 0 as unknown as Data<FooComponents, FooRootProps>;
const testConfig = 0 as unknown as Config<{
  components: FooComponents;
  root: FooRootProps;
}>;

// no longer errors
<Puck config={testConfig} data={testData} />;
```
