### PR TITLE
fix: allow edge escape from components containing an active zone

### DIFF
--- a/packages/core/lib/dnd/NestedDroppablePlugin.ts
+++ b/packages/core/lib/dnd/NestedDroppablePlugin.ts
@@ -21,7 +21,7 @@ type NestedDroppablePluginOptions = {
       area: string | null;
       zone: string | null;
     },
-    manager: DragDropManager
+    manager: DragDropManager,
   ) => void;
 };
 
@@ -67,17 +67,17 @@ const BUFFER = 6;
 
 const getPointerCollisions = (
   position: GlobalPosition,
-  manager: DragDropManager
+  manager: DragDropManager,
 ) => {
   const candidates: Droppable[] = [];
 
   let elements = position.target.ownerDocument.elementsFromPoint(
     position.x,
-    position.y
+    position.y,
   );
 
   const previewFrame = elements.find((el) =>
-    el.getAttribute("data-puck-preview")
+    el.getAttribute("data-puck-preview"),
   );
 
   // Restrict to drawer element if pointer is over drawer. This is necessary if
@@ -150,7 +150,7 @@ const getPointerCollisions = (
 
 export const findDeepestCandidate = (
   position: GlobalPosition,
-  manager: DragDropManager
+  manager: DragDropManager,
 ) => {
   const candidates = getPointerCollisions(position, manager);
 
@@ -160,7 +160,7 @@ export const findDeepestCandidate = (
     const draggable = manager.dragOperation.source;
 
     const draggedCandidateIndex = sortedCandidates.findIndex(
-      (candidate) => candidate.id === draggable?.id
+      (candidate) => candidate.id === draggable?.id,
     );
 
     const draggedCandidateId = draggable?.id;
@@ -175,8 +175,7 @@ export const findDeepestCandidate = (
     // Remove any descendants
     filteredCandidates = filteredCandidates.filter((candidate) => {
       const candidateData = candidate.data as
-        | ComponentDndData
-        | DropZoneDndData;
+        ComponentDndData | DropZoneDndData;
 
       if (draggedCandidateId && draggedCandidateIndex > -1) {
         if (candidateData.path.indexOf(draggedCandidateId) > -1) {
@@ -215,13 +214,40 @@ export const findDeepestCandidate = (
     if (!primaryCandidate) return { zone: null, area: null };
 
     const primaryCandidateData = primaryCandidate.data as
-      | ComponentDndData
-      | DropZoneDndData;
+      ComponentDndData | DropZoneDndData;
     const primaryCandidateIsComponent =
       "containsActiveZone" in primaryCandidateData;
-    const zone = getZoneId(primaryCandidate);
+    let zone = getZoneId(primaryCandidate);
+
+    // containsActiveZone freezes zone targeting to keep the interior
+    // stable, but freezing the edge band makes it impossible to drop a
+    // container next to another container. Allow escape to the parent
+    // zone near the component's edges.
+    if (
+      zone === null &&
+      primaryCandidateIsComponent &&
+      (primaryCandidateData as ComponentDndData).containsActiveZone
+    ) {
+      const rect = primaryCandidate.element?.getBoundingClientRect();
+
+      if (rect) {
+        const margin = Math.min(BUFFER * 2, rect.width / 4, rect.height / 4);
+
+        const nearEdge =
+          position.frame.x < rect.left + margin ||
+          position.frame.x > rect.right - margin ||
+          position.frame.y < rect.top + margin ||
+          position.frame.y > rect.bottom - margin;
+
+        if (nearEdge) {
+          zone = (primaryCandidateData as ComponentDndData).zone;
+        }
+      }
+    }
+
+    // Frozen zone highlights the host, resolved zone follows its area.
     const area =
-      primaryCandidateIsComponent && primaryCandidateData.containsActiveZone
+      zone === null && primaryCandidateIsComponent
         ? filteredCandidates[0].id
         : filteredCandidates[0]?.data.areaId;
 
@@ -236,7 +262,7 @@ export const findDeepestCandidate = (
 
 export const createNestedDroppablePlugin = (
   { onChange }: NestedDroppablePluginOptions,
-  id: string
+  id: string,
 ): any =>
   class NestedDroppablePlugin extends Plugin<DragDropManager, {}> {
     constructor(manager: DragDropManager, options?: {}) {
@@ -261,7 +287,7 @@ export const createNestedDroppablePlugin = (
 
           const elements = document.elementsFromPoint(
             position.global.x,
-            position.global.y
+            position.global.y,
           );
 
           const overEl = elements.some((el) => el.id === id);


### PR DESCRIPTION
## Description

Dropping a component next to a container that accepts it doesn't work. The most visible case is dragging a container while another container is on the page: the insert preview dives into the deepest zone under the pointer and never comes back out, so everything keeps nesting.

The cause is in `NestedDroppablePlugin.ts`. `getZoneId` returns null for any component candidate whose zone accepts the dragged type, which during a container drag is every container on the page. Null freezes zone targeting, so the parent zone can never be reached from a container's edge band. That band is exactly the region the `BUFFER` contraction in `getPointerCollisions` reserves for falling through to the parent, so the two mechanisms cancel each other out.

The freeze itself is worth keeping for interior hovers, since it stops the target from bouncing to the parent while hovering a component's chrome around its slot. This PR keeps that and only allows the pointer to escape to the parent zone within an edge margin of the component's box (2x `BUFFER`, clamped so small components keep a stable interior).

No public API changes.

## Changes made

- `findDeepestCandidate` lets a null zone resolve to the component's own
  zone (its parent) when the pointer is within an edge margin of the component's bounding box.
- `area` now follows the same resolution: a frozen zone highlights the
  hosting component, a resolved zone follows `areaId`. Previously these could disagree.

## How to test

- Add a slot-based Container component to a config:

```tsx
const config = {
  components: {
    Container: {
      fields: { content: { type: 'slot' } },
      render: ({ content: Content }) => (
        <div style={{ padding: 10 }}>
          <Content />
        </div>
      ),
    },
  },
};
```

- Drop one Container onto the canvas, then drag a second one from the
  drawer and hover near the first one's edge. Before this change the preview gets stuck inside the first container and the drop nests. After it, the edge shows the sibling insert position and the drop lands next to it.
- Interior behavior is unchanged: hovering the middle of a container
  still nests into it, and reordering inside a container doesn't pop items out unless you drag them to the edge.

Related: #1710, #123, #1486 (not fully fixed by this, but this is the mechanism behind much of the pain described there).