### PR TITLE
Improve drag and drop for granular changes

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -27,6 +27,13 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   if (!isClient) return null;
 
   const params = new URL(window.location.href).searchParams;
+  const requestedDndBehavior = params.get("dndBehavior");
+  const dndBehavior =
+    requestedDndBehavior === "auto" ||
+    requestedDndBehavior === "fluid" ||
+    requestedDndBehavior === "static"
+      ? requestedDndBehavior
+      : undefined;
 
   if (isEdit) {
     return (
@@ -41,6 +48,9 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
           headerPath={path}
           iframe={{
             enabled: params.get("disableIframe") === "true" ? false : true,
+          }}
+          dnd={{
+            behavior: dndBehavior,
           }}
           fieldTransforms={{
             userField: ({ value }) => value, // Included to check types

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -123,9 +123,18 @@ Configure drag-and-drop behavior.
 
 #### dnd params
 
-| Param                                     | Example                   | Type    | Status |
-| ----------------------------------------- | ------------------------- | ------- | ------ |
-| [`disableAutoScroll`](#disableautoscroll) | `disableAutoScroll: true` | boolean | -      |
+| Param                                     | Example                   | Type                            | Status |
+| ----------------------------------------- | ------------------------- | ------------------------------- | ------ |
+| [`behavior`](#behavior)                   | `behavior: "static"`      | `"auto" \| "fluid" \| "static"` | -      |
+| [`disableAutoScroll`](#disableautoscroll) | `disableAutoScroll: true` | boolean                         | -      |
+
+##### `behavior`
+
+Control animation behavior while dragging. Defaults to `"auto"`.
+
+- `"auto"`: Use fluid behavior within a slot, then switch to a static when dragging an item between slots.
+- `"fluid"`: Move the item during a drag, animating other items out of the way.
+- `"static"`: Freeze the item in-place during a drag, showing a line placeholder at the drop destination.
 
 ##### `disableAutoScroll`
 

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -30,6 +30,11 @@ import {
   ZoneStoreProvider,
 } from "../DropZone/context";
 import { createNestedDroppablePlugin } from "../../lib/dnd/NestedDroppablePlugin";
+import { prepareCommitFlip } from "../../lib/dnd/flip-commit";
+import {
+  resolveDndMode,
+  resolveOriginPreviewIndex,
+} from "../../lib/dnd/resolve-dnd-mode";
 import { insertComponent } from "../../lib/insert-component";
 import { moveComponent } from "../../lib/move-component";
 import { useDebouncedCallback } from "use-debounce";
@@ -44,6 +49,8 @@ import { useSafeId } from "../../lib/use-safe-id";
 import { getFrame } from "../../lib/get-frame";
 import { effect } from "@dnd-kit/state";
 import { scrollIntoView } from "../../lib/scroll-into-view";
+import type { DndBehavior } from "../../types";
+import { useLinePlaceholder } from "./use-line-placeholder";
 
 const DEBUG = false;
 
@@ -86,6 +93,7 @@ const AREA_CHANGE_DEBOUNCE_MS = 100;
 type DragDropContextProps = {
   children: ReactNode;
   disableAutoScroll?: boolean;
+  behavior?: DndBehavior;
 };
 
 /**
@@ -117,6 +125,7 @@ const useTempDisableFallback = (timeout: number) => {
 const DragDropContextClient = ({
   children,
   disableAutoScroll,
+  behavior = "auto",
 }: DragDropContextProps) => {
   const dispatch = useAppStore((s) => s.dispatch);
   const instanceId = useAppStore((s) => s.instanceId);
@@ -318,6 +327,14 @@ const DragDropContextClient = ({
 
   const initialSelector = useRef<{ zone: string; index: number }>(undefined);
 
+  const {
+    getTargetIndex: getLinePlaceholderTargetIndex,
+    setActive: setLinePlaceholderActive,
+    startScrollTracking: startLinePlaceholderScrollTracking,
+    stopScrollTracking: stopLinePlaceholderScrollTracking,
+    update: updateLinePlaceholder,
+  } = useLinePlaceholder(zoneStore);
+
   const nextContextValue = useMemo<DropZoneContext>(
     () => ({
       mode: "edit",
@@ -338,12 +355,15 @@ const DragDropContextClient = ({
         plugins={plugins}
         sensors={sensors}
         onDragEnd={(event, manager) => {
+          stopLinePlaceholderScrollTracking();
+
           const entryEl = getFrame()?.querySelector("[data-puck-entry]");
           entryEl?.removeAttribute("data-puck-dragging");
 
           const { source, target } = event.operation;
 
           if (!source) {
+            setLinePlaceholderActive(false);
             zoneStore.setState({ draggedItem: null });
 
             return;
@@ -353,12 +373,40 @@ const DragDropContextClient = ({
 
           const { previewIndex = {} } = zoneStore.getState() || {};
 
+          // Look the preview up by id: during line placeholder (cross-zone)
+          // drags the source stays in its original zone, so the preview key
+          // no longer matches the source's zone. Ghost previews only pin the
+          // item visually and never describe the drop position.
           const thisPreview: Preview | null =
-            previewIndex[zone]?.props.id === source.id
-              ? previewIndex[zone]
+            Object.values(previewIndex).find(
+              (preview) => preview?.props.id === source.id && !preview.ghost
+            ) ?? null;
+
+          // Capture sibling positions now, before dnd-kit tears the drag
+          // state down, so the slide animations measure from what's on
+          // screen at the moment of drop
+          const playCommitFlip =
+            !event.canceled &&
+            target?.type !== "void" &&
+            thisPreview?.linePlaceholder
+              ? prepareCommitFlip({
+                  zones: initialSelector.current
+                    ? [initialSelector.current.zone, thisPreview.zone]
+                    : [thisPreview.zone],
+                  itemId:
+                    thisPreview.type === "move"
+                      ? thisPreview.props.id
+                      : undefined,
+                  targetZone: thisPreview.zone,
+                  getExpectedOrder: () =>
+                    appStore.getState().state.indexes.zones[thisPreview.zone]
+                      ?.contentIds ?? [],
+                })
               : null;
 
           const onAnimationEnd = () => {
+            // Keep the ghost faded until the drop animation lands
+            setLinePlaceholderActive(false);
             zoneStore.setState({ draggedItem: null });
 
             // Tidy up cancellation
@@ -380,6 +428,18 @@ const DragDropContextClient = ({
               return;
             }
 
+            // Line placeholder indices count the dragged item at its
+            // original position, so moving to a later gap within the same
+            // zone lands one index lower once the item is removed
+            const commitIndex =
+              thisPreview &&
+              thisPreview.linePlaceholder &&
+              initialSelector.current &&
+              thisPreview.zone === initialSelector.current.zone &&
+              thisPreview.index > initialSelector.current.index
+                ? thisPreview.index - 1
+                : thisPreview?.index ?? index;
+
             // Finalise the drag
             if (thisPreview) {
               zoneStore.setState({ previewIndex: {} });
@@ -395,20 +455,24 @@ const DragDropContextClient = ({
                 moveComponent(
                   thisPreview.props.id,
                   initialSelector.current,
-                  thisPreview,
+                  { ...thisPreview, index: commitIndex },
                   appStore
                 );
               }
+
+              playCommitFlip?.();
             }
 
             const movedToNewPosition =
               initialSelector.current?.zone !== thisPreview?.zone ||
-              initialSelector.current?.index !== thisPreview?.index;
+              initialSelector.current?.index !== commitIndex;
 
             dispatch({
               type: "setUi",
               ui: {
-                itemSelector: { index, zone },
+                itemSelector: thisPreview
+                  ? { index: commitIndex, zone: thisPreview.zone }
+                  : { index, zone },
                 isDragging: false,
               },
               recordHistory: movedToNewPosition,
@@ -427,6 +491,16 @@ const DragDropContextClient = ({
               onAnimationEnd();
               dispose?.();
             }
+          });
+        }}
+        onDragMove={(event, manager) => {
+          // Keep the line in the gap nearest the pointer as it moves within
+          // the target zone: collisions only re-fire when the target
+          // changes, which can leave the line in a stale gap
+          updateLinePlaceholder(manager);
+
+          dragListeners.dragmove?.forEach((fn) => {
+            fn(event, manager);
           });
         }}
         onDragOver={(event, manager) => {
@@ -500,6 +574,17 @@ const DragDropContextClient = ({
           }
 
           if (dragMode.current === "new") {
+            const useLinePlaceholder =
+              resolveDndMode(behavior, { isNewComponent: true }) === "static";
+
+            if (useLinePlaceholder) {
+              targetIndex =
+                getLinePlaceholderTargetIndex(targetZone, manager) ??
+                targetIndex;
+            }
+
+            setLinePlaceholderActive(useLinePlaceholder);
+
             zoneStore.setState({
               previewIndex: {
                 [targetZone]: {
@@ -511,6 +596,7 @@ const DragDropContextClient = ({
                   props: {
                     id: source.id.toString(),
                   },
+                  linePlaceholder: useLinePlaceholder,
                 },
               },
             });
@@ -528,18 +614,56 @@ const DragDropContextClient = ({
             );
 
             if (item) {
-              zoneStore.setState({
-                previewIndex: {
-                  [targetZone]: {
-                    componentType: sourceData.componentType,
-                    type: "move",
-                    index: targetIndex,
-                    zone: targetZone,
-                    props: item.props,
-                    element: source.element,
-                  },
+              const originZone = initialSelector.current.zone;
+              const isReparenting = originZone !== targetZone;
+              const useLinePlaceholder =
+                resolveDndMode(behavior, {
+                  isDraggingBetweenSlots: isReparenting,
+                }) === "static";
+
+              if (useLinePlaceholder) {
+                targetIndex =
+                  getLinePlaceholderTargetIndex(targetZone, manager) ??
+                  targetIndex;
+              }
+
+              setLinePlaceholderActive(useLinePlaceholder);
+
+              const previewIndex: Record<string, Preview> = {
+                [targetZone]: {
+                  componentType: sourceData.componentType,
+                  type: "move",
+                  index: targetIndex,
+                  zone: targetZone,
+                  props: item.props,
+                  element: source.element,
+                  linePlaceholder: useLinePlaceholder,
                 },
-              });
+              };
+
+              if (useLinePlaceholder && isReparenting) {
+                // Pin the item at its rendered position in the original zone.
+                // Fluid previews render at their latest index, while static
+                // previews leave the item at its initial index.
+                const originPreview =
+                  zoneStore.getState().previewIndex[originZone];
+                const originIndex = resolveOriginPreviewIndex(
+                  initialSelector.current.index,
+                  originPreview
+                );
+
+                previewIndex[originZone] = {
+                  componentType: sourceData.componentType,
+                  type: "move",
+                  index: originIndex,
+                  zone: originZone,
+                  props: item.props,
+                  element: source.element,
+                  ghost: true,
+                };
+              }
+
+              zoneStore.setState({ previewIndex });
             }
           }
 
@@ -548,20 +672,29 @@ const DragDropContextClient = ({
           });
         }}
         onDragStart={(event, manager) => {
+          // Scrolling moves the content under a stationary pointer without
+          // firing drag events, which would leave the line placeholder
+          // drifting with the page; recompute it on scroll.
+          startLinePlaceholderScrollTracking(manager);
+
           const { source } = event.operation;
 
-          if (source && source.type !== "void") {
+          if (source?.type === "component") {
             const sourceData = source.data as ComponentDndData;
+            const sourceSelector = {
+              zone: sourceData.zone,
+              index: sourceData.index,
+            };
 
-            const item = getItem(
-              {
-                zone: sourceData.zone,
-                index: sourceData.index,
-              },
-              appStore.getState().state
-            );
+            initialSelector.current = sourceSelector;
+
+            const item = getItem(sourceSelector, appStore.getState().state);
 
             if (item) {
+              const useLinePlaceholder = resolveDndMode(behavior) === "static";
+
+              setLinePlaceholderActive(useLinePlaceholder);
+
               zoneStore.setState({
                 previewIndex: {
                   [sourceData.zone]: {
@@ -571,6 +704,7 @@ const DragDropContextClient = ({
                     zone: sourceData.zone,
                     props: item.props,
                     element: source.element,
+                    linePlaceholder: useLinePlaceholder,
                   },
                 },
               });
@@ -612,6 +746,7 @@ const DragDropContextClient = ({
           }
 
           const entryEl = getFrame()?.querySelector("[data-puck-entry]");
+          setLinePlaceholderActive(false);
           entryEl?.setAttribute("data-puck-dragging", "true");
         }}
       >
@@ -628,6 +763,7 @@ const DragDropContextClient = ({
 export const DragDropContext = ({
   children,
   disableAutoScroll,
+  behavior,
 }: DragDropContextProps) => {
   const status = useAppStore((s) => s.status);
 
@@ -636,7 +772,10 @@ export const DragDropContext = ({
   }
 
   return (
-    <DragDropContextClient disableAutoScroll={disableAutoScroll}>
+    <DragDropContextClient
+      disableAutoScroll={disableAutoScroll}
+      behavior={behavior}
+    >
       {children}
     </DragDropContextClient>
   );

--- a/packages/core/components/DragDropContext/use-line-placeholder.ts
+++ b/packages/core/components/DragDropContext/use-line-placeholder.ts
@@ -1,0 +1,148 @@
+import type { DragDropManager } from "@dnd-kit/dom";
+import { useCallback, useEffect, useRef } from "react";
+import type { StoreApi } from "zustand";
+import { getFrame } from "../../lib/get-frame";
+import { getFramePointer, getNearestGapIndex } from "../../lib/dnd/nearest-gap";
+import { useAppStoreApi } from "../../store";
+import type { ZoneStore } from "../DropZone/context";
+
+const getTargetIndex = (
+  zoneEl: Element,
+  manager: DragDropManager,
+  contentIds: string[]
+) =>
+  getNearestGapIndex(
+    zoneEl,
+    getFramePointer(zoneEl, manager.dragOperation.position.current),
+    contentIds
+  );
+
+/** Owns the DOM state, pointer tracking and scroll handling for line drags. */
+export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
+  const appStore = useAppStoreApi();
+  const scrollCleanup = useRef<(() => void) | null>(null);
+
+  const setActive = useCallback((active: boolean) => {
+    const entryEl = getFrame()?.querySelector("[data-puck-entry]");
+
+    if (active) {
+      entryEl?.setAttribute("data-puck-line-drag", "true");
+    } else {
+      entryEl?.removeAttribute("data-puck-line-drag");
+    }
+  }, []);
+
+  const getTargetIndexForZone = useCallback(
+    (zone: string, manager: DragDropManager) => {
+      const zoneEl = getFrame()?.querySelector(
+        `[data-puck-dropzone="${zone}"]`
+      );
+
+      if (!zoneEl) return null;
+
+      return getTargetIndex(
+        zoneEl,
+        manager,
+        appStore.getState().state.indexes.zones[zone]?.contentIds ?? []
+      );
+    },
+    [appStore]
+  );
+
+  const update = useCallback(
+    (manager: DragDropManager) => {
+      const { previewIndex = {} } = zoneStore.getState();
+      const linePreview = Object.values(previewIndex).find(
+        (preview) => preview?.linePlaceholder
+      );
+
+      if (!linePreview) return;
+
+      const zoneEl = getFrame()?.querySelector(
+        `[data-puck-dropzone="${linePreview.zone}"]`
+      );
+
+      if (!zoneEl) return;
+
+      const pointer = getFramePointer(
+        zoneEl,
+        manager.dragOperation.position.current
+      );
+      const zoneRect = zoneEl.getBoundingClientRect();
+      const insideZone =
+        pointer.x >= zoneRect.left &&
+        pointer.x <= zoneRect.right &&
+        pointer.y >= zoneRect.top &&
+        pointer.y <= zoneRect.bottom;
+
+      if (!insideZone) return;
+
+      const nearestIndex = getNearestGapIndex(
+        zoneEl,
+        pointer,
+        appStore.getState().state.indexes.zones[linePreview.zone]?.contentIds ??
+          []
+      );
+
+      if (nearestIndex !== null && nearestIndex !== linePreview.index) {
+        zoneStore.setState({
+          previewIndex: {
+            ...previewIndex,
+            [linePreview.zone]: { ...linePreview, index: nearestIndex },
+          },
+        });
+      }
+    },
+    [appStore, zoneStore]
+  );
+
+  const stopScrollTracking = useCallback(() => {
+    scrollCleanup.current?.();
+    scrollCleanup.current = null;
+  }, []);
+
+  const startScrollTracking = useCallback(
+    (manager: DragDropManager) => {
+      stopScrollTracking();
+
+      const frameDoc = getFrame();
+
+      if (!frameDoc) return;
+
+      let raf: number | null = null;
+
+      const handleScroll = () => {
+        if (raf !== null) return;
+
+        raf = requestAnimationFrame(() => {
+          raf = null;
+          update(manager);
+        });
+      };
+
+      frameDoc.addEventListener("scroll", handleScroll, {
+        capture: true,
+        passive: true,
+      });
+
+      scrollCleanup.current = () => {
+        if (raf !== null) cancelAnimationFrame(raf);
+
+        frameDoc.removeEventListener("scroll", handleScroll, {
+          capture: true,
+        });
+      };
+    },
+    [stopScrollTracking, update]
+  );
+
+  useEffect(() => stopScrollTracking, [stopScrollTracking]);
+
+  return {
+    getTargetIndex: getTargetIndexForZone,
+    setActive,
+    startScrollTracking,
+    stopScrollTracking,
+    update,
+  };
+};

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -26,7 +26,7 @@ import { dropZoneContext, DropZoneProvider } from "../DropZone";
 import { createDynamicCollisionDetector } from "../../lib/dnd/collision/dynamic";
 import { DragAxis } from "../../types";
 import { UniqueIdentifier } from "@dnd-kit/abstract";
-import { Feedback } from "@dnd-kit/dom";
+import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
 import { getDeepScrollPosition } from "../../lib/get-deep-scroll-position";
 import { DropZoneContext, ZoneStoreContext } from "../DropZone/context";
 import { useShallow } from "zustand/react/shallow";
@@ -34,6 +34,7 @@ import { getItem } from "../../lib/data/get-item";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useContextStore } from "../../lib/use-context-store";
 import { useOnDragFinished } from "../../lib/dnd/use-on-drag-finished";
+import { runDropAnimation } from "../../lib/dnd/drop-animation";
 import { LoadedRichTextMenu } from "../RichTextMenu";
 import type { NodeHandle } from "../../store/slices/nodes";
 import { assignRefs } from "../../lib/assign-refs";
@@ -178,12 +179,38 @@ export const DraggableComponent = ({
   );
 
   const zoneStore = useContext(ZoneStoreContext);
+  const appStore = useAppStoreApi();
 
   const [dragAxis, setDragAxis] = useState(userDragAxis || autoDragAxis);
 
   const dynamicCollisionDetector = useMemo(
     () => createDynamicCollisionDetector(dragAxis),
     [dragAxis]
+  );
+
+  // The default drop animation targets the source placeholder. Line drags and
+  // drawer insertion previews instead commit immediately and glide a visual
+  // copy to the item's final rendered position.
+  const dropAnimation: DropAnimationFunction = useCallback(
+    (context) => {
+      const preview = Object.values(
+        zoneStore.getState().previewIndex ?? {}
+      ).find((preview) => preview?.props.id === id && !preview.ghost);
+
+      return runDropAnimation(
+        context,
+        preview?.linePlaceholder || preview?.type === "insert"
+          ? {
+              itemId: preview.type === "move" ? id : undefined,
+              targetZone: preview.zone,
+              getExpectedOrder: () =>
+                appStore.getState().state.indexes.zones[preview.zone]
+                  ?.contentIds ?? [],
+            }
+          : undefined
+      );
+    },
+    [zoneStore, appStore, id]
   );
 
   const {
@@ -214,7 +241,7 @@ export const DraggableComponent = ({
     },
     plugins: (defaults) => [
       ...defaults,
-      Feedback.configure({ feedback: "clone" }),
+      Feedback.configure({ feedback: "clone", dropAnimation }),
     ],
   });
 
@@ -445,8 +472,6 @@ export const DraggableComponent = ({
     },
     [index, zoneCompound, id, isSelected, _experimentalFullScreenCanvas]
   );
-
-  const appStore = useAppStoreApi();
 
   const onSelectParent = useCallback(() => {
     const { nodes, zones } = appStore.getState().state.indexes;

--- a/packages/core/components/DraggableComponent/styles.css
+++ b/packages/core/components/DraggableComponent/styles.css
@@ -20,8 +20,10 @@
   cursor: pointer;
 }
 
-/* Placeholder */
-[data-dnd-placeholder] {
+/* Placeholder. The entry carries data-puck-line-drag during line placeholder
+   drags, where the placeholder renders as a faded ghost
+   of the actual content instead of a solid block */
+[data-dnd-placeholder]:not([data-puck-line-drag] *) {
   background: var(
     --puck-slot-component-color-placeholder,
     var(--puck-color-azure-06)
@@ -33,10 +35,16 @@
   transition: none !important;
 }
 
-[data-dnd-placeholder] *,
-[data-dnd-placeholder]::after,
-[data-dnd-placeholder]::before {
+[data-dnd-placeholder]:not([data-puck-line-drag] *) *,
+[data-dnd-placeholder]:not([data-puck-line-drag] *)::after,
+[data-dnd-placeholder]:not([data-puck-line-drag] *)::before {
   opacity: 0 !important;
+}
+
+[data-puck-line-drag] [data-dnd-placeholder] {
+  opacity: 0.4 !important;
+  outline: none !important;
+  transition: none !important;
 }
 
 [data-dnd-dragging][data-puck-component] {

--- a/packages/core/components/Drawer/index.tsx
+++ b/packages/core/components/Drawer/index.tsx
@@ -1,11 +1,23 @@
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { DragIcon } from "../DragIcon";
-import { ReactElement, ReactNode, Ref, useMemo, useState } from "react";
+import {
+  ReactElement,
+  ReactNode,
+  Ref,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { generateId } from "../../lib/generate-id";
 import { useDragListener } from "../DragDropContext";
 import { useSafeId } from "../../lib/use-safe-id";
 import { useDraggable, useDroppable } from "@dnd-kit/react";
+import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
+import { ZoneStoreContext } from "../DropZone/context";
+import { useAppStoreApi } from "../../store";
+import { runDropAnimation } from "../../lib/dnd/drop-animation";
 
 const getClassName = getClassNameFactory("Drawer", styles);
 const getClassNameItem = getClassNameFactory("DrawerItem", styles);
@@ -72,11 +84,36 @@ const DrawerItemDraggable = ({
   id: string;
   isDragDisabled?: boolean;
 }) => {
+  const zoneStore = useContext(ZoneStoreContext);
+  const appStore = useAppStoreApi();
+
+  const dropAnimation: DropAnimationFunction = useCallback(
+    (context) => {
+      const preview = Object.values(
+        zoneStore.getState().previewIndex ?? {}
+      ).find((preview) => preview?.type === "insert");
+
+      return runDropAnimation(
+        context,
+        preview
+          ? {
+              targetZone: preview.zone,
+              getExpectedOrder: () =>
+                appStore.getState().state.indexes.zones[preview.zone]
+                  ?.contentIds ?? [],
+            }
+          : undefined
+      );
+    },
+    [appStore, zoneStore]
+  );
+
   const { ref } = useDraggable({
     id,
     data: { componentType: name },
     disabled: isDragDisabled,
     type: "drawer",
+    plugins: [Feedback.configure({ dropAnimation })],
   });
 
   return (

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -1,0 +1,139 @@
+import { CSSProperties, RefObject, useLayoutEffect, useState } from "react";
+import { getClassNameFactory } from "../../lib";
+import type { DragAxis } from "../../types";
+import styles from "./styles.module.css";
+
+const getClassName = getClassNameFactory("DropZone", styles);
+const LINE_PLACEHOLDER_SIZE = 4;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+/**
+ * A thin line rendered at the insertion point during static drags.
+ * Positioned from neighboring item rects so it never affects zone layout.
+ */
+export const LinePlaceholder = ({
+  zoneRef,
+  contentIds,
+  index,
+  dragAxis,
+}: {
+  zoneRef: RefObject<HTMLDivElement | null>;
+  contentIds: string[];
+  index: number;
+  dragAxis: DragAxis;
+}) => {
+  const [style, setStyle] = useState<CSSProperties>();
+
+  useLayoutEffect(() => {
+    const zoneEl = zoneRef.current;
+
+    if (!zoneEl) return;
+
+    const win = zoneEl.ownerDocument.defaultView;
+    const styleOf = (el?: Element | null) =>
+      el && win ? win.getComputedStyle(el) : undefined;
+    const px = (value?: string) => parseFloat(value ?? "") || 0;
+    const getItem = (itemIndex: number) => {
+      const id = contentIds[itemIndex];
+
+      if (typeof id === "undefined") return undefined;
+
+      // Exclude the flying drag element: in same-zone line drags the item's
+      // in-flow position is represented by its placeholder clone.
+      const el = zoneEl.querySelector(
+        `:scope > [data-puck-component="${CSS.escape(
+          id
+        )}"]:not([data-dnd-dragging])`
+      );
+
+      if (!el) return undefined;
+
+      return { el, rect: el.getBoundingClientRect() };
+    };
+
+    const zoneRect = zoneEl.getBoundingClientRect();
+    const zoneStyle = styleOf(zoneEl);
+    const prev = getItem(index - 1);
+    const next = getItem(index);
+    const closest = next ?? prev;
+    const size = LINE_PLACEHOLDER_SIZE;
+
+    if (dragAxis === "y") {
+      const rowGap = px(zoneStyle?.rowGap);
+
+      // Vertical flows insert between rows. At the edges, respect the zone
+      // gap or sibling margin; in empty zones, start after the zone padding.
+      const y = next
+        ? prev && prev.rect.bottom <= next.rect.top
+          ? (prev.rect.bottom + next.rect.top) / 2
+          : next.rect.top -
+            Math.max(px(styleOf(next.el)?.marginTop), rowGap) / 2
+        : prev
+        ? prev.rect.bottom +
+          Math.max(px(styleOf(prev.el)?.marginBottom), rowGap) / 2
+        : zoneRect.top + px(zoneStyle?.paddingTop);
+
+      setStyle({
+        left:
+          (closest?.rect.left ?? zoneRect.left + px(zoneStyle?.paddingLeft)) -
+          zoneRect.left +
+          zoneEl.scrollLeft,
+        width:
+          closest?.rect.width ??
+          zoneRect.width -
+            px(zoneStyle?.paddingLeft) -
+            px(zoneStyle?.paddingRight),
+        top: clamp(
+          y - zoneRect.top + zoneEl.scrollTop - size / 2,
+          0,
+          zoneEl.scrollHeight - size
+        ),
+        height: size,
+      });
+    } else {
+      const columnGap = px(zoneStyle?.columnGap);
+
+      // Horizontal and grid flows use a vertical caret at the insertion edge.
+      // Row wraps and edge positions respect the zone gap or sibling margin.
+      const x = next
+        ? prev && prev.rect.right <= next.rect.left
+          ? (prev.rect.right + next.rect.left) / 2
+          : next.rect.left -
+            Math.max(px(styleOf(next.el)?.marginLeft), columnGap) / 2
+        : prev
+        ? prev.rect.right +
+          Math.max(px(styleOf(prev.el)?.marginRight), columnGap) / 2
+        : zoneRect.left + px(zoneStyle?.paddingLeft);
+
+      setStyle({
+        top:
+          (closest?.rect.top ?? zoneRect.top + px(zoneStyle?.paddingTop)) -
+          zoneRect.top +
+          zoneEl.scrollTop,
+        height:
+          closest?.rect.height ??
+          zoneRect.height -
+            px(zoneStyle?.paddingTop) -
+            px(zoneStyle?.paddingBottom),
+        left: clamp(
+          x - zoneRect.left + zoneEl.scrollLeft - size / 2,
+          0,
+          zoneEl.scrollWidth - size
+        ),
+        width: size,
+      });
+    }
+  }, [zoneRef, contentIds, index, dragAxis]);
+
+  if (!style) return null;
+
+  return (
+    <div
+      className={getClassName("linePlaceholder")}
+      style={style}
+      data-puck-line-placeholder
+    />
+  );
+};

--- a/packages/core/components/DropZone/VirtualizedDropZone.tsx
+++ b/packages/core/components/DropZone/VirtualizedDropZone.tsx
@@ -64,7 +64,13 @@ export const VirtualizedDropZone = ({
 
   const dragTargetParentId = useContextStore(ZoneStoreContext, (s) => {
     if (s.draggedItem?.id) {
-      const parentZone = Object.keys(s.previewIndex ?? {})[0];
+      // Ghost previews only pin the item in its original zone; the drop
+      // target is described by the non-ghost preview
+      const [parentZone] =
+        Object.entries(s.previewIndex ?? {}).find(
+          ([, preview]) => !preview?.ghost
+        ) ?? [];
+
       return parentZone?.split(":")[0];
     }
 

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -33,6 +33,17 @@ export type Preview = {
   props: Record<string, any>;
   type: "insert" | "move";
   element: Element | undefined;
+  /**
+   * Render a thin line at the insertion point instead of the full item,
+   * preventing layout shift.
+   */
+  linePlaceholder?: boolean;
+  /**
+   * Pins the dragged item at its last previewed position in its original
+   * zone while a line placeholder shows in another zone, preventing the
+   * original zone from shifting back. Ignored when committing the drag.
+   */
+  ghost?: boolean;
 } | null;
 
 export type RootVirtualizerHandle = {

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -54,6 +54,7 @@ import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
 import { MemoizeComponent } from "../MemoizeComponent";
 import { VirtualizedDropZone } from "./VirtualizedDropZone";
+import { LinePlaceholder } from "./LinePlaceholder";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -444,7 +445,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
     const isDropEnabled =
       isEnabled &&
       (preview
-        ? contentIdsWithPreview.length === 1
+        ? contentIdsWithPreview.length === (preview.linePlaceholder ? 0 : 1)
         : contentIdsWithPreview.length === 0);
 
     const zoneStore = useContext(ZoneStoreContext);
@@ -551,6 +552,14 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
               inDroppableZone={targetAccepted}
             />
           ))
+        )}
+        {preview?.linePlaceholder && (
+          <LinePlaceholder
+            zoneRef={ref}
+            contentIds={contentIds}
+            index={preview.index}
+            dragAxis={dragAxis}
+          />
         )}
       </El>
     );

--- a/packages/core/components/DropZone/lib/use-content-with-preview.ts
+++ b/packages/core/components/DropZone/lib/use-content-with-preview.ts
@@ -30,7 +30,8 @@ export const useContentIdsWithPreview = (
       preview: Preview | undefined,
       isDragging: boolean,
       draggedItemId?: string,
-      previewExists?: boolean
+      previewExists?: boolean,
+      linePlaceholderActive?: boolean
     ) => {
       // Preview is cleared but context hasn't yet caught up
       // This is necessary because Zustand clears the preview before the dispatcher finishes
@@ -38,27 +39,19 @@ export const useContentIdsWithPreview = (
         return;
       }
 
-      if (preview) {
-        if (preview.type === "insert") {
-          setContentIdsWithPreview(
-            insert(
-              contentIds.filter((id) => id !== preview.props.id),
-              preview.index,
-              preview.props.id
-            )
-          );
-        } else {
-          setContentIdsWithPreview(
-            insert(
-              contentIds.filter((id) => id !== preview.props.id),
-              preview.index,
-              preview.props.id
-            )
-          );
-        }
-      } else {
+      if (preview && !preview.linePlaceholder) {
         setContentIdsWithPreview(
-          previewExists
+          insert(
+            contentIds.filter((id) => id !== preview.props.id),
+            preview.index,
+            preview.props.id
+          )
+        );
+      } else {
+        // Line placeholders render as a zone overlay rather than as content,
+        // and the rendered item order remains unchanged during the drag
+        setContentIdsWithPreview(
+          previewExists && !linePlaceholderActive
             ? contentIds.filter((id) => id !== draggedItemId)
             : contentIds
         );
@@ -76,14 +69,17 @@ export const useContentIdsWithPreview = (
     // the renderedCallback.
     const s = zoneStore.getState();
     const draggedItemId = s.draggedItem?.id;
-    const previewExists = Object.keys(s.previewIndex || {}).length > 0;
+    const previews = Object.values(s.previewIndex || {});
+    const previewExists = previews.length > 0;
+    const linePlaceholderActive = previews.some((p) => p?.linePlaceholder);
 
     updateContent(
       contentIds,
       preview,
       isDragging,
       draggedItemId,
-      previewExists
+      previewExists,
+      linePlaceholderActive
     );
   }, [contentIds, preview, isDragging]);
 

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -40,6 +40,17 @@
   position: relative;
 }
 
+.DropZone-linePlaceholder {
+  background: var(
+    --puck-slot-component-color-placeholder,
+    var(--puck-color-azure-06)
+  );
+  border-radius: 2px;
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+}
+
 .DropZone-hitbox {
   position: absolute;
   bottom: calc(var(--puck-space-3) * -1);
@@ -54,7 +65,7 @@
     var(--puck-slot-color-border, var(--puck-color-selection-border));
 }
 
-.DropZone > *:not([data-puck-component]) {
+.DropZone > *:not([data-puck-component]):not([data-puck-line-placeholder]) {
   opacity: 0;
 }
 

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -274,7 +274,10 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
       id={instanceId}
       style={{ height, visibility: "hidden" }}
     >
-      <DragDropContext disableAutoScroll={dnd?.disableAutoScroll}>
+      <DragDropContext
+        disableAutoScroll={dnd?.disableAutoScroll}
+        behavior={dnd?.behavior}
+      >
         <CustomPuck>
           {children || (
             <FrameProvider>

--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -28,6 +28,7 @@ import type {
   Metadata,
   AsFieldProps,
   DefaultComponentProps,
+  DndBehavior,
 } from "../../types";
 
 import { PuckAction } from "../../reducer";
@@ -85,6 +86,14 @@ type PuckProps<
   iframe?: IframeConfig;
   dnd?: {
     disableAutoScroll?: boolean;
+    /**
+     * - `auto` (default): fluid drags within a slot, switching to a static
+     *   line placeholder when dragging between slots or inserting a new item
+     * - `fluid`: always animate sibling items during a drag
+     * - `static`: always show a line placeholder during a drag, only
+     *   animating sibling items on drop
+     */
+    behavior?: DndBehavior;
   };
   initialHistory?: InitialHistory;
   metadata?: Metadata;

--- a/packages/core/components/Sortable/styles.css
+++ b/packages/core/components/Sortable/styles.css
@@ -1,8 +1,11 @@
-[data-dnd-placeholder] * {
+/* Guarded with data-puck-line-drag so canvas placeholders can render as a
+   faded ghost during line placeholder drags — see
+   DraggableComponent/styles.css */
+[data-dnd-placeholder]:not([data-puck-line-drag] *) * {
   opacity: 0 !important;
 }
 
-[data-dnd-placeholder] {
+[data-dnd-placeholder]:not([data-puck-line-drag] *) {
   background: var(
     --_puck-field-array-color-placeholder,
     var(--puck-color-azure-06)

--- a/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
+++ b/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
@@ -1,0 +1,84 @@
+import { runTargetDropAnimation } from "../drop-animation";
+
+jest.mock("../../get-frame", () => ({
+  getFrame: () => document,
+}));
+
+const rect = (top: number): DOMRect =>
+  ({
+    top,
+    bottom: top + 100,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeItem = (id: string, top: number) => {
+  const element = document.createElement("div");
+
+  element.setAttribute("data-puck-component", id);
+  element.getBoundingClientRect = () => rect(top);
+
+  return element;
+};
+
+describe("runTargetDropAnimation", () => {
+  let animationFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    animationFrames = [];
+    document.body.innerHTML = "";
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => ({ finished: Promise.resolve() })),
+    });
+  });
+
+  it("animates a new drawer item to its inferred committed element", () => {
+    const zone = document.createElement("div");
+    const existing = makeItem("existing", 100);
+    const feedback = document.createElement("div");
+    let expectedOrder = ["existing"];
+
+    zone.setAttribute("data-puck-dropzone", "root:slot");
+    zone.append(existing);
+    document.body.append(zone, feedback);
+    feedback.getBoundingClientRect = () => rect(300);
+
+    runTargetDropAnimation({
+      feedbackElement: feedback,
+      targetZone: "root:slot",
+      getExpectedOrder: () => expectedOrder,
+    });
+
+    const inserted = makeItem("inserted", 0);
+    expectedOrder = ["inserted", "existing"];
+    zone.prepend(inserted);
+    animationFrames.forEach((callback) => callback(0));
+
+    const copy = document.body.querySelector<HTMLElement>(
+      '[inert][style*="2147483647"]'
+    );
+
+    expect(copy).not.toBeNull();
+    expect(copy?.animate).toHaveBeenCalledWith(
+      {
+        translate: ["0px 0px 0", "0px -300px 0"],
+        width: ["100px", "100px"],
+        height: ["100px", "100px"],
+      },
+      { duration: 250, easing: "ease", fill: "forwards" }
+    );
+  });
+});

--- a/packages/core/lib/dnd/__tests__/flip-commit.spec.ts
+++ b/packages/core/lib/dnd/__tests__/flip-commit.spec.ts
@@ -1,0 +1,89 @@
+import { prepareCommitFlip } from "../flip-commit";
+
+jest.mock("../../get-frame", () => ({
+  getFrame: () => document,
+}));
+
+const rect = (top: number): DOMRect =>
+  ({
+    top,
+    bottom: top + 100,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeItem = (id: string, top: number) => {
+  const element = document.createElement("div");
+
+  element.setAttribute("data-puck-component", id);
+  element.getBoundingClientRect = () => rect(top);
+  element.animate = jest.fn() as typeof element.animate;
+
+  return element;
+};
+
+describe("commit animations", () => {
+  let animationFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    animationFrames = [];
+    document.body.innerHTML = "";
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => ({ finished: Promise.resolve() })),
+    });
+  });
+
+  const flushAnimationFrame = () => {
+    const callbacks = animationFrames;
+    animationFrames = [];
+    callbacks.forEach((callback) => callback(0));
+  };
+
+  it("infers a newly inserted item and animates its displaced siblings", () => {
+    const zone = document.createElement("div");
+    const first = makeItem("first", 0);
+    const second = makeItem("second", 100);
+    let expectedOrder = ["first", "second"];
+
+    zone.setAttribute("data-puck-dropzone", "root:slot");
+    zone.append(first, second);
+    document.body.appendChild(zone);
+
+    const play = prepareCommitFlip({
+      zones: ["root:slot"],
+      targetZone: "root:slot",
+      getExpectedOrder: () => expectedOrder,
+    });
+
+    const inserted = makeItem("inserted", 0);
+    first.getBoundingClientRect = () => rect(100);
+    second.getBoundingClientRect = () => rect(200);
+    expectedOrder = ["inserted", "first", "second"];
+    zone.prepend(inserted);
+
+    play();
+    flushAnimationFrame();
+
+    expect(first.animate).toHaveBeenCalledWith(
+      { translate: ["0px -100px 0", "0px 0px 0"] },
+      { duration: 250, easing: "ease" }
+    );
+    expect(second.animate).toHaveBeenCalledWith(
+      { translate: ["0px -100px 0", "0px 0px 0"] },
+      { duration: 250, easing: "ease" }
+    );
+  });
+});

--- a/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
+++ b/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
@@ -1,0 +1,101 @@
+import { getNearestGapIndex } from "../nearest-gap";
+
+type ItemSpec = { id: string; top: number; height: number };
+
+const rect = (top: number, height: number): DOMRect =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 100,
+    width: 100,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeZone = (items: ItemSpec[]) => {
+  const zone = document.createElement("div");
+
+  items.forEach(({ id, top, height }) => {
+    const el = document.createElement("div");
+
+    el.setAttribute("data-puck-component", id);
+    el.getBoundingClientRect = () => rect(top, height);
+
+    zone.appendChild(el);
+  });
+
+  document.body.appendChild(zone);
+
+  return zone;
+};
+
+describe("getNearestGapIndex", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the index of the gap nearest the pointer", () => {
+    const contentIds = ["a", "b", "c"];
+    const zone = makeZone([
+      { id: "a", top: 0, height: 100 },
+      { id: "b", top: 100, height: 100 },
+      { id: "c", top: 200, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 5 }, contentIds)).toBe(0);
+    expect(getNearestGapIndex(zone, { x: 50, y: 90 }, contentIds)).toBe(1);
+    expect(getNearestGapIndex(zone, { x: 50, y: 110 }, contentIds)).toBe(1);
+    expect(getNearestGapIndex(zone, { x: 50, y: 190 }, contentIds)).toBe(2);
+    expect(getNearestGapIndex(zone, { x: 50, y: 290 }, contentIds)).toBe(3);
+  });
+
+  it("maps rendered items to their content indices in virtualized zones", () => {
+    // 50 items, but only a window (20..23) is rendered in the DOM
+    const contentIds = Array.from({ length: 50 }, (_, i) => `item-${i}`);
+    const zone = makeZone([
+      { id: "item-20", top: 0, height: 100 },
+      { id: "item-21", top: 100, height: 100 },
+      { id: "item-22", top: 200, height: 100 },
+      { id: "item-23", top: 300, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 95 }, contentIds)).toBe(21);
+    expect(getNearestGapIndex(zone, { x: 50, y: 205 }, contentIds)).toBe(22);
+    expect(getNearestGapIndex(zone, { x: 50, y: 390 }, contentIds)).toBe(24);
+    expect(getNearestGapIndex(zone, { x: 50, y: 4 }, contentIds)).toBe(20);
+  });
+
+  it("exposes both edges of a virtualization discontinuity", () => {
+    const contentIds = Array.from({ length: 50 }, (_, i) => `item-${i}`);
+
+    // item-10 is pinned (e.g. selected) far above the rendered window
+    const zone = makeZone([
+      { id: "item-10", top: 0, height: 100 },
+      { id: "item-30", top: 500, height: 100 },
+      { id: "item-31", top: 600, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 105 }, contentIds)).toBe(11);
+    expect(getNearestGapIndex(zone, { x: 50, y: 495 }, contentIds)).toBe(30);
+  });
+
+  it("ignores elements that aren't part of the zone's content", () => {
+    const contentIds = ["a", "b"];
+    const zone = makeZone([
+      { id: "a", top: 0, height: 100 },
+      { id: "spacer", top: 100, height: 50 }, // e.g. virtualizer gap element
+      { id: "b", top: 150, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 130 }, contentIds)).toBe(1);
+  });
+
+  it("returns 0 for empty zones", () => {
+    const zone = makeZone([]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 50 }, [])).toBe(0);
+  });
+});

--- a/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
+++ b/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
@@ -1,0 +1,46 @@
+import { resolveDndMode, resolveOriginPreviewIndex } from "../resolve-dnd-mode";
+
+describe("resolveDndMode", () => {
+  it("uses fluid mode within a slot for auto behavior", () => {
+    expect(resolveDndMode("auto")).toBe("fluid");
+  });
+
+  it("uses static mode between slots and for new components for auto behavior", () => {
+    expect(resolveDndMode("auto", { isDraggingBetweenSlots: true })).toBe(
+      "static"
+    );
+    expect(resolveDndMode("auto", { isNewComponent: true })).toBe("static");
+  });
+
+  it("always uses fluid mode for fluid behavior", () => {
+    expect(resolveDndMode("fluid")).toBe("fluid");
+    expect(resolveDndMode("fluid", { isDraggingBetweenSlots: true })).toBe(
+      "fluid"
+    );
+    expect(resolveDndMode("fluid", { isNewComponent: true })).toBe("fluid");
+  });
+
+  it("always uses static mode for static behavior", () => {
+    expect(resolveDndMode("static")).toBe("static");
+    expect(resolveDndMode("static", { isDraggingBetweenSlots: true })).toBe(
+      "static"
+    );
+    expect(resolveDndMode("static", { isNewComponent: true })).toBe("static");
+  });
+});
+
+describe("resolveOriginPreviewIndex", () => {
+  it("pins static previews to the initial rendered index", () => {
+    expect(
+      resolveOriginPreviewIndex(0, { index: 2, linePlaceholder: true })
+    ).toBe(0);
+  });
+
+  it("pins fluid previews to their latest rendered index", () => {
+    expect(resolveOriginPreviewIndex(0, { index: 2 })).toBe(2);
+  });
+
+  it("falls back to the initial index without a preview", () => {
+    expect(resolveOriginPreviewIndex(1)).toBe(1);
+  });
+});

--- a/packages/core/lib/dnd/commit-animation.ts
+++ b/packages/core/lib/dnd/commit-animation.ts
@@ -1,0 +1,82 @@
+export const COMMIT_ANIMATION: KeyframeAnimationOptions = {
+  duration: 250,
+  easing: "ease",
+};
+
+const MAX_COMMIT_WAIT_FRAMES = 10;
+
+export const prefersReducedMotion = (doc: Document) =>
+  doc.defaultView?.matchMedia("(prefers-reduced-motion: reduce)").matches ??
+  false;
+
+type WaitForCommitOptions = {
+  zones: string[];
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+  initialExpectedOrder?: string[];
+};
+
+/**
+ * Waits for a dispatched move or insert to render. The committed item must
+ * appear in the target zone's expected order and leave every other zone.
+ * Inserted item ids are inferred by comparing the pre- and post-commit order.
+ */
+export const waitForCommit = (
+  doc: Document,
+  {
+    zones,
+    itemId,
+    targetZone,
+    getExpectedOrder,
+    initialExpectedOrder = [],
+  }: WaitForCommitOptions,
+  callback: (committed: HTMLElement | null) => void
+) => {
+  let attempts = 0;
+
+  const tick = () => {
+    const zoneEl = doc.querySelector(`[data-puck-dropzone="${targetZone}"]`);
+    const expected = getExpectedOrder();
+    const committedItemId =
+      itemId ?? expected.find((id) => !initialExpectedOrder.includes(id));
+    const committed = committedItemId
+      ? zoneEl?.querySelector<HTMLElement>(
+          `:scope > [data-puck-component="${committedItemId}"]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+        ) ?? null
+      : null;
+    const rendered = zoneEl
+      ? Array.from(
+          zoneEl.querySelectorAll(
+            ":scope > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])"
+          )
+        ).map((el) => el.getAttribute("data-puck-component"))
+      : [];
+    const expectedRendered = expected.filter((id) => rendered.includes(id));
+    const orderMatches =
+      rendered.length === expectedRendered.length &&
+      rendered.every((id, index) => id === expectedRendered[index]);
+    const leftOtherZones = zones.every(
+      (zone) =>
+        zone === targetZone ||
+        !committedItemId ||
+        !doc.querySelector(
+          `[data-puck-dropzone="${zone}"] > [data-puck-component="${committedItemId}"]`
+        )
+    );
+
+    if (
+      (!committed || !orderMatches || !leftOtherZones) &&
+      attempts < MAX_COMMIT_WAIT_FRAMES
+    ) {
+      attempts++;
+      requestAnimationFrame(tick);
+
+      return;
+    }
+
+    callback(committed);
+  };
+
+  requestAnimationFrame(tick);
+};

--- a/packages/core/lib/dnd/drop-animation.ts
+++ b/packages/core/lib/dnd/drop-animation.ts
@@ -1,0 +1,246 @@
+import type { DropAnimationFunction } from "@dnd-kit/dom";
+import { getFrame } from "../get-frame";
+import {
+  COMMIT_ANIMATION,
+  prefersReducedMotion,
+  waitForCommit,
+} from "./commit-animation";
+
+type DropAnimationContext = Parameters<DropAnimationFunction>[0];
+
+type TargetDrop = {
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+};
+
+const parseTranslateValue = (value: string) => {
+  if (!value || value === "none") return null;
+
+  const [x, y = "0px"] = value.split(" ");
+  const parsed = { x: parseFloat(x), y: parseFloat(y) };
+
+  if (isNaN(parsed.x) || isNaN(parsed.y)) return null;
+
+  return parsed;
+};
+
+const getFrameTransform = (element: Element, boundary: Element | null) => {
+  const transform = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
+  let frame = element.ownerDocument.defaultView
+    ?.frameElement as HTMLIFrameElement | null;
+
+  while (frame && frame !== boundary) {
+    const rect = frame.getBoundingClientRect();
+    const scaleX = frame.offsetWidth ? rect.width / frame.offsetWidth : 1;
+    const scaleY = frame.offsetHeight ? rect.height / frame.offsetHeight : 1;
+
+    transform.x += rect.left;
+    transform.y += rect.top;
+    transform.scaleX *= scaleX;
+    transform.scaleY *= scaleY;
+    frame = frame.ownerDocument.defaultView
+      ?.frameElement as HTMLIFrameElement | null;
+  }
+
+  return transform;
+};
+
+const getRectInDocument = (element: HTMLElement, doc: Document) => {
+  const rect = element.getBoundingClientRect();
+
+  if (element.ownerDocument === doc) {
+    return rect;
+  }
+
+  const transform = getFrameTransform(
+    element,
+    doc.defaultView?.frameElement ?? null
+  );
+
+  return {
+    left: rect.left * transform.scaleX + transform.x,
+    top: rect.top * transform.scaleY + transform.y,
+    width: rect.width * transform.scaleX,
+    height: rect.height * transform.scaleY,
+  };
+};
+
+/**
+ * Matches dnd-kit's default behavior when a drag needs to return to its
+ * source placeholder, such as a canceled or invalid drop.
+ */
+export const runFallbackDropAnimation: DropAnimationFunction = ({
+  element,
+  feedbackElement,
+  placeholder,
+  translate,
+}) => {
+  const target = placeholder ?? element;
+  const currentRect = feedbackElement.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const finalPosition = {
+    x: targetRect.left + (targetRect.width - currentRect.width) / 2,
+    y: targetRect.top + (targetRect.height - currentRect.height) / 2,
+  };
+  const win = feedbackElement.ownerDocument.defaultView ?? window;
+  const currentTranslate =
+    parseTranslateValue(
+      win.getComputedStyle(feedbackElement as HTMLElement).translate
+    ) ?? translate;
+  const finalTranslate = {
+    x: currentTranslate.x + finalPosition.x - currentRect.left,
+    y: currentTranslate.y + finalPosition.y - currentRect.top,
+  };
+
+  feedbackElement.setAttribute("data-dnd-dropping", "");
+
+  return feedbackElement
+    .animate(
+      {
+        translate: [
+          `${currentTranslate.x}px ${currentTranslate.y}px 0`,
+          `${finalTranslate.x}px ${finalTranslate.y}px 0`,
+        ],
+      },
+      COMMIT_ANIMATION
+    )
+    .finished.catch(() => undefined)
+    .then(() => {
+      feedbackElement.removeAttribute("data-dnd-dropping");
+    });
+};
+
+/**
+ * Commits a valid drop immediately, then glides a visual copy from the
+ * pointer to the final rendered item in the canvas.
+ */
+export const runTargetDropAnimation = ({
+  feedbackElement,
+  itemId,
+  targetZone,
+  getExpectedOrder,
+}: {
+  feedbackElement: HTMLElement;
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+}) => {
+  const overlayDoc = feedbackElement.ownerDocument;
+  const targetDoc = getFrame() ?? overlayDoc;
+
+  if (prefersReducedMotion(overlayDoc)) return;
+
+  const rect = feedbackElement.getBoundingClientRect();
+  const initialExpectedOrder = getExpectedOrder();
+  const copy = feedbackElement.cloneNode(true) as HTMLElement;
+
+  copy.removeAttribute("id");
+  copy.removeAttribute("popover");
+  copy.removeAttribute("data-puck-component");
+  copy.removeAttribute("data-puck-dnd");
+  copy.removeAttribute("data-dnd-dragging");
+  copy.setAttribute("inert", "true");
+
+  Object.assign(copy.style, {
+    position: "fixed",
+    left: `${rect.left}px`,
+    top: `${rect.top}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    margin: "0",
+    overflow: "hidden",
+    pointerEvents: "none",
+    transform: "none",
+    transition: "none",
+    translate: "none",
+    zIndex: "2147483647",
+  });
+
+  const hideStyle = targetDoc.createElement("style");
+  hideStyle.textContent = `
+    ${
+      itemId
+        ? `[data-puck-component="${itemId}"] { visibility: hidden !important; }`
+        : ""
+    }
+    [data-puck-overlay] { opacity: 0 !important; }
+  `;
+
+  targetDoc.head.appendChild(hideStyle);
+  overlayDoc.body.appendChild(copy);
+
+  const cleanup = () => {
+    copy.remove();
+    hideStyle.remove();
+  };
+
+  waitForCommit(
+    targetDoc,
+    {
+      zones: [targetZone],
+      itemId,
+      targetZone,
+      getExpectedOrder,
+      initialExpectedOrder,
+    },
+    (committed) => {
+      if (!committed) {
+        cleanup();
+
+        return;
+      }
+
+      const committedId = committed.getAttribute("data-puck-component");
+
+      if (!itemId && committedId) {
+        hideStyle.textContent += `
+          [data-puck-component="${committedId}"] { visibility: hidden !important; }
+        `;
+      }
+
+      const final = getRectInDocument(committed, overlayDoc);
+
+      copy
+        .animate(
+          {
+            translate: [
+              "0px 0px 0",
+              `${final.left - rect.left}px ${final.top - rect.top}px 0`,
+            ],
+            width: [`${rect.width}px`, `${final.width}px`],
+            height: [`${rect.height}px`, `${final.height}px`],
+          },
+          { ...COMMIT_ANIMATION, fill: "forwards" }
+        )
+        .finished.catch(() => undefined)
+        .then(cleanup);
+    }
+  );
+};
+
+/**
+ * Sends valid committed drops to their rendered destination and canceled or
+ * invalid drops back to dnd-kit's source placeholder.
+ */
+export const runDropAnimation = (
+  context: DropAnimationContext,
+  target?: TargetDrop
+) => {
+  const operation = context.source.manager?.dragOperation;
+  const aborted =
+    (operation?.canceled ?? false) || operation?.target?.type === "void";
+
+  if (!aborted && target) {
+    runTargetDropAnimation({
+      ...target,
+      feedbackElement: context.feedbackElement as HTMLElement,
+    });
+
+    // Resolve immediately so dnd-kit commits and cleans up while the visual
+    // copy independently glides to the newly rendered component.
+    return;
+  }
+
+  return runFallbackDropAnimation(context);
+};

--- a/packages/core/lib/dnd/flip-commit.ts
+++ b/packages/core/lib/dnd/flip-commit.ts
@@ -1,0 +1,82 @@
+import { getFrame } from "../get-frame";
+import {
+  COMMIT_ANIMATION,
+  prefersReducedMotion,
+  waitForCommit,
+} from "./commit-animation";
+
+/**
+ * Captures sibling positions before a static drop commits and returns a
+ * callback that FLIP-animates those siblings once the new layout renders.
+ */
+export const prepareCommitFlip = ({
+  zones,
+  itemId,
+  targetZone,
+  getExpectedOrder,
+}: {
+  zones: string[];
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+}): (() => void) => {
+  const frame = getFrame();
+
+  if (!frame || prefersReducedMotion(frame)) {
+    return () => {};
+  }
+
+  const itemsSelector = Array.from(new Set(zones))
+    .map(
+      (zone) =>
+        `[data-puck-dropzone="${zone}"] > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+    )
+    .join(", ");
+
+  const capture = () => {
+    const items = new Map<string, { el: HTMLElement; rect: DOMRect }>();
+
+    frame.querySelectorAll<HTMLElement>(itemsSelector).forEach((el) => {
+      const id = el.getAttribute("data-puck-component");
+
+      if (id && id !== itemId) {
+        items.set(id, { el, rect: el.getBoundingClientRect() });
+      }
+    });
+
+    return items;
+  };
+
+  const first = capture();
+  const initialExpectedOrder = getExpectedOrder();
+
+  return () => {
+    waitForCommit(
+      frame,
+      {
+        zones,
+        itemId,
+        targetZone,
+        getExpectedOrder,
+        initialExpectedOrder,
+      },
+      () => {
+        capture().forEach(({ el, rect }, id) => {
+          const initial = first.get(id)?.rect;
+
+          if (!initial) return;
+
+          const dx = initial.x - rect.x;
+          const dy = initial.y - rect.y;
+
+          if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+
+          el.animate(
+            { translate: [`${dx}px ${dy}px 0`, "0px 0px 0"] },
+            COMMIT_ANIMATION
+          );
+        });
+      }
+    );
+  };
+};

--- a/packages/core/lib/dnd/nearest-gap.ts
+++ b/packages/core/lib/dnd/nearest-gap.ts
@@ -1,0 +1,159 @@
+type Point = { x: number; y: number };
+
+type GapCandidate = {
+  index: number;
+  // A line segment describing the gap
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+const distanceToSegment = (point: Point, gap: GapCandidate) => {
+  const x = Math.max(gap.x1, Math.min(gap.x2, point.x));
+  const y = Math.max(gap.y1, Math.min(gap.y2, point.y));
+
+  return Math.hypot(point.x - x, point.y - y);
+};
+
+/**
+ * Maps a drag position from top-window coordinates (as tracked by dnd-kit's
+ * sensors) into the coordinate space of the element's frame, accounting for
+ * the canvas iframe scale.
+ */
+export const getFramePointer = (targetEl: Element, position: Point): Point => {
+  const frameEl = document.querySelector(
+    "iframe#preview-frame"
+  ) as HTMLIFrameElement | null;
+
+  if (!frameEl || targetEl.ownerDocument !== frameEl.contentDocument) {
+    return position;
+  }
+
+  const rect = frameEl.getBoundingClientRect();
+  const scale = rect.width / (frameEl.contentWindow?.innerWidth || 1);
+
+  return {
+    x: (position.x - rect.left) / scale,
+    y: (position.y - rect.top) / scale,
+  };
+};
+
+/**
+ * Returns the insertion index whose gap is nearest to the pointer, using the
+ * same geometry as the line placeholder indicator. This is more predictable
+ * than directional midpoint collisions for cross-zone drags, where items
+ * don't move out of the way and the drag shape's size is unrelated to the
+ * target zone's items.
+ *
+ * Rendered items are mapped to their real content indices via `contentIds`:
+ * virtualized zones only render a window of their content, so DOM positions
+ * can't be used as indices directly.
+ */
+export const getNearestGapIndex = (
+  zoneEl: Element,
+  pointer: Point,
+  contentIds: string[]
+): number | null => {
+  const win = zoneEl.ownerDocument.defaultView;
+
+  if (!win) return null;
+
+  const rendered = Array.from(
+    zoneEl.querySelectorAll(
+      ":scope > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])"
+    )
+  )
+    .map((el) => ({
+      index: contentIds.indexOf(el.getAttribute("data-puck-component") ?? ""),
+      rect: el.getBoundingClientRect(),
+    }))
+    .filter((item) => item.index !== -1)
+    .sort((a, b) => a.index - b.index);
+
+  if (rendered.length === 0) return 0;
+
+  const style = win.getComputedStyle(zoneEl);
+  const horizontalFlow =
+    style.display === "grid" ||
+    (style.display === "flex" && style.flexDirection.startsWith("row"));
+
+  const candidates: GapCandidate[] = [];
+
+  const edgeCandidate = (
+    index: number,
+    rect: DOMRect,
+    side: "before" | "after"
+  ) => {
+    if (horizontalFlow) {
+      const x = side === "before" ? rect.left : rect.right;
+
+      candidates.push({ index, x1: x, x2: x, y1: rect.top, y2: rect.bottom });
+    } else {
+      const y = side === "before" ? rect.top : rect.bottom;
+
+      candidates.push({ index, y1: y, y2: y, x1: rect.left, x2: rect.right });
+    }
+  };
+
+  for (let i = 0; i <= rendered.length; i++) {
+    const prev = rendered[i - 1];
+    const next = rendered[i];
+
+    if (!next) {
+      // After the last rendered item
+      edgeCandidate(prev.index + 1, prev.rect, "after");
+    } else if (!prev) {
+      // Before the first rendered item
+      edgeCandidate(next.index, next.rect, "before");
+    } else if (next.index - prev.index > 1) {
+      // The items between these two are virtualized out: expose both edges
+      // as separate insertion points
+      edgeCandidate(prev.index + 1, prev.rect, "after");
+      edgeCandidate(next.index, next.rect, "before");
+    } else if (horizontalFlow) {
+      const wraps = prev.rect.right > next.rect.left;
+
+      if (wraps) {
+        // Row wraps expose both the end of the previous row and the start
+        // of the next as the same index
+        edgeCandidate(next.index, next.rect, "before");
+        edgeCandidate(next.index, prev.rect, "after");
+      } else {
+        const x = (prev.rect.right + next.rect.left) / 2;
+
+        candidates.push({
+          index: next.index,
+          x1: x,
+          x2: x,
+          y1: next.rect.top,
+          y2: next.rect.bottom,
+        });
+      }
+    } else {
+      const y = (prev.rect.bottom + next.rect.top) / 2;
+
+      candidates.push({
+        index: next.index,
+        y1: y,
+        y2: y,
+        x1: next.rect.left,
+        x2: next.rect.right,
+      });
+    }
+  }
+
+  let nearest: GapCandidate | null = null;
+  let nearestDistance = Infinity;
+
+  for (const candidate of candidates) {
+    const distance = distanceToSegment(pointer, candidate);
+
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = candidate;
+    }
+  }
+
+  return nearest?.index ?? null;
+};

--- a/packages/core/lib/dnd/resolve-dnd-mode.ts
+++ b/packages/core/lib/dnd/resolve-dnd-mode.ts
@@ -1,0 +1,33 @@
+import type { DndBehavior } from "../../types";
+
+export type DndMode = Exclude<DndBehavior, "auto">;
+
+type ResolveDndModeOptions = {
+  isDraggingBetweenSlots?: boolean;
+  isNewComponent?: boolean;
+};
+
+export const resolveDndMode = (
+  behavior: DndBehavior,
+  {
+    isDraggingBetweenSlots = false,
+    isNewComponent = false,
+  }: ResolveDndModeOptions = {}
+): DndMode => {
+  if (behavior === "auto") {
+    return isDraggingBetweenSlots || isNewComponent ? "static" : "fluid";
+  }
+
+  return behavior;
+};
+
+export const resolveOriginPreviewIndex = (
+  initialIndex: number,
+  preview?: { index: number; linePlaceholder?: boolean } | null
+) => {
+  if (!preview || preview.linePlaceholder) {
+    return initialIndex;
+  }
+
+  return preview.index;
+};

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -22,6 +22,8 @@ export type IframeConfig = {
   syncHostStyles?: boolean;
 };
 
+export type DndBehavior = "auto" | "fluid" | "static";
+
 export type OnAction<UserData extends Data = Data> = (
   action: PuckAction,
   appState: AppState<UserData>,


### PR DESCRIPTION
Closes puckeditor/puck#1358, closes puckeditor/puck#1286

## Description

This PR changes the default drag-and-drop behaviour when dragging between slots to use a static placeholder with a line preview. When dragging within the same slot, the existing behaviour remains.

This is configurable via the `dnd.behavior` API, which can be `auto` (the default, changing based on reparenting), `fluid` (the original) or `static`.

## How to test

* Try dragging items between slots
* Set `?dndBehavior="fluid"` on the demo URL to restore the legacy behavior
* Set `?dndBehavior="static"` on the demo URL to enable static behavior for everything

In code, set the `dnd.behavior` property to change behavior:

```tsx
<Puck dnd={{ behaviour: "static" }} />
```

## Remaining considerations

1. I wasn't totally sure of the parameter name `behavior`, so if you have any suggestions, I'm all ears.