### PR TITLE
docs: fix link to UI overrides on compositional doc

### DIFF
--- a/apps/docs/pages/docs/extending-puck/composition.mdx
+++ b/apps/docs/pages/docs/extending-puck/composition.mdx
@@ -66,7 +66,7 @@ Puck exposes its core components, allowing you to compose them together to creat
 - [`<Puck.Outline>`](/docs/api-reference/components/puck-outline) - An interactive outline.
 - [`<Puck.Preview>`](/docs/api-reference/components/puck-preview) - A drag-and-drop preview.
 
-The internal UI for these components can also be changed by implementing [UI overrides](/docs/extending-puck/overrides) or [theming](theming).
+The internal UI for these components can also be changed by implementing [UI overrides](/docs/extending-puck/ui-overrides) or [theming](theming).
 
 ### Helper components
 


### PR DESCRIPTION
Fix the link to UI overrides doc on compositional documentation.