### PR TITLE
feat(core): forward additional props to slot `as` component

### DIFF
--- a/apps/docs/pages/docs/api-reference/fields/slot.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/slot.mdx
@@ -225,6 +225,20 @@ const config = {
 };
 ```
 
+Any additional props are forwarded to the element or component provided via `as`, typed against it.
+
+```tsx copy {5}
+const config = {
+  components: {
+    Example: {
+      render: ({ content: Content }) => {
+        return <Content as={Box} sx={{ display: "flex" }} />;
+      },
+    },
+  },
+};
+```
+
 ### `className`
 
 Provide a className to the rendered element. The default styles will still be applied.

--- a/apps/docs/pages/docs/api-reference/fields/slot.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/slot.mdx
@@ -239,6 +239,17 @@ const config = {
 };
 ```
 
+The following Puck-internal props are **not** forwarded, as they are consumed by Puck itself:
+
+| Prop | Reason |
+| ---- | ------ |
+| `zone` | Identifies the drop zone internally |
+| `allow` | Controls which component types are allowed |
+| `disallow` | Controls which component types are disallowed |
+| `collisionAxis` | Configures drag collision detection |
+| `minEmptyHeight` | Sets the minimum height of an empty zone |
+| `content` | Injected by Puck with the slot's component data |
+
 ### `className`
 
 Provide a className to the rendered element. The default styles will still be applied.

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -293,7 +293,10 @@ const DropZoneChild = ({
 
 const DropZoneChildMemo = memo(DropZoneChild);
 
-export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
+// `content` is injected by the slot transform but unused by DropZoneEdit
+type DropZoneEditProps = DropZoneProps & { content?: unknown };
+
+export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneEditProps>(
   function DropZoneEditInternal(
     {
       zone,
@@ -304,6 +307,8 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
       minEmptyHeight: userMinEmptyHeight = "128px",
       collisionAxis,
       as,
+      content: _content,
+      ...rest
     },
     userRef
   ) {
@@ -501,6 +506,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
 
     return (
       <El
+        {...rest}
         className={`${getClassName({
           isRootZone,
           hoveringOverArea,
@@ -602,7 +608,20 @@ export const DropZoneRenderPure = (props: DropZoneProps) => (
 );
 
 const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
-  function DropZoneRenderInternal({ className, style, zone, as }, ref) {
+  function DropZoneRenderInternal(
+    {
+      className,
+      style,
+      zone,
+      as,
+      allow,
+      disallow,
+      collisionAxis,
+      minEmptyHeight,
+      ...rest
+    },
+    ref
+  ) {
     const ctx = useContext(dropZoneContext);
     const { areaId = "root" } = ctx || {};
     const { config, data, metadata } = useContext(renderContext);
@@ -630,7 +649,7 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
       content = setupZone(data, zoneCompound).zones[zoneCompound];
     }
     return (
-      <El className={className} style={style} ref={ref}>
+      <El {...rest} className={className} style={style} ref={ref}>
         {content.map((item) => {
           const Component = config.components[item.type];
           if (Component) {

--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -1,7 +1,12 @@
-import { CSSProperties, ElementType, Ref } from "react";
+import {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ElementType,
+  Ref,
+} from "react";
 import { DragAxis } from "../../types";
 
-export type DropZoneProps = {
+export type DropZoneOwnProps = {
   zone: string;
   allow?: string[];
   disallow?: string[];
@@ -9,6 +14,18 @@ export type DropZoneProps = {
   minEmptyHeight?: CSSProperties["minHeight"] | number;
   className?: string;
   collisionAxis?: DragAxis;
-  as?: ElementType;
   ref?: Ref<any>;
 };
+
+/**
+ * Props for a slot or DropZone.
+ *
+ * Any additional props not consumed by Puck are forwarded to the element or
+ * component provided via `as` (defaulting to a `div`), typed against it.
+ */
+export type DropZoneProps<T extends ElementType = "div"> = DropZoneOwnProps & {
+  as?: T;
+} & Omit<
+    ComponentPropsWithoutRef<T>,
+    keyof DropZoneOwnProps | "as" | "content"
+  >;

--- a/packages/core/components/ServerRender/__tests__/index.spec.tsx
+++ b/packages/core/components/ServerRender/__tests__/index.spec.tsx
@@ -102,4 +102,47 @@ describe("ServerRender", () => {
     expect(html).toContain("<h2>Nested heading</h2>");
     expect(html).not.toContain("&lt;p&gt;Hello");
   });
+
+  it("forwards additional props to the element provided via `as`", () => {
+    const config: Config = {
+      components: {
+        Section: {
+          fields: {
+            content: { type: "slot" },
+          },
+          render: ({ content: Content }) => (
+            <Content as="section" id="my-slot" data-custom="foo" />
+          ),
+        },
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Section",
+          props: {
+            id: "section-1",
+            content: [
+              { type: "Heading", props: { id: "heading-1", title: "Hello" } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const html = renderToString(<Render config={config} data={data} />);
+
+    expect(html).toContain("<section");
+    expect(html).toContain('id="my-slot"');
+    expect(html).toContain('data-custom="foo"');
+    expect(html).toContain("<h2>Hello</h2>");
+    // Puck-internal props should not leak onto the element
+    expect(html).not.toContain('zone="');
+  });
 });

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -57,13 +57,26 @@ const Item = ({
  */
 export const SlotRender = forwardRef<HTMLDivElement, SlotRenderProps>(
   function SlotRenderInternal(
-    { className, style, content, config, metadata, as },
+    {
+      className,
+      style,
+      content,
+      config,
+      metadata,
+      as,
+      zone,
+      allow,
+      disallow,
+      collisionAxis,
+      minEmptyHeight,
+      ...rest
+    },
     ref
   ) {
     const El = as ?? "div";
 
     return (
-      <El className={className} style={style} ref={ref}>
+      <El {...rest} className={className} style={style} ref={ref}>
         {content.map((item) => {
           if (!config.components[item.type]) {
             return null;

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -13,8 +13,11 @@ import {
   LeftOrExactRight,
   WithDeepSlots,
 } from "./Internal";
+import { ElementType } from "react";
 
-export type SlotComponent = (props?: Omit<DropZoneProps, "zone">) => ReactNode;
+export type SlotComponent = <T extends ElementType = "div">(
+  props?: Omit<DropZoneProps<T>, "zone">
+) => ReactNode;
 
 export type PuckComponent<Props> = (
   props: WithId<


### PR DESCRIPTION
Closes puckeditor/puck#1441

## Description

Slots (and `puck.renderDropZone`) accept an `as` prop to render a custom element or component, but previously any other props were dropped. This forwards those additional props onto the `as` element/component, so you can pass e.g. styling props through:

```tsx
render: ({ SlotComponent, height }) => (
  <SlotComponent as={Box} sx={{ height: (theme) => theme.units * height }} />
);
```

Puck-internal props (`zone`, `allow`, `disallow`, `collisionAxis`, `minEmptyHeight`, `content`) are stripped so they don't leak onto the DOM.

## Changes made

* `DropZoneProps` is now polymorphic over `as` (defaulting to `"div"`), so additional props are typed against the chosen element/component. `SlotComponent` is typed accordingly.
* `SlotRender`, `DropZoneRender`, and `DropZoneEdit` spread the remaining props onto the rendered element, after removing the Puck-internal ones.
* Documented the behaviour in the slot field reference.

## How to test

Add extra props alongside `as` in a slot render function and confirm they reach the element and that internal props don't leak:

```tsx
render: ({ content: Content }) => (
  <Content as="section" id="my-slot" data-custom="foo" />
);
```

Covered by a new test in `packages/core/components/ServerRender/__tests__/index.spec.tsx`.