### PR TITLE
fix: allow hooks inside field transforms

### DIFF
--- a/apps/docs/pages/docs/api-reference/field-transforms.mdx
+++ b/apps/docs/pages/docs/api-reference/field-transforms.mdx
@@ -15,7 +15,7 @@ const fieldTransforms = {
 
 You can specify a custom render method for each known [field type](/docs/api-reference/fields), or introduce completely new ones.
 
-Transform functions are called directly by Puck, so you can't use [hooks](https://react.dev/reference/rules/rules-of-hooks) within them. To use hooks, return a component and let React render it—for example `text: (props) => <MyComponent {...props} />`. See [Making it interactive](/docs/extending-puck/field-transforms#making-it-interactive) for a full example.
+Transforms are rendered as React components, so you can use [hooks](https://react.dev/reference/rules/rules-of-hooks) within them. See [Making it interactive](/docs/extending-puck/field-transforms#making-it-interactive) for an example.
 
 ## Render Props
 

--- a/apps/docs/pages/docs/api-reference/field-transforms.mdx
+++ b/apps/docs/pages/docs/api-reference/field-transforms.mdx
@@ -15,6 +15,8 @@ const fieldTransforms = {
 
 You can specify a custom render method for each known [field type](/docs/api-reference/fields), or introduce completely new ones.
 
+Transform functions are called directly by Puck, so you can't use [hooks](https://react.dev/reference/rules/rules-of-hooks) within them. To use hooks, return a component and let React render it—for example `text: (props) => <MyComponent {...props} />`. See [Making it interactive](/docs/extending-puck/field-transforms#making-it-interactive) for a full example.
+
 ## Render Props
 
 | Prop                          | Example              | Type                                |

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -48,11 +48,28 @@ const EditableText = ({ value }) => {
 };
 
 const fieldTransforms = {
-  text: EditableText,
+  // Return EditableText as an element so React renders it as a component
+  text: (props) => <EditableText {...props} />,
 };
 
 const Example = () => <Puck fieldTransforms={fieldTransforms} />;
 ```
+
+<Callout type="warning">
+  Puck calls transform functions directly rather than rendering them as
+  components, so you can't use [hooks](https://react.dev/reference/rules/rules-of-hooks)
+  (like `useState` or `useEffect`) in the transform function itself. To use hooks,
+  return a component and let React render it:
+
+```tsx
+// 🚫 Throws "Do not call Hooks inside useMemo(...)"
+const fieldTransforms = { text: EditableText };
+
+// ✅ Works — EditableText is rendered as a component
+const fieldTransforms = { text: (props) => <EditableText {...props} /> };
+```
+
+</Callout>
 
 ## Define new fields
 

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -48,27 +48,14 @@ const EditableText = ({ value }) => {
 };
 
 const fieldTransforms = {
-  // Return EditableText as an element so React renders it as a component
-  text: (props) => <EditableText {...props} />,
+  text: EditableText,
 };
 
 const Example = () => <Puck fieldTransforms={fieldTransforms} />;
 ```
 
-<Callout type="warning">
-  Puck calls transform functions directly rather than rendering them as
-  components, so you can't use [hooks](https://react.dev/reference/rules/rules-of-hooks)
-  (like `useState` or `useEffect`) in the transform function itself. To use hooks,
-  return a component and let React render it:
-
-```tsx
-// 🚫 Throws "Do not call Hooks inside useMemo(...)"
-const fieldTransforms = { text: EditableText };
-
-// ✅ Works — EditableText is rendered as a component
-const fieldTransforms = { text: (props) => <EditableText {...props} /> };
-```
-
+<Callout type="info">
+  Transforms are rendered as React components, so you can use [hooks](https://react.dev/reference/rules/rules-of-hooks) (like `useState` or `useEffect`) within them.
 </Callout>
 
 ## Define new fields

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -50,6 +50,7 @@ import { useFieldTransformsTracked } from "../../lib/field-transforms/use-field-
 import { getInlineTextTransform } from "../../lib/field-transforms/default-transforms/inline-text-transform";
 import { getSlotTransform } from "../../lib/field-transforms/default-transforms/slot-transform";
 import { getRichTextTransform } from "../../lib/field-transforms/default-transforms/rich-text-transform";
+import { renderTransformsAsComponents } from "../../lib/field-transforms/render-transforms-as-components";
 import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
 import { MemoizeComponent } from "../MemoizeComponent";
@@ -208,11 +209,13 @@ const DropZoneChild = ({
       )),
       ...getInlineTextTransform(),
       ...getRichTextTransform(),
-      ...plugins.reduce<FieldTransforms>(
-        (acc, plugin) => ({ ...acc, ...plugin.fieldTransforms }),
-        {}
-      ),
-      ...userFieldTransforms,
+      ...renderTransformsAsComponents({
+        ...plugins.reduce<FieldTransforms>(
+          (acc, plugin) => ({ ...acc, ...plugin.fieldTransforms }),
+          {}
+        ),
+        ...userFieldTransforms,
+      }),
     }),
     [plugins, userFieldTransforms]
   );

--- a/packages/core/components/Puck/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/Puck/__tests__/field-transforms.spec.tsx
@@ -1,0 +1,136 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useEffect, useRef, useState } from "react";
+import { Config, Data } from "../../../types";
+import "@testing-library/jest-dom";
+
+jest.mock("../styles.module.css");
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+const originalConsoleError = console.error;
+const consoleErrorSpy = jest
+  .spyOn(console, "error")
+  .mockImplementation((...args: unknown[]) => {
+    if (
+      args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+    ) {
+      return;
+    }
+    originalConsoleError(...(args as Parameters<typeof console.error>));
+  });
+
+jest.spyOn(console, "warn").mockImplementation(() => {});
+
+import { Puck } from "../index";
+
+const config: Config = {
+  components: {
+    Heading: {
+      fields: { title: { type: "text" } },
+      defaultProps: { title: "Something" },
+      render: ({ title }) => <div>{title}</div>,
+    },
+  },
+};
+
+const data: Data = {
+  root: { props: {} },
+  content: [{ type: "Heading", props: { id: "heading-1", title: "Hello" } }],
+};
+
+describe("Puck - fieldTransforms with hooks", () => {
+  afterEach(() => {
+    cleanup();
+    consoleErrorSpy.mockClear();
+  });
+
+  it("renders a transform that uses hooks without throwing", async () => {
+    // Reproduces https://github.com/puckeditor/puck/issues/1251, where passing
+    // a component that uses hooks directly as a transform threw a rules-of-hooks
+    // error because the transform was called inside a useMemo.
+    const EditableText = ({ value }: { value: string }) => {
+      const ref = useRef<HTMLParagraphElement>(null);
+      const [suffix, setSuffix] = useState("");
+
+      useEffect(() => {
+        setSuffix(" (edited)");
+      }, []);
+
+      return (
+        <p ref={ref} data-testid="editable-text">
+          {value}
+          {suffix}
+        </p>
+      );
+    };
+
+    const fieldTransforms = { text: EditableText };
+
+    render(
+      <Puck
+        config={config}
+        data={data}
+        fieldTransforms={fieldTransforms}
+        iframe={{ enabled: false }}
+      />
+    );
+
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(screen.getByTestId("editable-text")).toBeInTheDocument();
+    });
+
+    // The effect ran, proving hooks work inside the transform
+    await waitFor(() => {
+      expect(screen.getByText("Hello (edited)")).toBeInTheDocument();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Do not call Hooks")
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Invalid hook call")
+    );
+  });
+});

