### PR TITLE
fix: don't drop transformed fields on updates

### DIFF
--- a/packages/core/lib/data/__tests__/map-fields.spec.tsx
+++ b/packages/core/lib/data/__tests__/map-fields.spec.tsx
@@ -1,4 +1,4 @@
-import { Config } from "../../../types";
+import { ComponentData, Config } from "../../../types";
 import { mapFields, Mappers } from "../map-fields";
 
 type Props = {
@@ -71,6 +71,47 @@ describe("mapFields", () => {
       { type: "Comp", props: { id: "abc", nested: {} } },
       mappers,
       config
+    );
+
+    expect(result.props.nested.title).toBe("mapped:nested.title:undefined");
+  });
+
+  it("walks only the given fields when fieldsToMap is provided", () => {
+    const result: ComponentData = mapFields(
+      { type: "Comp", props: { id: "abc", title: "Hello", plain: "World" } },
+      mappers,
+      config,
+      false,
+      true,
+      ["id", "title"]
+    );
+
+    expect(result.props.title).toBe("mapped:title:Hello");
+    expect("plain" in result.props).toBe(false);
+  });
+
+  it("defaults missing fields listed in fieldsToMap", () => {
+    const result: ComponentData = mapFields(
+      { type: "Comp", props: { id: "abc" } },
+      mappers,
+      config,
+      false,
+      true,
+      ["id", "title"]
+    );
+
+    // e.g. a prop that was just deleted still gets its transform run
+    expect(result.props.title).toBe("mapped:title:undefined");
+  });
+
+  it("defaults missing subfields of object values listed in fieldsToMap", () => {
+    const result: ComponentData = mapFields(
+      { type: "Comp", props: { id: "abc", nested: {} } },
+      mappers,
+      config,
+      false,
+      true,
+      ["nested"]
     );
 
     expect(result.props.nested.title).toBe("mapped:nested.title:undefined");

--- a/packages/core/lib/data/map-fields.ts
+++ b/packages/core/lib/data/map-fields.ts
@@ -44,6 +44,7 @@ type WalkObjectOpts = {
   config: Config;
   recurseSlots?: boolean;
   ownedFields?: boolean;
+  keysToWalk?: string[];
 };
 
 const isPromise = <T = unknown>(v: any): v is Promise<T> =>
@@ -160,13 +161,11 @@ const walkObject = ({
   config,
   recurseSlots,
   ownedFields,
+  keysToWalk: providedKeys,
 }: WalkObjectOpts): Record<string, any> => {
-  const keys = Object.keys(value);
+  const keys = providedKeys ?? Object.keys(value);
 
-  // Include fields that have a mapper but no value, so their transforms still
-  // run (e.g. a contentEditable text field without a default prop). Slots are
-  // defaulted separately via defaultSlots.
-  if (ownedFields) {
+  if (!providedKeys && ownedFields) {
     for (const fieldName in fields) {
       const fieldType = fields[fieldName].type;
 
@@ -213,7 +212,8 @@ export function mapFields<T extends ComponentData | RootData>(
   mappers: Mappers<MapFn>,
   config: Config,
   recurseSlots?: boolean,
-  shouldDefaultSlots?: boolean
+  shouldDefaultSlots?: boolean,
+  fieldsToMap?: string[]
 ): T;
 
 export function mapFields<T extends ComponentData | RootData>(
@@ -221,15 +221,29 @@ export function mapFields<T extends ComponentData | RootData>(
   mappers: Mappers<PromiseMapFn>,
   config: Config,
   recurseSlots?: boolean,
-  shouldDefaultSlots?: boolean
+  shouldDefaultSlots?: boolean,
+  fieldsToMap?: string[]
 ): Promise<T>;
 
+/**
+ * Walks and transforms the fields of a component or root item.
+ *
+ * @param item The component or root item to transform.
+ * @param mappers The mapping functions to apply to each field type.
+ * @param config The puck config for the item.
+ * @param recurseSlots Whether to recurse into slot fields.
+ * @param shouldDefaultSlots Whether to default missing slot fields.
+ * @param fieldsToMap Limit the walk to these top-level fields.
+ *                    When omitted, all props and field definitions are walked.
+ * @returns The transformed item.
+ */
 export function mapFields(
   item: any,
   mappers: Mappers,
   config: Config,
   recurseSlots: boolean = false,
-  shouldDefaultSlots: boolean = true
+  shouldDefaultSlots: boolean = true,
+  fieldsToMap?: string[]
 ): any {
   const itemType = "type" in item ? item.type : "root";
 
@@ -247,6 +261,7 @@ export function mapFields(
     config,
     recurseSlots,
     ownedFields: true,
+    keysToWalk: fieldsToMap,
   });
 
   if (isPromise(newProps)) {

--- a/packages/core/lib/field-transforms/__tests__/use-field-transforms-tracked.spec.tsx
+++ b/packages/core/lib/field-transforms/__tests__/use-field-transforms-tracked.spec.tsx
@@ -1,0 +1,176 @@
+import { renderHook } from "@testing-library/react";
+import { ComponentData, Config } from "../../../types";
+import { FieldTransforms } from "../../../types/API/FieldTransforms";
+import { useFieldTransformsTracked } from "../use-field-transforms-tracked";
+
+type Props = {
+  Comp: {
+    body?: string;
+    other?: string;
+  };
+};
+
+const makeConfig = (): Config<Props> => ({
+  components: {
+    Comp: {
+      fields: {
+        body: { type: "text" },
+        other: { type: "text" },
+      },
+      render: () => <div />,
+    },
+  },
+});
+
+type TransformCall = { propPath: string; value: any; isReadOnly?: boolean };
+
+const makeTransforms = (calls: TransformCall[]): FieldTransforms => ({
+  text: ({ value, propPath }) => {
+    calls.push({ propPath, value });
+
+    return `transformed:${propPath}:${value}`;
+  },
+});
+
+const makeSlotConfig = (): Config => ({
+  components: {
+    Comp: {
+      fields: {
+        slotA: { type: "slot" },
+        slotB: { type: "slot" },
+        body: { type: "text" },
+      },
+      render: () => <div />,
+    },
+  },
+});
+
+const makeItem = (props: Record<string, any> = {}): ComponentData => ({
+  type: "Comp",
+  props: { id: "comp-1", ...props },
+});
+
+describe("useFieldTransformsTracked", () => {
+  it("transforms props on first render", () => {
+    const calls: TransformCall[] = [];
+    const transforms = makeTransforms(calls);
+    const item = makeItem({ body: "<p>Hello</p>" });
+
+    const { result } = renderHook(
+      ({ config }) => useFieldTransformsTracked(config, item, transforms),
+      { initialProps: { config: makeConfig() } }
+    );
+
+    expect(result.current.body).toBe("transformed:body:<p>Hello</p>");
+  });
+
+  it("re-runs transforms when a prop value changes", () => {
+    const calls: TransformCall[] = [];
+    const transforms = makeTransforms(calls);
+    const config = makeConfig();
+
+    const { result, rerender } = renderHook(
+      ({ item }) => useFieldTransformsTracked(config, item, transforms),
+      { initialProps: { item: makeItem({ body: "<p>Hello</p>" }) } }
+    );
+
+    rerender({ item: makeItem({ body: "<p>Edited</p>" }) });
+
+    expect(result.current.body).toBe("transformed:body:<p>Edited</p>");
+  });
+
+  it("does not re-run transforms for unchanged props", () => {
+    const calls: TransformCall[] = [];
+    const transforms = makeTransforms(calls);
+    const config = makeConfig();
+    const props = { body: "<p>Hello</p>", other: "Keep me" };
+
+    const { result, rerender } = renderHook(
+      ({ item }) => useFieldTransformsTracked(config, item, transforms),
+      { initialProps: { item: makeItem(props) } }
+    );
+
+    // `other` keeps the same value identity; only `body` changes
+    rerender({ item: makeItem({ ...props, body: "<p>Edited</p>" }) });
+
+    expect(result.current.other).toBe("transformed:other:Keep me");
+    expect(calls.filter((c) => c.propPath === "other")).toHaveLength(1);
+  });
+
+  it("re-runs all transforms when readOnly changes", () => {
+    const calls: TransformCall[] = [];
+    const transforms: FieldTransforms = {
+      text: ({ value, propPath, isReadOnly }) => {
+        calls.push({ propPath, value, isReadOnly });
+
+        return `transformed:${propPath}:${value}:${isReadOnly}`;
+      },
+    };
+    const config = makeConfig();
+    const item = makeItem({ body: "<p>Hello</p>" }); // `other` unset
+
+    const { result, rerender } = renderHook(
+      ({ forceReadOnly }) =>
+        useFieldTransformsTracked(
+          config,
+          item,
+          transforms,
+          undefined,
+          forceReadOnly
+        ),
+      { initialProps: { forceReadOnly: true } }
+    );
+
+    expect(result.current.body).toBe("transformed:body:<p>Hello</p>:true");
+
+    rerender({ forceReadOnly: false });
+
+    expect(result.current.body).toBe("transformed:body:<p>Hello</p>:false");
+    expect(result.current.other).toBe("transformed:other:undefined:false");
+  });
+
+  it("does not visit slot fields absent from props", () => {
+    const slotCalls: TransformCall[] = [];
+    const transforms: FieldTransforms = {
+      slot: ({ value, propPath }) => {
+        slotCalls.push({ propPath, value });
+
+        return value;
+      },
+    };
+    const item = makeItem({ body: "Hello" }); // no slot props
+
+    renderHook(() =>
+      useFieldTransformsTracked(makeSlotConfig(), item, transforms)
+    );
+
+    expect(slotCalls).toHaveLength(0);
+  });
+
+  it("re-walks only the changed slot, keeping sibling slot results", () => {
+    const slotCalls: TransformCall[] = [];
+    const transforms: FieldTransforms = {
+      slot: ({ value, propPath }) => {
+        slotCalls.push({ propPath, value });
+
+        return value;
+      },
+    };
+    const config = makeSlotConfig();
+
+    const { rerender } = renderHook(
+      ({ item }) => useFieldTransformsTracked(config, item, transforms),
+      { initialProps: { item: makeItem({ slotA: [] }) } } // one slot set, slotB unset
+    );
+
+    // The first walk defaults the unset slotB, so it is walked too
+    expect(slotCalls.map((c) => c.propPath).sort()).toEqual(["slotA", "slotB"]);
+
+    slotCalls.length = 0;
+
+    rerender({ item: makeItem({ slotA: [] }) }); // new array identity
+
+    // Only the changed slot is re-walked; slotB keeps its previous result
+    expect(slotCalls.map((c) => c.propPath)).toEqual(["slotA"]);
+  });
+});

--- a/packages/core/lib/field-transforms/use-field-transforms-tracked.tsx
+++ b/packages/core/lib/field-transforms/use-field-transforms-tracked.tsx
@@ -16,6 +16,7 @@ export function useFieldTransformsTracked<
   readOnly?: T["readOnly"],
   forceReadOnly?: boolean
 ): T["props"] {
+  const prevMappers = useRef<Mappers>(null);
   const prevProps = useRef<Record<string, any>>(null);
   const prevResult = useRef<Record<string, any>>(item.props);
 
@@ -25,43 +26,57 @@ export function useFieldTransformsTracked<
   );
 
   const transformedProps = useMemo(() => {
-    // Filter to changed fields only (shallow comparison)
-    const changedProps: Record<string, any> = {};
-
     const componentConfig =
       item.type === "root" ? config.root : config.components?.[item.type];
 
+    const componentFields = componentConfig?.fields ?? {};
+
+    // Transformed props depend on mappers, so a mappers change
+    // invalidates all of them (e.g when readOnly changes)
+    const fullRemap = prevMappers.current !== mappers;
+
+    let changedFields: string[] | undefined;
     let changeIncludesSlot = false;
 
-    for (const fieldName in item.props) {
-      const fieldType = componentConfig?.fields?.[fieldName]?.type;
-
-      if (
-        !prevProps.current ||
-        item.props[fieldName] !== prevProps.current[fieldName]
-      ) {
-        changedProps[fieldName] = item.props[fieldName];
-
-        if (fieldType === "slot") {
+    if (!prevProps.current || fullRemap) {
+      for (const fieldName in item.props) {
+        if (componentFields[fieldName]?.type === "slot") {
           changeIncludesSlot = true;
+        }
+      }
+    } else {
+      changedFields = ["id"]; // Always include ID
+
+      const allFieldNames = new Set([
+        ...Object.keys(item.props),
+        ...Object.keys(prevProps.current),
+      ]);
+
+      for (const fieldName of allFieldNames) {
+        if (item.props[fieldName] !== prevProps.current[fieldName]) {
+          changedFields.push(fieldName);
+
+          if (componentFields[fieldName]?.type === "slot") {
+            changeIncludesSlot = true;
+          }
         }
       }
     }
 
-    // Always include ID
-    changedProps.id = item.props.id;
-
-    prevProps.current = item.props;
-
     const mapped = mapFields(
-      { ...item, props: changedProps },
+      item,
       mappers,
       config,
       false,
-      changeIncludesSlot
+      changeIncludesSlot,
+      changedFields
     ).props;
 
-    prevResult.current = { ...prevResult.current, ...mapped };
+    prevProps.current = item.props;
+    prevMappers.current = mappers;
+    prevResult.current = changedFields
+      ? { ...prevResult.current, ...mapped }
+      : mapped;
 
     return prevResult.current;
   }, [config, item, mappers]);


### PR DESCRIPTION
Closes puckeditor/puck#1740

## Description

This PR fixes an issue where field transforms where being set to undefined after updating a component.

The problem was that `mapFields` was getting called from the tracked version of `useFieldTransforms` with partial updates in the component. With the fix we did on `mapFields` this was setting any non set prop that was defined in the fields as undefined.

## Changes made

* Added a param to control which fields to map in `mapFields`.
* Updated use field transforms tracked to use this new param.
* Added tests to cover the new map fields prop.
* Added tests to cover use field transforms tracked.

## How to test

* Render the `Puck` component with the following config:

```tsx
export const config = {
  components: {
    HeadingBlock: {
      fields: {
        text: { type: "text", contentEditable: true },
        someNumber: { type: "number" },
      },
      defaultProps: {
        text: "Hello",
        someNumber: 0,
      },
      render: ({ text, someNumber }) => (
        <div style={{ padding: 64 }}>
          <h1>{text}</h1>
          <p>{someNumber}</p>
        </div>
      ),
    },
  },
};
```

* Update the text field
* Update the number field
* Observe the text field not being deleted from the canvas