### PR TITLE
Prepare recipes for new Puck AI agent

### DIFF
--- a/packages/create-puck-app/index.js
+++ b/packages/create-puck-app/index.js
@@ -66,11 +66,18 @@ program
     Explicitly tell the CLI to bootstrap the application using Yarn
   `
   )
+  .option(
+    "--ai",
+    `
+
+    Add Puck AI to the editor (requires a Puck Cloud account)
+  `
+  )
   .action(async (_appName, options) => {
-    const beforeQuestions = [];
+    const questions = [];
 
     if (!_appName) {
-      beforeQuestions.push({
+      questions.push({
         type: "input",
         name: "appName",
         message: "What is the name of your app?",
@@ -78,26 +85,27 @@ program
       });
     }
 
-    const questions = [
-      ...beforeQuestions,
-      {
-        type: "list",
-        name: "recipe",
-        message: "Which recipe would you like to use?",
-        required: true,
-        default: "next",
-        choices: [
-          {
-            name: "Next.js",
-            value: "next",
-          },
-          {
-            name: "React Router",
-            value: "react-router",
-          },
-        ],
-      },
-      {
+    questions.push({
+      type: "list",
+      name: "recipe",
+      message: "Which recipe would you like to use?",
+      required: true,
+      default: "next",
+      choices: [
+        {
+          name: "Next.js",
+          value: "next",
+        },
+        {
+          name: "React Router",
+          value: "react-router",
+        },
+      ],
+    });
+
+    // If the user didn't specify the --ai flag, ask them if they want to add Puck AI to the editor.
+    if (!options.ai) {
+      questions.push({
         type: "confirm",
         name: "puckAi",
         message: `Puck AI (beta) lets you generate pages using your own components. Learn more: ${ansiColors.cyan}https://puckeditor.com/docs/ai/overview${ansiColors.reset}
@@ -105,8 +113,8 @@ program
   Add Puck AI to the editor? (Requires a Puck Cloud account)`,
         required: true,
         default: true,
-      },
-    ];
+      });
+    }
 
     const answers = await inquirer.prompt(questions);
 
@@ -120,7 +128,7 @@ program
     }
 
     const recipe = answers.recipe;
-    const usesPuckAi = answers.puckAi;
+    const usesPuckAi = answers.puckAi || !!options.ai;
 
     // Copy template files to the new directory
     const recipeName = `${recipe}${usesPuckAi ? "-ai" : ""}`;

--- a/recipes/next-ai/README.md
+++ b/recipes/next-ai/README.md
@@ -1,60 +1,74 @@
 # `next-ai` recipe
 
-The `next-ai` recipe showcases one of the most powerful ways to combine Puck and [Puck AI](https://puckeditor.com/docs/ai/overview): providing an authoring tool with AI page generation capabilities for any route in your Next app.
+[Puck](https://puckeditor.com) is the visual editor for React, and [Puck AI](https://puckeditor.com/docs/ai/overview) lets you generate pages from a prompt using your own components. This app wires both into the **Next.js App Router** so you can visually edit — or AI-generate — _any_ route by adding `/edit` to the URL, and serves the published pages as fast, statically rendered pages.
 
-## Demonstrates
+> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to Next.js routing, a database, and Puck AI.
 
-- Puck AI integration for generating pages with AI
-- Next.js App Router implementation
-- JSON database implementation with HTTP API
-- Catch-all routes to use puck for any route on the platform
-- Incremental static regeneration (ISR) for all Puck pages
+## What this app demonstrates
 
-## Usage
+- [Puck AI](https://puckeditor.com/docs/ai/overview) integration for generating pages from a prompt
+- Next.js App Router integration
+- Editing any route by appending `/edit` (even routes that don't exist yet)
+- Statically rendered pages with Incremental Static Regeneration (ISR)
+- A JSON file standing in for a database, written through an HTTP API route
 
-Run the generator and select `Next.js` when prompted
+## Getting started
 
-```
-npx create-puck-app my-app
+### 1. Set up Puck AI
 
-? Which recipe would you like to use?
-❯ Next.js
-```
+Puck AI runs through [Puck Cloud](https://cloud.puckeditor.com). Create an account and [generate an API key](https://puckeditor.com/docs/ai/getting-started#generate-an-api-key), then copy the example env file and add your key:
 
-Confirm you want to use Puck AI
-
-```
-? Would you like to use Puck AI? (Y/n) Y
+```sh
+cp .env.example .env.local
 ```
 
