### PR TITLE
fix: preserve caret in controlled custom input fields

### DIFF
--- a/packages/core/components/AutoField/__tests__/custom-field-caret.spec.tsx
+++ b/packages/core/components/AutoField/__tests__/custom-field-caret.spec.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Config } from "../../../types";
+
+jest.mock("../../Puck/styles.module.css");
+jest.mock("@dnd-kit/react");
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false, // default → desktop
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+// Silence the noisy "Could not parse CSS stylesheet" jsdom warnings
+const originalConsoleError = console.error;
+jest.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  if (
+    args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+  ) {
+    return;
+  }
+
+  originalConsoleError(...(args as Parameters<typeof console.error>));
+});
+
+import { Puck } from "../../Puck";
+
+describe("AutoField custom field", () => {
+  // Records the `value` prop passed to the custom field on every render.
+  const renderedValues: unknown[] = [];
+
+  const config: Config = {
+    root: {
+      fields: {
+        title: {
+          type: "custom",
+          render: ({ id, value, onChange }) => {
+            renderedValues.push(value);
+
+            return (
+              <input
+                data-testid="custom-input"
+                id={id}
+                value={(value as string) ?? ""}
+                onChange={(e) => onChange(e.currentTarget.value)}
+              />
+            );
+          },
+        },
+      },
+      render: ({ children }) => <div>{children}</div>,
+    },
+    components: {},
+  };
+
+  afterEach(() => {
+    cleanup();
+    renderedValues.length = 0;
+  });
+
+  const flush = () => act(async () => {});
+
+  // A controlled <input> keeps its caret only if its `value` prop reflects the
+  // latest keystroke on the same render. Custom fields read their value from
+  // the field store, which was previously only updated after an async
+  // round-trip through the app store — so the input re-rendered a tick later
+  // with a stale value, resetting the caret to the end on every keystroke
+  // (#1642). This asserts the value is mirrored back synchronously.
+  it("updates a custom field's value synchronously on change", async () => {
+    render(
+      <Puck
+        config={config}
+        data={{ root: { props: { title: "abcdef" } } }}
+        iframe={{ enabled: false }}
+      />
+    );
+
+    await flush();
+
+    const input = screen.getAllByTestId("custom-input")[0] as HTMLInputElement;
+
+    expect(input.value).toBe("abcdef");
+
+    // Emulate the browser inserting "X" between "abc" and "def".
+    fireEvent.change(input, { target: { value: "abcXdef" } });
+
+    // Without awaiting the async app-store round-trip, the custom field should
+    // already have re-rendered with the new value.
+    expect(renderedValues[renderedValues.length - 1]).toBe("abcXdef");
+
+    await flush();
+
+    expect(input.value).toBe("abcXdef");
+  });
+});

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -1,5 +1,5 @@
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Field, FieldProps } from "../../types";
+import { Field, FieldProps, UiState } from "../../types";
 
 import styles from "./styles.module.css";
 import {
@@ -25,6 +25,7 @@ import { useSafeId } from "../../lib/use-safe-id";
 import { NestedFieldContext } from "./context";
 import { useShallow } from "zustand/react/shallow";
 import { getDeep } from "../../lib/data/get-deep";
+import { setDeep } from "../../lib/data/set-deep";
 import type {
   FieldLabelPropsInternal,
   FieldPropsInternalOptional,
@@ -106,6 +107,29 @@ function AutoFieldInternal<
     }
   });
 
+  const fieldStore = useFieldStoreApi();
+
+  const onChange = useMemo(() => {
+    // Custom fields read their value from the field store, which is only
+    // updated after an async round-trip through the app store. For a
+    // controlled input this means it re-renders a tick later with a stale
+    // value, resetting the caret to the end on every keystroke (#1642).
+    // Synchronously mirror the new value into the field store so the value
+    // is up-to-date on the same render. Built-in fields don't need this as
+    // they track their value locally via useLocalValue.
+    if (field.type !== "custom") {
+      return props.onChange;
+    }
+
+    return (value: any, uiState?: Partial<UiState>) => {
+      props.onChange?.(value, uiState);
+
+      fieldStore.setState(
+        setDeep(fieldStore.getState(), props.name ?? resolvedId, value)
+      );
+    };
+  }, [field.type, props.onChange, props.name, resolvedId, fieldStore]);
+
   const mergedProps = useMemo(
     () => ({
       ...props,
@@ -115,8 +139,9 @@ function AutoFieldInternal<
       Label,
       id: resolvedId,
       value: fieldValue,
+      onChange,
     }),
-    [props, field, label, labelIcon, Label, resolvedId, fieldValue]
+    [props, field, label, labelIcon, Label, resolvedId, fieldValue, onChange]
   );
 
   const onFocus = useCallback(


### PR DESCRIPTION
Closes #1642

## Description

When a custom field renders a controlled `<input>` (i.e. passes a `value` prop), the caret jumped to the end on every keystroke, making it impossible to edit text in place. This was introduced by the 0.21 fields refactor.

Custom fields read their `value` from the field store, which was only updated after an async round-trip through the app store (`resolveComponentData` → dispatch → store subscription). For a controlled input this means it re-renders a tick later with a stale value, so React resets the caret to the end. Built-in fields don't hit this because they track their value locally via `useLocalValue`.

The fix wraps the `onChange` passed to custom fields so it synchronously mirrors the new value back into the field store, ensuring the value is up-to-date on the same render. The parent `onChange` is still called first so nested (object/array) fields keep computing their updates against the pre-change store value.

## Changes made

- `AutoFieldInternal` now provides custom fields an `onChange` that writes the new value into the field store synchronously (via `setDeep`) after invoking the parent `onChange`. Built-in fields are unaffected.
- Added a regression test asserting a custom field's `value` updates synchronously on change (fails before this fix).

## How to test

Register a custom field with a controlled input, type in the middle of an existing value, and confirm the caret stays put:

```tsx
const config = {
  components: {
    MyComponent: {
      fields: {
        title: {
          type: "custom",
          render: ({ id, onChange, value }) => (
            <input id={id} value={value} onChange={(e) => onChange(e.target.value)} />
          ),
        },
      },
      render: ({ title }) => <h1>{title}</h1>,
    },
  },
};
```