--- a/packages/core/lib/field-transforms/render-transforms-as-components.tsx
+++ b/packages/core/lib/field-transforms/render-transforms-as-components.tsx
@@ -1,0 +1,35 @@
+import { createElement, FunctionComponent } from "react";
+import {
+  FieldTransformFn,
+  FieldTransforms,
+} from "../../types/API/FieldTransforms";
+
+/**
+ * Wraps user-provided field transforms so they render as React components
+ * rather than being invoked as plain functions during the parent's render.
+ *
+ * Field transforms are applied within a `useMemo` (see `useFieldTransforms`
+ * and `useFieldTransformsTracked`). Calling a transform directly means any
+ * hooks it uses run inside that `useMemo`, which violates the rules of hooks.
+ * Rendering the transform as a component with `createElement` instead gives its
+ * hooks their own render scope, so they behave as expected.
+ *
+ * https://github.com/puckeditor/puck/issues/1251
+ */
+export const renderTransformsAsComponents = (
+  transforms: FieldTransforms
+): FieldTransforms =>
+  Object.keys(transforms).reduce<FieldTransforms>((acc, type) => {
+    const fieldType = type as keyof FieldTransforms;
+    const fn = transforms[fieldType];
+
+    if (!fn) return acc;
+
+    const Transform = fn as FunctionComponent<any>;
+
+    return {
+      ...acc,
+      [fieldType]: ((params) =>
+        createElement(Transform, params)) as FieldTransformFn<any>,
+    };
+  }, {});


### PR DESCRIPTION
Closes puckeditor/puck#1251

## Description

Using hooks (`useState`, `useEffect`, `useRef`, etc.) inside a `fieldTransform` threw `Do not call Hooks inside useMemo(...)`. This included the "Making it interactive" example straight from the docs.

Field transforms are applied inside a `useMemo` (in `useFieldTransforms` / `useFieldTransformsTracked`), and user transforms were invoked directly as functions — so any hooks they used ran inside that `useMemo`, violating the rules of hooks. The built-in transforms (slot, inline text, richtext) avoid this by returning elements (`<InlineTextField />` etc.) rather than calling hooks in the transform body.

This renders user- and plugin-provided transforms as React components via `createElement`, giving their hooks their own render scope. Built-in transforms are still called directly, as they intentionally return raw values (e.g. non-`contentEditable` text) or components (slots).

An earlier commit on this branch documented the limitation as a workaround; those notes are now inaccurate, so this restores the example to passing the component directly and updates the callouts to state that hooks are supported.

## Changes made

* Added `renderTransformsAsComponents`, which wraps user/plugin transforms so they render via `createElement` instead of being called directly.
* Applied it to the plugin + user transforms in `DropZone` (built-ins unchanged).
* Updated the field-transforms docs to reflect that hooks now work directly.
* Added a test asserting a transform using hooks renders without throwing.

## How to test

Render `<Puck>` with a transform that uses hooks and confirm it renders without a rules-of-hooks error:

```tsx
const EditableText = ({ value }) => {
  const ref = useRef(null);
  useEffect(() => { if (ref.current) registerOverlayPortal(ref.current); }, [ref.current]);
  return <p ref={ref} contentEditable>{value}</p>;
};

<Puck config={config} fieldTransforms={{ text: EditableText }} />
```