-Start the server
-
-```
-cd my-app
-yarn dev
-```
-
-### Set up Puck AI
-
-Create a [Puck account](https://cloud.puckeditor.com) and [obtain an API key](https://cloud.puckeditor.com/api-keys).
-
-Create a `.env.local` file in the root of your project and add your API key:
-
-```
+```sh
+# .env.local
 PUCK_API_KEY=your-api-key
 ```
 
-Navigate to the homepage at https://localhost:3000. To edit the homepage, access the Puck editor at https://localhost:3000/edit, and select the AI button in the left navigation bar to generate content for the page using Puck AI.
+### 2. Start the dev server
 
-You can do this for any route on the application, **even if the page doesn't exist**. For example, visit https://localhost:3000/hello/world and you'll receive a 404. You can author and publish a page by visiting https://localhost:3000/hello/world/edit. After publishing, go back to the original URL to see your page.
+```sh
+npm run dev
+```
 
-## Using this recipe
+Open [http://localhost:3000](http://localhost:3000) to see the home page, then add `/edit` to edit it: [http://localhost:3000/edit](http://localhost:3000/edit). Select the **AI** button in the left sidebar to generate content with Puck AI.
 
-To adopt this recipe you will need to:
+This works for **any route, even ones that don't exist yet**:
 
-- **IMPORTANT** Add authentication to `/edit` routes. This can be done by modifying the example API routes in `/app/puck/api/route.ts` and server component in `/app/puck/[...puckPath]/page.tsx`. **If you don't do this, Puck will be completely public.**
-- Integrate your database into the API calls in `/app/puck/api/route.ts`
-- Implement a custom puck configuration in `puck.config.tsx`
-- Add business context for the AI generation in `/app/api/puck/[...all]/route.ts`
+1. Visit [http://localhost:3000/hello/world](http://localhost:3000/hello/world) — you'll get a 404.
+2. Add `/edit` ([http://localhost:3000/hello/world/edit](http://localhost:3000/hello/world/edit)) to open the editor for that path.
+3. Build (or AI-generate) a page, press **Publish**, then visit the original URL to see it live.
 
-By default, this recipe will generate static pages by setting `dynamic` to [`force-static`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in the `/app/[...puckPath]/page.tsx`. This will strip headers and cookies. If you need dynamic pages, you can delete this.
+> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+
+## How it works
+
+The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+
+| File | Responsibility |
+| --- | --- |
+| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
+| `app/puck/[...puckPath]/page.tsx` | **Editor entry point (server).** Loads the saved [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) for the path and passes it to the client component. |
+| `app/puck/[...puckPath]/client.tsx` | **Editor entry point (client).** Renders the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor with the [Puck AI plugin](https://puckeditor.com/docs/ai/overview); its [`onPublish`](https://puckeditor.com/docs/api-reference/components/puck#onpublishdata) callback posts the page to the persistence API route. |
+| `app/[...puckPath]/page.tsx` | **Public page (server).** Loads the saved page and displays it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render), or returns a 404. Statically rendered with ISR (`force-static`). |
+| `proxy.ts` | The routing "magic". Rewrites `/<path>/edit` to the internal editor route and hides the raw `/puck/*` routes — this is what lets you edit any URL by appending `/edit`. |
+| `app/api/pages/route.ts` | **Persistence API route.** `POST` saves a published page to the database and revalidates the Next.js cache so the public page updates. |
+| `app/api/puck/[...all]/route.ts` | **Puck AI API route.** Proxies AI requests to Puck Cloud via `puckHandler`. Set your business `context` (what the AI should generate) here. See [Getting Started with Puck AI](https://puckeditor.com/docs/ai/getting-started). |
+| `lib/get-page.ts` | Reads a page's `Data` from `database.json`. |
+
+The editor runs on a dynamic route while your published pages stay static, so visitors get fast static pages and editors get a live editor.
+
+## Adapting this app for production
+
+- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the editor's server component (`app/puck/[...puckPath]/page.tsx`), the persistence route (`app/api/pages/route.ts`), and the Puck AI route (`app/api/puck/[...all]/route.ts`). **Without this, anyone can edit, generate, and publish your pages.**
+- **Give the AI context.** Replace the placeholder `context` in `app/api/puck/[...all]/route.ts` with a description of your business so generated pages are on-brand.
+- **Connect a real database.** Replace the `database.json` reads and writes in `lib/get-page.ts` and `app/api/pages/route.ts`.
+- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+- **Static vs. dynamic pages.** Public pages set [`export const dynamic = "force-static"`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in `app/[...puckPath]/page.tsx`, which strips headers and cookies. Remove it if you need dynamic rendering.
+
+## Learn more
+
+- [Puck AI documentation](https://puckeditor.com/docs/ai/overview) · [Puck documentation](https://puckeditor.com/docs)
+- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/next-ai/README.md
+++ b/recipes/next-ai/README.md
@@ -1,74 +1,169 @@
-# `next-ai` recipe
+# Puck AI + Next.js recipe
 
-[Puck](https://puckeditor.com) is the visual editor for React, and [Puck AI](https://puckeditor.com/docs/ai/overview) lets you generate pages from a prompt using your own components. This app wires both into the **Next.js App Router** so you can visually edit — or AI-generate — _any_ route by adding `/edit` to the URL, and serves the published pages as fast, statically rendered pages.
+[Puck](https://puckeditor.com) is the open-source visual editor for React. It lets you create page builders that use your own components.
 
-> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to Next.js routing, a database, and Puck AI.
+[Puck AI](https://puckeditor.com/docs/ai/overview) builds on the same principles to let you generate pages by assembling your existing components or creating new ones on the fly, either as a copilot in the editor or headlessly.
 
-## What this app demonstrates
+This recipe connects Puck and Puck AI to the [Next.js App Router](https://nextjs.org/docs/app), so you can create and edit pages for any route in this app.
 
-- [Puck AI](https://puckeditor.com/docs/ai/overview) integration for generating pages from a prompt
-- Next.js App Router integration
-- Editing any route by appending `/edit` (even routes that don't exist yet)
-- Statically rendered pages with Incremental Static Regeneration (ISR)
-- A JSON file standing in for a database, written through an HTTP API route
+## Core concepts
 
-## Getting started
+If you're new to Puck, this section introduces the core concepts you need to know.
 
-### 1. Set up Puck AI
+### Puck
 
-Puck AI runs through [Puck Cloud](https://cloud.puckeditor.com). Create an account and [generate an API key](https://puckeditor.com/docs/ai/getting-started#generate-an-api-key), then copy the example env file and add your key:
+The Puck visual editor has three main parts: a config, the editor, and the renderer.
 
-```sh
-cp .env.example .env.local
+#### Config
+
+The [config](https://puckeditor.com/docs/integrating-puck/component-configuration) registers the components users can use to build pages in the editor and the fields they can edit.
+
+```tsx
+const config = {
+  components: {
+    HeadingBlock: {
+      fields: {
+        title: { type: "text" },
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    },
+  },
+};
 ```
 
+#### The editor
+
+The [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) component renders the editor. It uses a config, exports [pages as JSON](https://puckeditor.com/docs/api-reference/data-model/data), and accepts initial page data for editing existing pages.
+
+```tsx
+<Puck
+  config={config} // The components available to the editor
+  data={data} // The page JSON to edit
+  onPublish={(data) => {
+    // Save data to your database
+  }}
+/>
+```
+
+#### The renderer
+
+The [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) component renders pages. It expects the page JSON and the config used to create that page.
+
+```tsx
+<Render
+  config={config} // The components used to create the page
+  data={data} // The page JSON to render
+/>
+```
+
+### Puck AI
+
+This recipe adds Puck AI as a copilot. It has two parts: the AI plugin (browser) and the Cloud Client (server).
+
+#### The AI plugin
+
+The [AI plugin](https://puckeditor.com/docs/api-reference/ai/ai-plugin/installation) renders the chat in the editor and sends each message to the Cloud Client on your server.
+
+```tsx
+const aiPlugin = createAiPlugin();
+
+function Editor() {
+  return <Puck plugins={[aiPlugin]} config={config} data={data} />;
+}
+```
+
+#### The Cloud Client
+
+The [Cloud Client](https://puckeditor.com/docs/api-reference/ai/cloud-client/installation) provides APIs for connecting your server to the Puck cloud. This recipe uses its [`puckHandler`](https://puckeditor.com/docs/api-reference/ai/cloud-client/puck-handler) API, which receives each chat message, forwards it to the Puck cloud, and streams the response back to the plugin in the browser.
+
+```ts
+const handleRequest = (request: NextRequest) => {
+  return puckHandler(request, {
+    ai: {
+      context: "We are Google. You create Google landing pages.",
+    },
+  });
+};
+
+export const DELETE = handleRequest;
+export const GET = handleRequest;
+export const POST = handleRequest;
+```
+
+#### Puck AI modes
+
+Puck AI can build pages in two ways:
+
+- **Assembly mode** only builds pages using components from your config.
+- **Design mode** can generate new components when needed.
+
+This recipe comes with [Design mode](https://puckeditor.com/docs/api-reference/ai/cloud-client/puck-handler#aidesignmode) enabled out of the box.
+
+## Run the recipe
+
+### 1. Add a Puck API key
+
+Start by creating an account, [generating an API key](https://cloud.puckeditor.com/api-keys), and adding it to a `.env.local` file:
+
 ```sh
-# .env.local
 PUCK_API_KEY=your-api-key
 ```
 
-### 2. Start the dev server
+### 2. Start the development server
+
+Run:
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see the home page, then add `/edit` to edit it: [http://localhost:3000/edit](http://localhost:3000/edit). Select the **AI** button in the left sidebar to generate content with Puck AI.
+Once the server is running, navigate to [http://localhost:3000](http://localhost:3000) to view the home page, or [http://localhost:3000/edit](http://localhost:3000/edit) to edit it with Puck.
 
-This works for **any route, even ones that don't exist yet**:
+### 3. Create a page with Puck AI
 
-1. Visit [http://localhost:3000/hello/world](http://localhost:3000/hello/world) — you'll get a 404.
-2. Add `/edit` ([http://localhost:3000/hello/world/edit](http://localhost:3000/hello/world/edit)) to open the editor for that path.
-3. Build (or AI-generate) a page, press **Publish**, then visit the original URL to see it live.
+Navigate to [http://localhost:3000/edit](http://localhost:3000/edit), click the **AI** button in the left sidebar, enter a prompt, and press Enter.
 
-> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+### 4. Publish the page
+
+Once your page is ready, select **Publish** in the header to save the result, then navigate to [http://localhost:3000](http://localhost:3000) to view the published page.
+
+You can also create a page at any path by navigating to `/your/path/edit` and publishing it. The route `/your/path` will render the page.
 
 ## How it works
 
-The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+When a URL ends in `/edit`, [`proxy.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) sends the request to the Puck editor route (`app/puck/[...puckPath]/page.tsx`). The editor loads the saved page, or starts with an empty page if the path is new.
 
-| File | Responsibility |
-| --- | --- |
-| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
-| `app/puck/[...puckPath]/page.tsx` | **Editor entry point (server).** Loads the saved [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) for the path and passes it to the client component. |
-| `app/puck/[...puckPath]/client.tsx` | **Editor entry point (client).** Renders the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor with the [Puck AI plugin](https://puckeditor.com/docs/ai/overview); its [`onPublish`](https://puckeditor.com/docs/api-reference/components/puck#onpublishdata) callback posts the page to the persistence API route. |
-| `app/[...puckPath]/page.tsx` | **Public page (server).** Loads the saved page and displays it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render), or returns a 404. Statically rendered with ISR (`force-static`). |
-| `proxy.ts` | The routing "magic". Rewrites `/<path>/edit` to the internal editor route and hides the raw `/puck/*` routes — this is what lets you edit any URL by appending `/edit`. |
-| `app/api/pages/route.ts` | **Persistence API route.** `POST` saves a published page to the database and revalidates the Next.js cache so the public page updates. |
-| `app/api/puck/[...all]/route.ts` | **Puck AI API route.** Proxies AI requests to Puck Cloud via `puckHandler`. Set your business `context` (what the AI should generate) here. See [Getting Started with Puck AI](https://puckeditor.com/docs/ai/getting-started). |
-| `lib/get-page.ts` | Reads a page's `Data` from `database.json`. |
+Selecting **Publish** sends the page data to the `/api/pages` endpoint (`app/api/pages/route.ts`). The handler writes the JSON to `database.json` and clears the Next.js cache for that page. The catch-all route (`app/[...puckPath]/page.tsx`) then loads the same data and renders it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render).
 
-The editor runs on a dynamic route while your published pages stay static, so visitors get fast static pages and editors get a live editor.
+The table below shows the files that implement this flow.
 
-## Adapting this app for production
+| File                                | Purpose                                                                                                              |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `puck.config.tsx`                   | Defines the components, fields, and default props available to Puck and Assembly mode. Add your own components here. |
+| `app/puck/[...puckPath]/page.tsx`   | Loads page data for the editor.                                                                                      |
+| `app/puck/[...puckPath]/client.tsx` | Renders the editor with the AI copilot, sends prompts to your server, and publishes changes.                         |
+| `app/[...puckPath]/page.tsx`        | Loads and renders published pages.                                                                                   |
+| `app/api/pages/route.ts`            | Saves published pages.                                                                                               |
+| `app/api/puck/[...all]/route.ts`    | Handles requests from the AI plugin and configures AI generation.                                                    |
+| `proxy.ts`                          | Routes URLs ending in `/edit` to `/puck/[...puckPath]/page.tsx`.                                                     |
+| `lib/get-page.ts`                   | Reads page data from `database.json`. Replace this with your own data fetching logic.                                |
+| `database.json`                     | Acts as a local database. Replace this with your own database solution.                                              |
 
-- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the editor's server component (`app/puck/[...puckPath]/page.tsx`), the persistence route (`app/api/pages/route.ts`), and the Puck AI route (`app/api/puck/[...all]/route.ts`). **Without this, anyone can edit, generate, and publish your pages.**
-- **Give the AI context.** Replace the placeholder `context` in `app/api/puck/[...all]/route.ts` with a description of your business so generated pages are on-brand.
-- **Connect a real database.** Replace the `database.json` reads and writes in `lib/get-page.ts` and `app/api/pages/route.ts`.
-- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
-- **Static vs. dynamic pages.** Public pages set [`export const dynamic = "force-static"`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in `app/[...puckPath]/page.tsx`, which strips headers and cookies. Remove it if you need dynamic rendering.
+## Before deploying to production
+
+Before deploying this recipe, make sure to:
+
+- **Protect the editor and APIs.** The `/edit`, `/api/pages`, and `/api/puck` routes are public by default. Add authentication, authorization, and rate limits to protect page data and AI usage.
+- **Add your component library.** Replace the example `HeadingBlock` in `puck.config.tsx` with the components and fields your users need.
+- **Set your business context.** Replace the example Google context in `app/api/puck/[...all]/route.ts` with clear information about your product, audience, and content rules.
+- **Use a real database.** Replace `database.json` in `lib/get-page.ts` and `app/api/pages/route.ts`. Local files are not reliable across server instances or serverless deployments.
+- **Choose a rendering strategy.** `app/[...puckPath]/page.tsx` uses `force-static`. Remove it if a page needs request-time data such as headers, cookies, or user sessions.
 
 ## Learn more
 
-- [Puck AI documentation](https://puckeditor.com/docs/ai/overview) · [Puck documentation](https://puckeditor.com/docs)
-- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)
+- [Puck documentation](https://puckeditor.com/docs)
+- [Getting started with Puck](https://puckeditor.com/docs/getting-started)
+- [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [Puck AI documentation](https://puckeditor.com/docs/ai/overview)
+- [Getting started with Puck AI](https://puckeditor.com/docs/ai/getting-started)
+- [Puck Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/next-ai/app/[...puckPath]/client.tsx
+++ b/recipes/next-ai/app/[...puckPath]/client.tsx
@@ -2,8 +2,11 @@
 
 import type { Data } from "@puckeditor/core";
 import { Render } from "@puckeditor/core";
+import { withDynamicConfig } from "@puckeditor/plugin-ai";
 import config from "../../puck.config";
 
 export function Client({ data }: { data: Data }) {
-  return <Render config={config} data={data} />;
+  const configWithDesignedComponents = withDynamicConfig(config, data);
+
+  return <Render config={configWithDesignedComponents} data={data} />;
 }

--- a/recipes/next-ai/app/api/puck/[...all]/route.ts
+++ b/recipes/next-ai/app/api/puck/[...all]/route.ts
@@ -1,12 +1,27 @@
 // Handles all requests for Puck AI
 // Learn more: https://puckeditor.com/docs/ai/getting-started
+import type { NextRequest } from "next/server";
 import { puckHandler } from "@puckeditor/cloud-client";
 
-const handleRequest = (request) => {
+const handleRequest = (request: NextRequest): Promise<Response> => {
   return puckHandler(request, {
     ai: {
       // Replace with your business context
       context: "We are Google. You create Google landing pages.",
+      designMode: {
+        // Allow AI to generate new components using "design mode"
+        // Learn more: https://puckeditor.com/docs/ai/design-mode
+        allowed: true,
+        // Constrain component generation, replace with your own instructions
+        instructions: `
+        #### Color Palette
+
+        Always use the following colors:
+
+        * Primary: \`#1976d2\`
+        * Secondary: \`#9c27b0\`
+        `,
+      },
     },
   });
 };

--- a/recipes/next-ai/app/puck/[...puckPath]/client.tsx
+++ b/recipes/next-ai/app/puck/[...puckPath]/client.tsx
@@ -1,19 +1,32 @@
 "use client";
 
 import type { Data } from "@puckeditor/core";
-import { Puck } from "@puckeditor/core";
-import { createAiPlugin } from "@puckeditor/plugin-ai";
+import { Puck, blocksPlugin, outlinePlugin } from "@puckeditor/core";
+import { createAiPlugin, withDynamicConfig } from "@puckeditor/plugin-ai";
 
 import config from "../../../puck.config";
 
-const aiPlugin = createAiPlugin();
+const aiPlugin = createAiPlugin({
+  // Allow users to switch between design and assembly mode.
+  // Read more: https://puckeditor.com/docs/ai/design-mode
+  designMode: {
+    visible: true,
+  },
+  // Select design mode by default.
+  defaultMode: "design",
+});
+
+// Place the ai plugin in the first position in the side nav.
+const plugins = [aiPlugin, blocksPlugin(), outlinePlugin()];
 
 export function Client({ path, data }: { path: string; data: Partial<Data> }) {
+  const configWithDesignedComponents = withDynamicConfig(config, data);
+
   return (
     <Puck
-      plugins={[aiPlugin]}
-      config={config}
+      plugins={plugins}
       data={data}
+      config={configWithDesignedComponents}
       onPublish={async (data) => {
         await fetch("/api/pages", {
           method: "post",

--- a/recipes/next/README.md
+++ b/recipes/next/README.md
@@ -1,38 +1,58 @@
 # `next` recipe
 
-The `next` recipe showcases one of the most powerful ways to implement Puck using to provide an authoring tool for any route in your Next app.
+[Puck](https://puckeditor.com) is the visual editor for React. This app wires Puck into the **Next.js App Router** so you can visually edit _any_ route — just add `/edit` to the URL — and serves the published pages as fast, statically rendered pages.
 
-## Demonstrates
+> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to Next.js routing and a database.
 
-- Next.js App Router implementation
-- JSON database implementation with HTTP API
-- Catch-all routes to use puck for any route on the platform
-- Incremental static regeneration (ISR) for all Puck pages
+## What this app demonstrates
 
-## Usage
+- Next.js App Router integration
+- Editing any route by appending `/edit` (even routes that don't exist yet)
+- Statically rendered pages with Incremental Static Regeneration (ISR)
+- A JSON file standing in for a database, written through an HTTP API route
 
-Run the generator and enter `next` when prompted
+## Getting started
 
-```
-npx create-puck-app my-app
-```
+Start the dev server:
 
-Start the server
-
-```
-yarn dev
+```sh
+npm run dev
 ```
 
-Navigate to the homepage at https://localhost:3000. To edit the homepage, access the Puck editor at https://localhost:3000/edit.
+Open [http://localhost:3000](http://localhost:3000) to see the home page, then add `/edit` to edit it: [http://localhost:3000/edit](http://localhost:3000/edit).
 
-You can do this for any route on the application, **even if the page doesn't exist**. For example, visit https://localhost:3000/hello/world and you'll receive a 404. You can author and publish a page by visiting https://localhost:3000/hello/world/edit. After publishing, go back to the original URL to see your page.
+This works for **any route, even ones that don't exist yet**:
 
-## Using this recipe
+1. Visit [http://localhost:3000/hello/world](http://localhost:3000/hello/world) — you'll get a 404.
+2. Add `/edit` ([http://localhost:3000/hello/world/edit](http://localhost:3000/hello/world/edit)) to open the editor for that path.
+3. Build a page, press **Publish**, then visit the original URL to see it live.
 
-To adopt this recipe you will need to:
+> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
 
-- **IMPORTANT** Add authentication to `/edit` routes. This can be done by modifying the example API routes in `/app/puck/api/route.ts` and server component in `/app/puck/[...puckPath]/page.tsx`. **If you don't do this, Puck will be completely public.**
-- Integrate your database into the API calls in `/app/puck/api/route.ts`
-- Implement a custom puck configuration in `puck.config.tsx`
+## How it works
 
-By default, this recipe will generate static pages by setting `dynamic` to [`force-static`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in the `/app/[...puckPath]/page.tsx`. This will strip headers and cookies. If you need dynamic pages, you can delete this.
+The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+
+| File | Responsibility |
+| --- | --- |
+| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
+| `app/puck/[...puckPath]/page.tsx` | **Editor entry point (server).** Loads the saved [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) for the path and passes it to the client component. |
+| `app/puck/[...puckPath]/client.tsx` | **Editor entry point (client).** Renders the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor; its [`onPublish`](https://puckeditor.com/docs/api-reference/components/puck#onpublishdata) callback posts the page to the API route. |
+| `app/[...puckPath]/page.tsx` | **Public page (server).** Loads the saved page and displays it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render), or returns a 404. Statically rendered with ISR (`force-static`). |
+| `proxy.ts` | The routing "magic". Rewrites `/<path>/edit` to the internal editor route and hides the raw `/puck/*` routes — this is what lets you edit any URL by appending `/edit`. |
+| `app/puck/api/route.ts` | **API route.** `POST` saves a published page to the database and revalidates the Next.js cache so the public page updates. |
+| `lib/get-page.ts` | Reads a page's `Data` from `database.json`. |
+
+The editor runs on a dynamic route while your published pages stay static, so visitors get fast static pages and editors get a live editor.
+
+## Adapting this app for production
+
+- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the editor's server component (`app/puck/[...puckPath]/page.tsx`) and the API route (`app/puck/api/route.ts`). **Without this, anyone can edit and publish your pages.**
+- **Connect a real database.** Replace the `database.json` reads and writes in `lib/get-page.ts` and `app/puck/api/route.ts`.
+- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+- **Static vs. dynamic pages.** Public pages set [`export const dynamic = "force-static"`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in `app/[...puckPath]/page.tsx`, which strips headers and cookies. Remove it if you need dynamic rendering.
+
+## Learn more
+
+- [Puck documentation](https://puckeditor.com/docs) · [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/next/README.md
+++ b/recipes/next/README.md
@@ -1,58 +1,112 @@
-# `next` recipe
+# Puck + Next.js recipe
 
-[Puck](https://puckeditor.com) is the visual editor for React. This app wires Puck into the **Next.js App Router** so you can visually edit _any_ route — just add `/edit` to the URL — and serves the published pages as fast, statically rendered pages.
+[Puck](https://puckeditor.com) is the open-source visual editor for React.
 
-> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to Next.js routing and a database.
+This recipe connects Puck to the [Next.js App Router](https://nextjs.org/docs/app), so you can create and edit pages for any route in this app.
 
-## What this app demonstrates
+## Core concepts
 
-- Next.js App Router integration
-- Editing any route by appending `/edit` (even routes that don't exist yet)
-- Statically rendered pages with Incremental Static Regeneration (ISR)
-- A JSON file standing in for a database, written through an HTTP API route
+If you're new to Puck, this section introduces the core concepts you need to know.
 
-## Getting started
+### Puck
 
-Start the dev server:
+The Puck visual editor has three main parts: a config, the editor, and the renderer.
+
+#### Config
+
+The [config](https://puckeditor.com/docs/integrating-puck/component-configuration) registers the components users can use to build pages in the editor and the fields they can edit.
+
+```tsx
+const config = {
+  components: {
+    HeadingBlock: {
+      fields: {
+        title: { type: "text" },
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    },
+  },
+};
+```
+
+#### The editor
+
+The [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) component renders the editor. It uses a config, exports [pages as JSON](https://puckeditor.com/docs/api-reference/data-model/data), and accepts initial page data for editing existing pages.
+
+```tsx
+<Puck
+  config={config} // The components available to the editor
+  data={data} // The page JSON to edit
+  onPublish={(data) => {
+    // Save data to your database
+  }}
+/>
+```
+
+#### The renderer
+
+The [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) component renders pages. It expects the page JSON and the config used to create that page.
+
+```tsx
+<Render
+  config={config} // The components used to create the page
+  data={data} // The page JSON to render
+/>
+```
+
+## Run the recipe
+
+### 1. Start the development server
+
+Run:
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see the home page, then add `/edit` to edit it: [http://localhost:3000/edit](http://localhost:3000/edit).
+Once the server is running, navigate to [http://localhost:3000](http://localhost:3000) to view the home page, or [http://localhost:3000/edit](http://localhost:3000/edit) to edit it with Puck.
 
-This works for **any route, even ones that don't exist yet**:
+### 2. Create a page
 
-1. Visit [http://localhost:3000/hello/world](http://localhost:3000/hello/world) — you'll get a 404.
-2. Add `/edit` ([http://localhost:3000/hello/world/edit](http://localhost:3000/hello/world/edit)) to open the editor for that path.
-3. Build a page, press **Publish**, then visit the original URL to see it live.
+Navigate to [http://localhost:3000/edit](http://localhost:3000/edit), open the `Blocks` tab in the left sidebar and build your page by dragging components onto the canvas.
 
-> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+### 3. Publish the page
+
+Once your page is ready, select **Publish** in the header to save the result, then navigate to [http://localhost:3000](http://localhost:3000) to view the published page.
+
+You can also create a page at any path by navigating to `/your/path/edit` and publishing it. The route `/your/path` will render the page.
 
 ## How it works
 
-The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+When a URL ends in `/edit`, [`proxy.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) sends the request to the Puck editor route (`app/puck/[...puckPath]/page.tsx`). The editor loads the saved page, or starts with an empty page if the path is new.
 
-| File | Responsibility |
-| --- | --- |
-| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
-| `app/puck/[...puckPath]/page.tsx` | **Editor entry point (server).** Loads the saved [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) for the path and passes it to the client component. |
-| `app/puck/[...puckPath]/client.tsx` | **Editor entry point (client).** Renders the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor; its [`onPublish`](https://puckeditor.com/docs/api-reference/components/puck#onpublishdata) callback posts the page to the API route. |
-| `app/[...puckPath]/page.tsx` | **Public page (server).** Loads the saved page and displays it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render), or returns a 404. Statically rendered with ISR (`force-static`). |
-| `proxy.ts` | The routing "magic". Rewrites `/<path>/edit` to the internal editor route and hides the raw `/puck/*` routes — this is what lets you edit any URL by appending `/edit`. |
-| `app/puck/api/route.ts` | **API route.** `POST` saves a published page to the database and revalidates the Next.js cache so the public page updates. |
-| `lib/get-page.ts` | Reads a page's `Data` from `database.json`. |
+Selecting **Publish** sends the page data to the `/puck/api` endpoint (`app/puck/api/route.ts`). The handler writes the JSON to `database.json` and clears the Next.js cache for that page. The catch-all route (`app/[...puckPath]/page.tsx`) then loads the same data and renders it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render).
 
-The editor runs on a dynamic route while your published pages stay static, so visitors get fast static pages and editors get a live editor.
+The table below shows the files that implement this flow.
 
-## Adapting this app for production
+| File                                | Purpose                                                                                            |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `puck.config.tsx`                   | Defines the components, fields, and default props available to Puck. Add your own components here. |
+| `app/puck/[...puckPath]/page.tsx`   | Loads page data for the editor.                                                                    |
+| `app/puck/[...puckPath]/client.tsx` | Renders the editor and publishes changes.                                                          |
+| `app/[...puckPath]/page.tsx`        | Loads and renders published pages.                                                                 |
+| `app/puck/api/route.ts`             | Saves published pages.                                                                             |
+| `proxy.ts`                          | Routes URLs ending in `/edit` to `/puck/[...puckPath]/page.tsx`.                                   |
+| `lib/get-page.ts`                   | Reads page data from `database.json`. Replace this with your own data fetching logic.              |
+| `database.json`                     | Acts as a local database. Replace this with your own database solution.                            |
 
-- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the editor's server component (`app/puck/[...puckPath]/page.tsx`) and the API route (`app/puck/api/route.ts`). **Without this, anyone can edit and publish your pages.**
-- **Connect a real database.** Replace the `database.json` reads and writes in `lib/get-page.ts` and `app/puck/api/route.ts`.
-- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
-- **Static vs. dynamic pages.** Public pages set [`export const dynamic = "force-static"`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in `app/[...puckPath]/page.tsx`, which strips headers and cookies. Remove it if you need dynamic rendering.
+## Before deploying to production
+
+Before deploying this recipe, make sure to:
+
+- **Protect the editor and API.** The `/edit` routes and `/puck/api` endpoint are public by default. Add authentication and authorization so only trusted users can edit or publish pages.
+- **Add your component library.** Replace the example `HeadingBlock` in `puck.config.tsx` with the components and fields your users need.
+- **Use a real database.** Replace `database.json` in `lib/get-page.ts` and `app/puck/api/route.ts`. Local files are not reliable across server instances or serverless deployments.
+- **Choose a rendering strategy.** `app/[...puckPath]/page.tsx` uses `force-static`. Remove it if a page needs request-time data such as headers, cookies, or user sessions.
 
 ## Learn more
 
-- [Puck documentation](https://puckeditor.com/docs) · [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
-- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)
+- [Puck documentation](https://puckeditor.com/docs)
+- [Getting started with Puck](https://puckeditor.com/docs/getting-started)
+- [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [Puck Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/react-router-ai/README.md
+++ b/recipes/react-router-ai/README.md
@@ -1,57 +1,71 @@
 # `react-router-ai` recipe
 
-The `react-router-ai` recipe showcases one of the most powerful ways to combine Puck and [Puck AI](https://puckeditor.com/docs/ai/overview): providing an authoring tool with AI page generation capabilities for any route in your React Router app.
+[Puck](https://puckeditor.com) is the visual editor for React, and [Puck AI](https://puckeditor.com/docs/ai/overview) lets you generate pages from a prompt using your own components. This app wires both into **React Router v7** (framework mode) so you can visually edit — or AI-generate — _any_ route by adding `/edit` to the URL, and serves the published pages from the same route.
 
-## Demonstrates
+> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to React Router, a database, and Puck AI.
 
-- Puck AI integration for generating pages with AI
-- React Router v7 (framework) implementation
-- JSON database implementation
-- Splat route to use puck for any route on the platform
+## What this app demonstrates
 
-## Usage
+- [Puck AI](https://puckeditor.com/docs/ai/overview) integration for generating pages from a prompt
+- React Router v7 (framework mode) integration
+- Editing any route by appending `/edit` (even routes that don't exist yet)
+- A single [splat route](https://reactrouter.com/start/framework/routing#splats) that both renders published pages and hosts the editor
+- A JSON file standing in for a database
 
-Run the generator and select `React Router` when prompted
+## Getting started
 
-```
-npx create-puck-app my-app
+### 1. Set up Puck AI
 
-? Which recipe would you like to use?
-❯ React Router
-```
+Puck AI runs through [Puck Cloud](https://cloud.puckeditor.com). Create an account and [generate an API key](https://puckeditor.com/docs/ai/getting-started#generate-an-api-key), then copy the example env file and add your key:
 
-Confirm you want to use Puck AI
-
-```
-? Would you like to use Puck AI? (Y/n) Y
+```sh
+cp .env.example .env.local
 ```
 
-Start the server
-
-```
-cd my-app
-yarn dev
-```
-
-### Set up Puck AI
-
-Create a [Puck account](https://cloud.puckeditor.com) and [obtain an API key](https://cloud.puckeditor.com/api-keys).
-
-Create a `.env.local` file in the root of your project and add your API key:
-
-```
+```sh
+# .env.local
 PUCK_API_KEY=your-api-key
 ```
 
-Navigate to the homepage at https://localhost:3000. To edit the homepage, access the Puck editor at https://localhost:3000/edit, and select the AI button in the left navigation bar to generate content for the page using Puck AI.
+### 2. Start the dev server
 
-You can do this for any route on the application, **even if the page doesn't exist**. For example, visit https://localhost:3000/hello/world and you'll receive a 404. You can author and publish a page by visiting https://localhost:3000/hello/world/edit. After publishing, go back to the original URL to see your page.
+```sh
+npm run dev
+```
 
-## Using this recipe
+Open [http://localhost:5173](http://localhost:5173) to see the home page, then add `/edit` to edit it: [http://localhost:5173/edit](http://localhost:5173/edit). Select the **AI** button in the left sidebar to generate content with Puck AI.
 
-To adopt this recipe, you will need to:
+This works for **any route, even ones that don't exist yet**:
 
-- **IMPORTANT** Add authentication to `/edit` routes. This can be done by modifying the [route module action](https://reactrouter.com/start/framework/route-module#action) in the splat route `/app/routes/puck-splat.tsx`. **If you don't do this, Puck will be completely public.**
-- Integrate your database into the functions in `/lib/pages.server.ts`
-- Implement a custom puck configuration in `/app/puck.config.tsx`
-- Add business context for the AI generation in `/app/routes/api.puck.ts`
+1. Visit [http://localhost:5173/hello/world](http://localhost:5173/hello/world) — you'll get a 404.
+2. Add `/edit` ([http://localhost:5173/hello/world/edit](http://localhost:5173/hello/world/edit)) to open the editor for that path.
+3. Build (or AI-generate) a page, press **Publish**, then visit the original URL to see it live.
+
+> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+
+## How it works
+
+The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+
+| File | Responsibility |
+| --- | --- |
+| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
+| `app/routes.ts` | Registers the routes: the home page, the Puck AI API route, and a catch-all [splat route](https://reactrouter.com/start/framework/routing#splats) (`*`) that handles every other path. |
+| `app/routes/puck-splat.tsx` | **The heart of the app.** Its [`loader`](https://reactrouter.com/start/framework/route-module#loader) reads the page's [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) (or a 404), its [`action`](https://reactrouter.com/start/framework/route-module#action) saves published pages, and the component renders either the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor (with the [Puck AI plugin](https://puckeditor.com/docs/ai/overview), on `/edit`) or [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) (for visitors). |
+| `app/routes/api.puck.ts` | **Puck AI API route.** Proxies AI requests to Puck Cloud via `puckHandler`. Set your business `context` (what the AI should generate) here. See [Getting Started with Puck AI](https://puckeditor.com/docs/ai/getting-started). |
+| `app/lib/resolve-puck-path.server.ts` | Detects whether a URL ends in `/edit` and returns the underlying page path. This is what lets you edit any URL by appending `/edit`. |
+| `app/routes/_index.tsx` | Renders the home page (`/`) with `<Render>`. |
+| `app/components/puck-render.tsx` | Thin wrapper around [`<Render>`](https://puckeditor.com/docs/api-reference/components/render). |
+| `app/lib/pages.server.ts` | Reads and writes page `Data` in `database.json`. |
+
+## Adapting this app for production
+
+- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the [`action`](https://reactrouter.com/start/framework/route-module#action) (which saves pages) in `app/routes/puck-splat.tsx` and the Puck AI route in `app/routes/api.puck.ts`. **Without this, anyone can edit, generate, and publish your pages.**
+- **Give the AI context.** Replace the placeholder `context` in `app/routes/api.puck.ts` with a description of your business so generated pages are on-brand.
+- **Connect a real database.** Replace the `database.json` reads and writes in `app/lib/pages.server.ts`.
+- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+
+## Learn more
+
+- [Puck AI documentation](https://puckeditor.com/docs/ai/overview) · [Puck documentation](https://puckeditor.com/docs)
+- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/react-router-ai/README.md
+++ b/recipes/react-router-ai/README.md
@@ -1,71 +1,172 @@
-# `react-router-ai` recipe
+# Puck AI + React Router recipe
 
-[Puck](https://puckeditor.com) is the visual editor for React, and [Puck AI](https://puckeditor.com/docs/ai/overview) lets you generate pages from a prompt using your own components. This app wires both into **React Router v7** (framework mode) so you can visually edit — or AI-generate — _any_ route by adding `/edit` to the URL, and serves the published pages from the same route.
+[Puck](https://puckeditor.com) is the open-source visual editor for React. It lets you create page builders that use your own components.
 
-> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to React Router, a database, and Puck AI.
+[Puck AI](https://puckeditor.com/docs/ai/overview) builds on the same principles to let you generate pages by assembling your existing components or creating new ones on the fly, either as a copilot in the editor or headlessly.
 
-## What this app demonstrates
+This recipe connects Puck and Puck AI to [React Router](https://reactrouter.com) in framework mode, so you can create and edit pages for any route in this app.
 
-- [Puck AI](https://puckeditor.com/docs/ai/overview) integration for generating pages from a prompt
-- React Router v7 (framework mode) integration
-- Editing any route by appending `/edit` (even routes that don't exist yet)
-- A single [splat route](https://reactrouter.com/start/framework/routing#splats) that both renders published pages and hosts the editor
-- A JSON file standing in for a database
+## Core concepts
 
-## Getting started
+If you're new to Puck, this section introduces the core concepts you need to know.
 
-### 1. Set up Puck AI
+### Puck
 
-Puck AI runs through [Puck Cloud](https://cloud.puckeditor.com). Create an account and [generate an API key](https://puckeditor.com/docs/ai/getting-started#generate-an-api-key), then copy the example env file and add your key:
+The Puck visual editor has three main parts: a config, the editor, and the renderer.
 
-```sh
-cp .env.example .env.local
+#### Config
+
+The [config](https://puckeditor.com/docs/integrating-puck/component-configuration) registers the components users can use to build pages in the editor and the fields they can edit.
+
+```tsx
+const config = {
+  components: {
+    HeadingBlock: {
+      fields: {
+        title: { type: "text" },
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    },
+  },
+};
 ```
 
+#### The editor
+
+The [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) component renders the editor. It uses a config, exports [pages as JSON](https://puckeditor.com/docs/api-reference/data-model/data), and accepts initial page data for editing existing pages.
+
+```tsx
+<Puck
+  config={config} // The components available to the editor
+  data={data} // The page JSON to edit
+  onPublish={(data) => {
+    // Save data to your database
+  }}
+/>
+```
+
+#### The renderer
+
+The [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) component renders pages. It expects the page JSON and the config used to create that page.
+
+```tsx
+<Render
+  config={config} // The components used to create the page
+  data={data} // The page JSON to render
+/>
+```
+
+### Puck AI
+
+This recipe adds Puck AI as a copilot. It has two parts: the AI plugin (browser) and the Cloud Client (server).
+
+#### The AI plugin
+
+The [AI plugin](https://puckeditor.com/docs/api-reference/ai/ai-plugin/installation) renders the chat in the editor and sends each message to the Cloud Client on your server.
+
+```tsx
+const aiPlugin = createAiPlugin();
+
+function Editor() {
+  return <Puck plugins={[aiPlugin]} config={config} data={data} />;
+}
+```
+
+#### The Cloud Client
+
+The [Cloud Client](https://puckeditor.com/docs/api-reference/ai/cloud-client/installation) provides APIs for connecting your server to the Puck cloud. This recipe uses its [`puckHandler`](https://puckeditor.com/docs/api-reference/ai/cloud-client/puck-handler) API, which receives each chat message, forwards it to the Puck cloud, and streams the response back to the plugin in the browser.
+
+```ts
+const options = {
+  ai: {
+    context: "We are Google. You create Google landing pages.",
+  },
+};
+
+export function loader(args: LoaderFunctionArgs) {
+  return puckHandler(args.request, options);
+}
+
+export function action(args: ActionFunctionArgs) {
+  return puckHandler(args.request, options);
+}
+```
+
+#### Puck AI modes
+
+Puck AI can build pages in two ways:
+
+- **Assembly mode** only builds pages using components from your config.
+- **Design mode** can generate new components when needed.
+
+This recipe comes with [Design mode](https://puckeditor.com/docs/api-reference/ai/cloud-client/puck-handler#aidesignmode) enabled out of the box.
+
+## Run the recipe
+
+### 1. Add a Puck API key
+
+Start by creating an account, [generating an API key](https://cloud.puckeditor.com/api-keys), and adding it to an `.env.local` file:
+
 ```sh
-# .env.local
 PUCK_API_KEY=your-api-key
 ```
 
-### 2. Start the dev server
+### 2. Start the development server
+
+Run:
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) to see the home page, then add `/edit` to edit it: [http://localhost:5173/edit](http://localhost:5173/edit). Select the **AI** button in the left sidebar to generate content with Puck AI.
+Once the server is running, navigate to [http://localhost:5173](http://localhost:5173) to view the home page, or [http://localhost:5173/edit](http://localhost:5173/edit) to edit it with Puck.
 
-This works for **any route, even ones that don't exist yet**:
+### 3. Create a page with Puck AI
 
-1. Visit [http://localhost:5173/hello/world](http://localhost:5173/hello/world) — you'll get a 404.
-2. Add `/edit` ([http://localhost:5173/hello/world/edit](http://localhost:5173/hello/world/edit)) to open the editor for that path.
-3. Build (or AI-generate) a page, press **Publish**, then visit the original URL to see it live.
+Navigate to [http://localhost:5173/edit](http://localhost:5173/edit), click the **AI** button in the left sidebar, enter a prompt, and press Enter.
 
-> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+### 4. Publish the page
+
+Once your page is ready, select **Publish** in the header to save the result, then navigate to [http://localhost:5173](http://localhost:5173) to view the published page.
+
+You can also create a page at any path by navigating to `/your/path/edit` and publishing it. The route `/your/path` will render the page.
 
 ## How it works
 
-The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+When a URL ends in `/edit`, `resolvePuckPath` (`app/lib/resolve-puck-path.server.ts`) returns the path of the page being edited. The loader in `app/routes/puck-splat.tsx` loads the saved page, or starts with an empty page if the path is new.
 
-| File | Responsibility |
-| --- | --- |
-| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
-| `app/routes.ts` | Registers the routes: the home page, the Puck AI API route, and a catch-all [splat route](https://reactrouter.com/start/framework/routing#splats) (`*`) that handles every other path. |
-| `app/routes/puck-splat.tsx` | **The heart of the app.** Its [`loader`](https://reactrouter.com/start/framework/route-module#loader) reads the page's [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) (or a 404), its [`action`](https://reactrouter.com/start/framework/route-module#action) saves published pages, and the component renders either the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor (with the [Puck AI plugin](https://puckeditor.com/docs/ai/overview), on `/edit`) or [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) (for visitors). |
-| `app/routes/api.puck.ts` | **Puck AI API route.** Proxies AI requests to Puck Cloud via `puckHandler`. Set your business `context` (what the AI should generate) here. See [Getting Started with Puck AI](https://puckeditor.com/docs/ai/getting-started). |
-| `app/lib/resolve-puck-path.server.ts` | Detects whether a URL ends in `/edit` and returns the underlying page path. This is what lets you edit any URL by appending `/edit`. |
-| `app/routes/_index.tsx` | Renders the home page (`/`) with `<Render>`. |
-| `app/components/puck-render.tsx` | Thin wrapper around [`<Render>`](https://puckeditor.com/docs/api-reference/components/render). |
-| `app/lib/pages.server.ts` | Reads and writes page `Data` in `database.json`. |
+Selecting **Publish** sends the page data to the action in `app/routes/puck-splat.tsx`. The action writes the JSON to `database.json`. The route then loads the same data and renders it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render).
 
-## Adapting this app for production
+The table below shows the files that implement this flow.
 
-- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the [`action`](https://reactrouter.com/start/framework/route-module#action) (which saves pages) in `app/routes/puck-splat.tsx` and the Puck AI route in `app/routes/api.puck.ts`. **Without this, anyone can edit, generate, and publish your pages.**
-- **Give the AI context.** Replace the placeholder `context` in `app/routes/api.puck.ts` with a description of your business so generated pages are on-brand.
-- **Connect a real database.** Replace the `database.json` reads and writes in `app/lib/pages.server.ts`.
-- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+| File                                  | Purpose                                                                                                              |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `puck.config.tsx`                     | Defines the components, fields, and default props available to Puck and Assembly mode. Add your own components here. |
+| `app/routes.ts`                       | Registers the home page, Puck AI API, and catch-all page route.                                                      |
+| `app/routes/puck-splat.tsx`           | Loads and saves page data, then renders the editor or published page.                                                |
+| `app/routes/api.puck.ts`              | Handles requests from the AI plugin and configures AI generation.                                                    |
+| `app/routes/_index.tsx`               | Loads and renders the home page.                                                                                     |
+| `app/lib/resolve-puck-path.server.ts` | Maps an `/edit` URL to the path of the page being edited.                                                            |
+| `app/lib/pages.server.ts`             | Reads and writes page data in `database.json`. Replace this with your own data fetching and saving logic.            |
+| `app/components/puck-render.tsx`      | Renders saved page data with `<Render>`.                                                                             |
+| `database.json`                       | Acts as a local database. Replace this with your own database solution.                                              |
+
+## Before deploying to production
+
+Before deploying this recipe, make sure to:
+
+- **Protect the editor and APIs.** The `/edit` routes, publish action, and `/api/puck` route are public by default. Add authentication, authorization, and rate limits to protect page data and AI usage.
+- **Add your component library.** Replace the example `HeadingBlock` in `puck.config.tsx` with the components and fields your users need.
+- **Set your business context.** Replace the example Google context in `app/routes/api.puck.ts` with clear information about your product, audience, and content rules.
+- **Use a real database.** Replace `database.json` and the functions in `app/lib/pages.server.ts`. Local files are not reliable across server instances or serverless deployments.
+- **Choose a deployment strategy.** This recipe uses server-side rendering, loaders, and actions. Deploy it to a React Router-compatible server runtime.
 
 ## Learn more
 
-- [Puck AI documentation](https://puckeditor.com/docs/ai/overview) · [Puck documentation](https://puckeditor.com/docs)
-- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)
+- [Puck documentation](https://puckeditor.com/docs)
+- [Getting started with Puck](https://puckeditor.com/docs/getting-started)
+- [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [Puck AI documentation](https://puckeditor.com/docs/ai/overview)
+- [Getting started with Puck AI](https://puckeditor.com/docs/ai/getting-started)
+- [React Router framework mode](https://reactrouter.com/start/framework/installation)
+- [Puck Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/react-router-ai/app/components/puck-render.tsx
+++ b/recipes/react-router-ai/app/components/puck-render.tsx
@@ -1,8 +1,11 @@
 import type { Data } from "@puckeditor/core";
 import { Render } from "@puckeditor/core";
+import { withDynamicConfig } from "@puckeditor/plugin-ai";
 
 import { config } from "../../puck.config";
 
 export function PuckRender({ data }: { data: Data }) {
-  return <Render config={config} data={data} />;
+  const configWithDesignedComponents = withDynamicConfig(config, data);
+
+  return <Render config={configWithDesignedComponents} data={data} />;
 }

--- a/recipes/react-router-ai/app/routes/api.puck.ts
+++ b/recipes/react-router-ai/app/routes/api.puck.ts
@@ -8,6 +8,20 @@ const options: PuckCloudOptions = {
   ai: {
     // Replace with your business context
     context: "We are Google. You create Google landing pages.",
+    designMode: {
+      // Allow AI to generate new components using "design mode"
+      // Learn more: https://puckeditor.com/docs/ai/design-mode
+      allowed: true,
+      // Constrain component generation, replace with your own instructions
+      instructions: `
+      #### Color Palette
+
+      Always use the following colors:
+
+      * Primary: \`#1976d2\`
+      * Secondary: \`#9c27b0\`
+      `,
+    },
   },
 };
 

--- a/recipes/react-router-ai/app/routes/puck-splat.tsx
+++ b/recipes/react-router-ai/app/routes/puck-splat.tsx
@@ -1,12 +1,15 @@
+import { useMemo } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import type { Data } from "@puckeditor/core";
-import { Puck, Render } from "@puckeditor/core";
-import { createAiPlugin } from "@puckeditor/plugin-ai";
+import { Puck, blocksPlugin, outlinePlugin } from "@puckeditor/core";
+import { createAiPlugin, withDynamicConfig } from "@puckeditor/plugin-ai";
 
 import type { Route } from "./+types/puck-splat";
 import { config } from "../../puck.config";
 import { resolvePuckPath } from "~/lib/resolve-puck-path.server";
 import { getPage, savePage } from "~/lib/pages.server";
+import { PuckRender } from "~/components/puck-render";
+
 import editorStyles from "@puckeditor/core/puck.css?url";
 import pluginStyles from "@puckeditor/plugin-ai/styles.css?url";
 
@@ -57,19 +60,35 @@ export async function action({ params, request }: Route.ActionArgs) {
   await savePage(path, body.data);
 }
 
-const aiPlugin = createAiPlugin();
+const aiPlugin = createAiPlugin({
+  // Allow users to switch between design and assembly mode.
+  // Read more: https://puckeditor.com/docs/ai/design-mode
+  designMode: {
+    visible: true,
+  },
+  // Select design mode by default.
+  defaultMode: "design",
+});
+
+// Place the ai plugin in the first position in the side nav.
+const plugins = [aiPlugin, blocksPlugin(), outlinePlugin()];
 
 function Editor() {
   const loaderData = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof action>();
+
+  const configWithDesignedComponents = useMemo(
+    () => withDynamicConfig(config, loaderData.data),
+    [config, loaderData.data]
+  );
 
   return (
     <>
       <link rel="stylesheet" href={editorStyles} id="puck-css" />
       <link rel="stylesheet" href={pluginStyles} id="puck-plugin-ai-css" />
       <Puck
-        plugins={[aiPlugin]}
-        config={config}
+        plugins={plugins}
+        config={configWithDesignedComponents}
         data={loaderData.data}
         onPublish={async (data) => {
           await fetcher.submit(
@@ -94,7 +113,7 @@ export default function PuckSplatRoute({ loaderData }: Route.ComponentProps) {
       {loaderData.isEditorRoute ? (
         <Editor />
       ) : (
-        <Render config={config} data={loaderData.data} />
+        <PuckRender data={loaderData.data} />
       )}
     </div>
   );

--- a/recipes/react-router/README.md
+++ b/recipes/react-router/README.md
@@ -1,35 +1,55 @@
 # `react-router` recipe
 
-The `react-router` recipe showcases one of the most powerful ways to implement Puck using to provide an authoring tool for any route in your React Router app.
+[Puck](https://puckeditor.com) is the visual editor for React. This app wires Puck into **React Router v7** (framework mode) so you can visually edit _any_ route — just add `/edit` to the URL — and serves the published pages from the same route.
 
-## Demonstrates
+> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to React Router and a database.
 
-- React Router v7 (framework) implementation
-- JSON database implementation
-- Splat route to use puck for any route on the platform
+## What this app demonstrates
 
-## Usage
+- React Router v7 (framework mode) integration
+- Editing any route by appending `/edit` (even routes that don't exist yet)
+- A single [splat route](https://reactrouter.com/start/framework/routing#splats) that both renders published pages and hosts the editor
+- A JSON file standing in for a database
 
-Run the generator and enter `react-router` when prompted
+## Getting started
 
-```
-npx create-puck-app my-app
-```
+Start the dev server:
 
-Start the server
-
-```
-yarn dev
+```sh
+npm run dev
 ```
 
-Navigate to the homepage at http://localhost:5173/. To edit the homepage, access the Puck editor at http://localhost:5173/edit.
+Open [http://localhost:5173](http://localhost:5173) to see the home page, then add `/edit` to edit it: [http://localhost:5173/edit](http://localhost:5173/edit).
 
-You can do this for any **base** route on the application, **even if the page doesn't exist**. For example, visit http://localhost:5173/hello-world and you'll receive a 404. You can author and publish a page by visiting http://localhost:5173/hello-world/edit. After publishing, go back to the original URL to see your page.
+This works for **any route, even ones that don't exist yet**:
 
-## Using this recipe
+1. Visit [http://localhost:5173/hello/world](http://localhost:5173/hello/world) — you'll get a 404.
+2. Add `/edit` ([http://localhost:5173/hello/world/edit](http://localhost:5173/hello/world/edit)) to open the editor for that path.
+3. Build a page, press **Publish**, then visit the original URL to see it live.
 
-To adopt this recipe, you will need to:
+> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
 
-- **IMPORTANT** Add authentication to `/edit` routes. This can be done by modifying the [route module action](https://reactrouter.com/start/framework/route-module#action) in the splat route `/app/routes/puck-splat.tsx`. **If you don't do this, Puck will be completely public.**
-- Integrate your database into the functions in `/lib/pages.server.ts`
-- Implement a custom puck configuration in `/app/puck.config.tsx`
+## How it works
+
+The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+
+| File | Responsibility |
+| --- | --- |
+| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
+| `app/routes.ts` | Registers the routes: the home page and a catch-all [splat route](https://reactrouter.com/start/framework/routing#splats) (`*`) that handles every other path. |
+| `app/routes/puck-splat.tsx` | **The heart of the app.** Its [`loader`](https://reactrouter.com/start/framework/route-module#loader) reads the page's [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) (or a 404), its [`action`](https://reactrouter.com/start/framework/route-module#action) saves published pages, and the component renders either the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor (on `/edit`) or [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) (for visitors). |
+| `app/lib/resolve-puck-path.server.ts` | Detects whether a URL ends in `/edit` and returns the underlying page path. This is what lets you edit any URL by appending `/edit`. |
+| `app/routes/_index.tsx` | Renders the home page (`/`) with `<Render>`. |
+| `app/components/puck-render.tsx` | Thin wrapper around [`<Render>`](https://puckeditor.com/docs/api-reference/components/render). |
+| `app/lib/pages.server.ts` | Reads and writes page `Data` in `database.json`. |
+
+## Adapting this app for production
+
+- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the [`action`](https://reactrouter.com/start/framework/route-module#action) (which saves pages) in `app/routes/puck-splat.tsx`. **Without this, anyone can edit and publish your pages.**
+- **Connect a real database.** Replace the `database.json` reads and writes in `app/lib/pages.server.ts`.
+- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+
+## Learn more
+
+- [Puck documentation](https://puckeditor.com/docs) · [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)

--- a/recipes/react-router/README.md
+++ b/recipes/react-router/README.md
@@ -1,55 +1,113 @@
-# `react-router` recipe
+# Puck + React Router recipe
 
-[Puck](https://puckeditor.com) is the visual editor for React. This app wires Puck into **React Router v7** (framework mode) so you can visually edit _any_ route — just add `/edit` to the URL — and serves the published pages from the same route.
+[Puck](https://puckeditor.com) is the open-source visual editor for React.
 
-> **New to Puck?** Read [What is Puck?](https://puckeditor.com/docs) and the [Getting Started guide](https://puckeditor.com/docs/getting-started) first. In short, Puck has three pieces: a [**config**](https://puckeditor.com/docs/api-reference/configuration/config) that describes your components, the [**`<Puck>`**](https://puckeditor.com/docs/api-reference/components/puck) editor, and [**`<Render>`**](https://puckeditor.com/docs/api-reference/components/render) for displaying a saved page. This app connects those three to React Router and a database.
+This recipe connects Puck to [React Router](https://reactrouter.com) in framework mode, so you can create and edit pages for any route in this app.
 
-## What this app demonstrates
+## Core concepts
 
-- React Router v7 (framework mode) integration
-- Editing any route by appending `/edit` (even routes that don't exist yet)
-- A single [splat route](https://reactrouter.com/start/framework/routing#splats) that both renders published pages and hosts the editor
-- A JSON file standing in for a database
+If you're new to Puck, this section introduces the core concepts you need to know.
 
-## Getting started
+### Puck
 
-Start the dev server:
+The Puck visual editor has three main parts: a config, the editor, and the renderer.
+
+#### Config
+
+The [config](https://puckeditor.com/docs/integrating-puck/component-configuration) registers the components users can use to build pages in the editor and the fields they can edit.
+
+```tsx
+const config = {
+  components: {
+    HeadingBlock: {
+      fields: {
+        title: { type: "text" },
+      },
+      render: ({ title }) => <h1>{title}</h1>,
+    },
+  },
+};
+```
+
+#### The editor
+
+The [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) component renders the editor. It uses a config, exports [pages as JSON](https://puckeditor.com/docs/api-reference/data-model/data), and accepts initial page data for editing existing pages.
+
+```tsx
+<Puck
+  config={config} // The components available to the editor
+  data={data} // The page JSON to edit
+  onPublish={(data) => {
+    // Save data to your database
+  }}
+/>
+```
+
+#### The renderer
+
+The [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) component renders pages. It expects the page JSON and the config used to create that page.
+
+```tsx
+<Render
+  config={config} // The components used to create the page
+  data={data} // The page JSON to render
+/>
+```
+
+## Run the recipe
+
+### 1. Start the development server
+
+Run:
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) to see the home page, then add `/edit` to edit it: [http://localhost:5173/edit](http://localhost:5173/edit).
+Once the server is running, navigate to [http://localhost:5173](http://localhost:5173) to view the home page, or [http://localhost:5173/edit](http://localhost:5173/edit) to edit it with Puck.
 
-This works for **any route, even ones that don't exist yet**:
+### 2. Create a page
 
-1. Visit [http://localhost:5173/hello/world](http://localhost:5173/hello/world) — you'll get a 404.
-2. Add `/edit` ([http://localhost:5173/hello/world/edit](http://localhost:5173/hello/world/edit)) to open the editor for that path.
-3. Build a page, press **Publish**, then visit the original URL to see it live.
+Navigate to [http://localhost:5173/edit](http://localhost:5173/edit), open the `Blocks` tab in the left sidebar and build your page by dragging components onto the canvas.
 
-> This app was scaffolded with `create-puck-app`. To create another, run `npx create-puck-app my-app`.
+### 3. Publish the page
+
+Once your page is ready, select **Publish** in the header to save the result, then navigate to [http://localhost:5173](http://localhost:5173) to view the published page.
+
+You can also create a page at any path by navigating to `/your/path/edit` and publishing it. The route `/your/path` will render the page.
 
 ## How it works
 
-The table below maps each key file to what it does and the relevant Puck docs. **To add your own components, start with `puck.config.tsx`.**
+When a URL ends in `/edit`, `resolvePuckPath` (`app/lib/resolve-puck-path.server.ts`) returns the path of the page being edited. The loader in `app/routes/puck-splat.tsx` loads the saved page, or starts with an empty page if the path is new.
 
-| File | Responsibility |
-| --- | --- |
-| `puck.config.tsx` | The [Puck config](https://puckeditor.com/docs/api-reference/configuration/config): the [components](https://puckeditor.com/docs/api-reference/configuration/component-config) users can drop onto a page, their [fields](https://puckeditor.com/docs/api-reference/fields/text), default props, and how each renders. |
-| `app/routes.ts` | Registers the routes: the home page and a catch-all [splat route](https://reactrouter.com/start/framework/routing#splats) (`*`) that handles every other path. |
-| `app/routes/puck-splat.tsx` | **The heart of the app.** Its [`loader`](https://reactrouter.com/start/framework/route-module#loader) reads the page's [`Data`](https://puckeditor.com/docs/api-reference/data-model/data) (or a 404), its [`action`](https://reactrouter.com/start/framework/route-module#action) saves published pages, and the component renders either the [`<Puck>`](https://puckeditor.com/docs/api-reference/components/puck) editor (on `/edit`) or [`<Render>`](https://puckeditor.com/docs/api-reference/components/render) (for visitors). |
-| `app/lib/resolve-puck-path.server.ts` | Detects whether a URL ends in `/edit` and returns the underlying page path. This is what lets you edit any URL by appending `/edit`. |
-| `app/routes/_index.tsx` | Renders the home page (`/`) with `<Render>`. |
-| `app/components/puck-render.tsx` | Thin wrapper around [`<Render>`](https://puckeditor.com/docs/api-reference/components/render). |
-| `app/lib/pages.server.ts` | Reads and writes page `Data` in `database.json`. |
+Selecting **Publish** sends the page data to the action in `app/routes/puck-splat.tsx`. The action writes the JSON to `database.json`. The route then loads the same data and renders it with [`<Render>`](https://puckeditor.com/docs/api-reference/components/render).
 
-## Adapting this app for production
+The table below shows the files that implement this flow.
 
-- ⚠️ **Add authentication.** The `/edit` routes are **public** out of the box. Protect the [`action`](https://reactrouter.com/start/framework/route-module#action) (which saves pages) in `app/routes/puck-splat.tsx`. **Without this, anyone can edit and publish your pages.**
-- **Connect a real database.** Replace the `database.json` reads and writes in `app/lib/pages.server.ts`.
-- **Build your components.** Extend `puck.config.tsx` — see [Component Configuration](https://puckeditor.com/docs/integrating-puck/component-configuration).
+| File                                  | Purpose                                                                                                   |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `puck.config.tsx`                     | Defines the components, fields, and default props available to Puck. Add your own components here.        |
+| `app/routes.ts`                       | Registers the home page and catch-all page route.                                                         |
+| `app/routes/puck-splat.tsx`           | Loads and saves page data, then renders the editor or published page.                                     |
+| `app/routes/_index.tsx`               | Loads and renders the home page.                                                                          |
+| `app/lib/resolve-puck-path.server.ts` | Maps an `/edit` URL to the path of the page being edited.                                                 |
+| `app/lib/pages.server.ts`             | Reads and writes page data in `database.json`. Replace this with your own data fetching and saving logic. |
+| `app/components/puck-render.tsx`      | Renders saved page data with `<Render>`.                                                                  |
+| `database.json`                       | Acts as a local database. Replace this with your own database solution.                                   |
+
+## Before deploying to production
+
+Before deploying this recipe, make sure to:
+
+- **Protect the editor and publishing.** The `/edit` routes and publish action are public by default. Add authentication and authorization so only trusted users can edit or publish pages.
+- **Add your component library.** Replace the example `HeadingBlock` in `puck.config.tsx` with the components and fields your users need.
+- **Use a real database.** Replace `database.json` and the functions in `app/lib/pages.server.ts`. Local files are not reliable across server instances or serverless deployments.
+- **Choose a deployment strategy.** This recipe uses server-side rendering, loaders, and actions. Deploy it to a React Router-compatible server runtime.
 
 ## Learn more
 
-- [Puck documentation](https://puckeditor.com/docs) · [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
-- [Puck on GitHub](https://github.com/puckeditor/puck) · [Discord](https://discord.gg/D9e4E3MQVZ)
+- [Puck documentation](https://puckeditor.com/docs)
+- [Getting started with Puck](https://puckeditor.com/docs/getting-started)
+- [Integrating Puck](https://puckeditor.com/docs/integrating-puck/component-configuration)
+- [React Router framework mode](https://reactrouter.com/start/framework/installation)
+- [Puck Discord](https://discord.gg/D9e4E3MQVZ)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,28 +12,28 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
   integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
 
-"@ai-sdk/gateway@3.0.123":
-  version "3.0.123"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.123.tgz#6ffebf1bd916087d3f171b3f1ee627f7e8bfcf5a"
-  integrity sha512-rL+3Sp9crOlfE7MwguFPS30qVp6HFcr9na0KYMb4CcQdxAIjBJec3EEdCjc94UyRVZWLmgQ6Yr605FmPlFIi0w==
+"@ai-sdk/gateway@3.0.152":
+  version "3.0.152"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.152.tgz#fe6bc052c2015d909d419c700371255372326b82"
+  integrity sha512-IM9D6if0CXsNkiyyIqoaD3/80gZVpCI3/tKpsq1N+vNa2O1ZeUfJmaUcIr92qqPO1G8u5YHah+0EayhIkk3ACA==
   dependencies:
-    "@ai-sdk/provider" "3.0.10"
-    "@ai-sdk/provider-utils" "4.0.27"
+    "@ai-sdk/provider" "3.0.14"
+    "@ai-sdk/provider-utils" "4.0.39"
     "@vercel/oidc" "3.2.0"
 
-"@ai-sdk/provider-utils@4.0.27":
-  version "4.0.27"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz#d2183685768626bcf1c968b7d73ea2b974da59b9"
-  integrity sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==
+"@ai-sdk/provider-utils@4.0.39":
+  version "4.0.39"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.39.tgz#920f0109ace2e1baec6f5478043f8b9f5772ba6d"
+  integrity sha512-XPR6o7561RYUkfYlLYouWsvm6Gv2tYIQy5pttGRkvML98u138ClPThn5yiQg5rMQutTtZLB+GUC8qFFCzDKQQQ==
   dependencies:
-    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider" "3.0.14"
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.8"
 
-"@ai-sdk/provider@3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.10.tgz#abfb6776f699951f9b8ac20cf1d42a3fc7d79752"
-  integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
+"@ai-sdk/provider@3.0.14":
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.14.tgz#5893a90e0b5355ec6a5c148f06bd7f08355c1a6f"
+  integrity sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==
   dependencies:
     json-schema "^0.4.0"
 
@@ -435,10 +435,15 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime@^7.11.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13":
+"@babel/runtime@^7.11.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
+"@babel/runtime@^7.20.13":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.28.6", "@babel/template@^7.3.3":
   version "7.28.6"
@@ -4348,13 +4353,13 @@ aggregate-error@^3.0.0:
     indent-string "^4.0.0"
 
 ai@^6.0.61:
-  version "6.0.195"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.195.tgz#b971c71f079b90a4ee23189ca8f1de1ddcbba37f"
-  integrity sha512-IYZpuVz0boWbpIQYyinfWFrvQ1N0dG+EVB63it45B2YAU/MxxCnwz4zBswjYnPtHnJBedpMPNrwVbeczbl2GKg==
+  version "6.0.229"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.229.tgz#44741d6d25ab2f01adb5034a0c92407230b2eda7"
+  integrity sha512-bDi36L2RdEFMS7z2WIhBr7fpQhMkjzd6mgRKgtlmBSs2zZwUI22s6ZBOak/XN/LpKiJnS7SrlVqKDcqqvzTW8A==
   dependencies:
-    "@ai-sdk/gateway" "3.0.123"
-    "@ai-sdk/provider" "3.0.10"
-    "@ai-sdk/provider-utils" "4.0.27"
+    "@ai-sdk/gateway" "3.0.152"
+    "@ai-sdk/provider" "3.0.14"
+    "@ai-sdk/provider-utils" "4.0.39"
     "@opentelemetry/api" "^1.9.0"
 
 ajv@^6.14.0:
@@ -14556,9 +14561,9 @@ use-sidecar@^1.1.3:
     tslib "^2.0.0"
 
 use-stick-to-bottom@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/use-stick-to-bottom/-/use-stick-to-bottom-1.1.4.tgz#2d7a7c1875d3185a04f5c8660924124ac6c36a90"
-  integrity sha512-2w/lydkrwhWMv1vCaEhYbzMDhgbwIodHpAHPV0/xKJErRkbjDEUe1EWmvr6Fwb+qhiERjc1EWgAEZaSaF69CpA==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/use-stick-to-bottom/-/use-stick-to-bottom-1.1.6.tgz#c35e7f9bcb1ee3da0c059c448fb9a61bdf01fe6b"
+  integrity sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==
 
 use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0, use-sync-external-store@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
This PR adds support for the new Puck agent in the recipes, reworks the recipes READMEs to better onboard new users, and adds an `--ai` option to the recipe to avoid additional questions while running the script.