### PR TITLE
Added opportunity to override search button label of external field

### DIFF
--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -709,26 +709,26 @@ Overrides the text shown in the search button when [`showSearch`](#showsearch) i
 
 ```tsx {16} copy
 const config = {
-components: {
-  Example: {
-    fields: {
-      data: {
-        type: "external",
+  components: {
+    Example: {
+      fields: {
+        data: {
+          type: "external",
           fetchList: async ({ query }) => {
-          return [
-            { title: "Apple", description: "Lorem ipsum 1" },
-            { title: "Orange", description: "Lorem ipsum 2" },
-          ].filter((item) => {
-            // ...
-          });
-        },
+            return [
+              { title: "Apple", description: "Lorem ipsum 1" },
+              { title: "Orange", description: "Lorem ipsum 2" },
+            ].filter((item) => {
+              // ...
+            });
+          },
           showSearch: true,
           searchButtonLabel: "Find fruit",
+        },
       },
+      // ...
     },
-    // ...
   },
-},
 };
 ```
 
@@ -771,7 +771,7 @@ components: {
       return <p>{data?.title || "No data selected"}</p>;
     },
 
-  }}
+}}
 />
 
 <div id="puck-portal-root" />

--- a/apps/docs/pages/docs/api-reference/fields/external.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/external.mdx
@@ -66,6 +66,7 @@ const config = {
 | [`placeholder`](#placeholder)             | `placeholder: "Select content"`              | String     | -        |
 | [`renderFooter()`](#renderfooterprops)    | `renderFooter: (props) => <p>Hello</p>`      | Function   | -        |
 | [`showSearch`](#showsearch)               | `showSearch: true`                           | Boolean    | -        |
+| [`searchButtonLabel`](#searchbuttonlabel) | `searchButtonLabel: "Search"`                | String     | -        |
 
 ## Required params
 
@@ -700,6 +701,77 @@ const config = {
     },
 
 }}
+/>
+
+### `searchButtonLabel`
+
+Overrides the text shown in the search button when [`showSearch`](#showsearch) is enabled.
+
+```tsx {16} copy
+const config = {
+components: {
+  Example: {
+    fields: {
+      data: {
+        type: "external",
+          fetchList: async ({ query }) => {
+          return [
+            { title: "Apple", description: "Lorem ipsum 1" },
+            { title: "Orange", description: "Lorem ipsum 2" },
+          ].filter((item) => {
+            // ...
+          });
+        },
+          showSearch: true,
+          searchButtonLabel: "Find fruit",
+      },
+    },
+    // ...
+  },
+},
+};
+```
+
+<ConfigPreview
+  label="Example"
+  componentConfig={{
+    fields: {
+      data: {
+        type: "external",
+        fetchList: async ({ query }) => {
+          return [
+            {
+              title: "Apple",
+              description:
+                "An apple is a round, edible fruit produced by an apple tree.",
+            },
+            {
+              title: "Orange",
+              description:
+                "An orange is a fruit of various citrus species in the family Rutaceae.",
+            },
+          ].filter((item) => {
+            if (!query) return item;
+
+            const queryLowercase = query.toLowerCase();
+
+            if (item.title.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+
+            if (item.description.toLowerCase().indexOf(queryLowercase) > -1) {
+              return item;
+            }
+          })
+        },
+        showSearch: true,
+      },
+    },
+    render: ({ data }) => {
+      return <p>{data?.title || "No data selected"}</p>;
+    },
+
+  }}
 />
 
 <div id="puck-portal-root" />

--- a/packages/core/components/ExternalInput/index.tsx
+++ b/packages/core/components/ExternalInput/index.tsx
@@ -199,7 +199,7 @@ export const ExternalInput = ({
                 </label>
                 <div className={getClassNameModal("searchActions")}>
                   <Button type="submit" loading={isLoading} fullWidth>
-                    Search
+                    {field.searchButtonLabel ?? "Search"}
                   </Button>
                   {hasFilterFields && (
                     <div className={getClassNameModal("searchActionIcon")}>

--- a/packages/core/types/Fields.ts
+++ b/packages/core/types/Fields.ts
@@ -145,6 +145,7 @@ export interface ExternalField<Props extends any = { [key: string]: any }>
   mapRow?: (value: any) => Record<string, string | number | ReactElement>;
   getItemSummary?: (item: NotUndefined<Props>, index?: number) => ReactNode;
   showSearch?: boolean;
+  searchButtonLabel?: string;
   renderFooter?: (props: { items: any[] }) => ReactElement;
   initialQuery?: string;
   filterFields?: Record<string, Field>;


### PR DESCRIPTION
Closes [#535](https://github.com/puckeditor/puck/issues/535)

## Description

This PR adds opportunity to override default "Search" label of External field search button

## Changes made

External field now receives an additional optional field `searchButtonLabel`

## How to test

You just need to create `external` field and pass new parameter: `searchButtonLabel`. I used `apps/demo/config/blocks/Hero/client.tsx:20` to test it.

<img width="1036" height="263" alt="image" src="https://github.com/user-attachments/assets/c456eafa-2a0f-4636-a9d0-71a834820fe8" />

