### PR TITLE
chore: widen recipe ranges for @puckeditor packages

### DIFF
--- a/packages/create-puck-app/templates/next-ai/package.json.hbs
+++ b/packages/create-puck-app/templates/next-ai/package.json.hbs
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@puckeditor/core": "{{puckVersion}}",
-    "@puckeditor/cloud-client": "^0.7.0",
-    "@puckeditor/plugin-ai": "^0.7.0",
+    "@puckeditor/cloud-client": "^0",
+    "@puckeditor/plugin-ai": "^0",
     "classnames": "^2.3.2",
     "next": "^16.0.8",
     "react": "^19.2.1",

--- a/packages/create-puck-app/templates/react-router-ai/package.json.hbs
+++ b/packages/create-puck-app/templates/react-router-ai/package.json.hbs
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@puckeditor/core": "{{puckVersion}}",
-    "@puckeditor/cloud-client": "^0.7.0",
-    "@puckeditor/plugin-ai": "^0.7.0",
+    "@puckeditor/cloud-client": "^0",
+    "@puckeditor/plugin-ai": "^0",
     "@react-router/node": "^7.5.3",
     "@react-router/serve": "^7.5.3",
     "isbot": "^5",

--- a/recipes/next-ai/package.json
+++ b/recipes/next-ai/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@puckeditor/core": "*",
-    "@puckeditor/cloud-client": "^0.7.0",
-    "@puckeditor/plugin-ai": "^0.7.0",
+    "@puckeditor/cloud-client": "^0",
+    "@puckeditor/plugin-ai": "^0",
     "classnames": "^2.3.2",
     "next": "^16.2.5",
     "react": "^19.2.1",

--- a/recipes/react-router-ai/package.json
+++ b/recipes/react-router-ai/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@puckeditor/core": "*",
-    "@puckeditor/cloud-client": "^0.7.0",
-    "@puckeditor/plugin-ai": "^0.7.0",
+    "@puckeditor/cloud-client": "^0",
+    "@puckeditor/plugin-ai": "^0",
     "@react-router/node": "^7.5.3",
     "@react-router/serve": "^7.5.3",
     "isbot": "^5",


### PR DESCRIPTION
## Description

Currently Puck recipes are pinned to specific versions of `@puckeditor` packages rather than using the latest released verison.

## Changes made

Widen the versions in `package.json` so that the recipes can fetch the latest new versions.
