### PR TITLE
fix: run field transforms for fields without default props

### DIFF
--- a/packages/core/lib/data/__tests__/map-fields.spec.tsx
+++ b/packages/core/lib/data/__tests__/map-fields.spec.tsx
@@ -1,0 +1,78 @@
+import { Config } from "../../../types";
+import { mapFields, Mappers } from "../map-fields";
+
+type Props = {
+  Comp: {
+    title?: string;
+    plain?: string;
+    nested?: { title?: string };
+  };
+};
+
+const config: Config<Props> = {
+  components: {
+    Comp: {
+      fields: {
+        title: { type: "text" },
+        plain: { type: "text" },
+        nested: {
+          type: "object",
+          objectFields: {
+            title: { type: "text" },
+          },
+        },
+      },
+      render: () => <div />,
+    },
+  },
+};
+
+const mappers: Mappers = {
+  text: ({ value, propPath }) => `mapped:${propPath}:${value}`,
+};
+
+describe("mapFields", () => {
+  it("runs transforms for fields that have no value set", () => {
+    const result: any = mapFields(
+      { type: "Comp", props: { id: "abc" } },
+      mappers,
+      config
+    );
+
+    // `title` has a mapper but no value in props — it should still be visited
+    expect(result.props.title).toBe("mapped:title:undefined");
+    expect(result.props.plain).toBe("mapped:plain:undefined");
+  });
+
+  it("still runs transforms for fields that do have a value", () => {
+    const result: any = mapFields(
+      { type: "Comp", props: { id: "abc", title: "Hello" } },
+      mappers,
+      config
+    );
+
+    expect(result.props.title).toBe("mapped:title:Hello");
+  });
+
+  it("does not add keys for field types without a mapper", () => {
+    const result: any = mapFields(
+      { type: "Comp", props: { id: "abc" } },
+      // No mapper registered at all
+      {},
+      config
+    );
+
+    expect("title" in result.props).toBe(false);
+    expect("plain" in result.props).toBe(false);
+  });
+
+  it("runs transforms for missing subfields of an object field", () => {
+    const result: any = mapFields(
+      { type: "Comp", props: { id: "abc", nested: {} } },
+      mappers,
+      config
+    );
+
+    expect(result.props.nested.title).toBe("mapped:nested.title:undefined");
+  });
+});

--- a/packages/core/lib/data/map-fields.ts
+++ b/packages/core/lib/data/map-fields.ts
@@ -43,6 +43,7 @@ type WalkObjectOpts = {
   getPropPath: (str: string) => string;
   config: Config;
   recurseSlots?: boolean;
+  ownedFields?: boolean;
 };
 
 const isPromise = <T = unknown>(v: any): v is Promise<T> =>
@@ -141,6 +142,8 @@ export const walkField = ({
         getPropPath: (k) => `${propPath}.${k}`,
         config,
         recurseSlots,
+        // Only default missing fields when objectFields describe this value
+        ownedFields: fields[propKey]?.type === "object",
       });
     }
   }
@@ -156,10 +159,26 @@ const walkObject = ({
   getPropPath,
   config,
   recurseSlots,
+  ownedFields,
 }: WalkObjectOpts): Record<string, any> => {
-  const newProps = Object.entries(value).map(([k, v]) => {
+  const keys = Object.keys(value);
+
+  // Include fields that have a mapper but no value, so their transforms still
+  // run (e.g. a contentEditable text field without a default prop). Slots are
+  // defaulted separately via defaultSlots.
+  if (ownedFields) {
+    for (const fieldName in fields) {
+      const fieldType = fields[fieldName].type;
+
+      if (fieldType !== "slot" && mappers[fieldType] && !(fieldName in value)) {
+        keys.push(fieldName);
+      }
+    }
+  }
+
+  const newProps = keys.map((k) => {
     const opts: WalkFieldOpts = {
-      value: v,
+      value: value[k],
       fields,
       mappers,
       propKey: k,
@@ -227,6 +246,7 @@ export function mapFields(
     getPropPath: (k) => k,
     config,
     recurseSlots,
+    ownedFields: true,
   });
 
   if (isPromise(newProps)) {


### PR DESCRIPTION
Closes #1342

## Description

Field transforms only ran for props that had a value. `walkObject` iterated over the props object (`Object.entries(value)`) rather than the component's configured fields, so a field defined in `fields` but absent from props (no default) never reached its transform. In practice a `contentEditable` text/textarea field without a default prop was never transformed, so inline editing controls weren't rendered and the component was left in a broken selection state.

## Changes made

- `walkObject` now also visits fields that have a registered mapper but no value, running their transform with an `undefined` value. Slots are excluded since they're already defaulted separately via `defaultSlots`. Gated behind an `ownedFields` flag so it only applies where the field set actually describes the object (top-level props and `object` field recursion), never the fallback object-walk path.
- Added `map-fields` unit tests covering missing top-level fields, missing object subfields, fields that still have values, and field types with no mapper.

## How to test

- Add a component with a `contentEditable` text/textarea field and omit that field from `defaultProps` (e.g. the demo `Text` component without `text: "Text"`).
- Drag it onto the canvas and confirm the inline editing control (`InlineTextField`) renders and is editable.
