### PR TITLE
release: v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!--__CHANGELOG_ENTRY__-->
 
+## [0.23.0](https://github.com/puckeditor/puck/compare/v0.22.0...v0.23.0) (2026-07-20)
+
+
+### Bug Fixes
+
+* add engines field to core package.json ([5f5b18a](https://github.com/puckeditor/puck/commit/5f5b18aa6843957783d9e1dec0679056cbb6e2e5)), closes [/linear.app/puckeditor/issue/PUCK-452/add-engines-to-core-packagejson#agent-session-471689d1](https://github.com//linear.app/puckeditor/issue/PUCK-452/add-engines-to-core-packagejson/issues/agent-session-471689d1)
+* don't drop last fields when updating config ([4bf6887](https://github.com/puckeditor/puck/commit/4bf6887d6ef08964c520a172a8db20da5329d1d5))
+* don't drop transformed fields on updates ([9bf3e00](https://github.com/puckeditor/puck/commit/9bf3e00a1cca9b8d496806b3ca265c003a264f66))
+* prevent unbounded cache growth in resolveAllData ([d8d77eb](https://github.com/puckeditor/puck/commit/d8d77eb5dc24e37c575f6267d9b7a1de059b0767))
+* run field transforms for fields without default props ([1a601e7](https://github.com/puckeditor/puck/commit/1a601e7048af8f5e72f76eb3d1b336965e36ffb5)), closes [/linear.app/puckeditor/issue/PUCK-316/field-transforms-not-called-if-no-default-props-are-set#agent-session-57b9b235](https://github.com//linear.app/puckeditor/issue/PUCK-316/field-transforms-not-called-if-no-default-props-are-set/issues/agent-session-57b9b235)
+
+
+### Features
+
+* add dictionary ([65790c8](https://github.com/puckeditor/puck/commit/65790c826cfdb51364da14ae9a7d96d43548edae))
+* add draggable outline and streamline UI ([db035ce](https://github.com/puckeditor/puck/commit/db035ce57a94425da9d0e82d3f1c06ecabd4c350))
+
+
+
+
 ## [0.22.1](https://github.com/puckeditor/puck/compare/v0.22.0...v0.22.1) (2026-07-13)
 
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -17,7 +17,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@puckeditor/core": "^0.22.1",
+    "@puckeditor/core": "^0.23.0",
     "next": "^15.5.16",
     "next-sitemap": "^4.2.3",
     "nextra": "^3.3.1",

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
     "packages/plugin-emotion-cache",
     "packages/plugin-heading-analyzer"
   ],
-  "version": "0.22.1",
+  "version": "0.23.0",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "recipes/*",
     "packages/*"
   ],
-  "version": "0.22.1",
+  "version": "0.23.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/core",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "The open-source visual editor for React",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",

--- a/packages/create-puck-app/package.json
+++ b/packages/create-puck-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-puck-app",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",

--- a/packages/field-contentful/package.json
+++ b/packages/field-contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/field-contentful",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.22.1",
+    "@puckeditor/core": "^0.23.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "contentful": "^10.8.6",

--- a/packages/plugin-emotion-cache/package.json
+++ b/packages/plugin-emotion-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-emotion-cache",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -24,7 +24,7 @@
   ],
   "devDependencies": {
     "@emotion/react": "^11.13.3",
-    "@puckeditor/core": "^0.22.1",
+    "@puckeditor/core": "^0.23.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.0.2",

--- a/packages/plugin-heading-analyzer/package.json
+++ b/packages/plugin-heading-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@puckeditor/plugin-heading-analyzer",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "author": "Chris Villa <chris@puckeditor.com>",
   "repository": "puckeditor/puck",
   "bugs": "https://github.com/puckeditor/puck/issues",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@puckeditor/core": "^0.22.1",
+    "@puckeditor/core": "^0.23.0",
     "@types/minimatch": "3.0.5",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",


### PR DESCRIPTION
Automated weekly release prep for v0.23.0.

On merge, this release is tagged and published to npm automatically.

## Changelog

## [0.23.0](https://github.com/puckeditor/puck/compare/v0.22.0...v0.23.0) (2026-07-20)


### Bug Fixes

* add engines field to core package.json ([5f5b18a](https://github.com/puckeditor/puck/commit/5f5b18aa6843957783d9e1dec0679056cbb6e2e5)), closes [/linear.app/puckeditor/issue/PUCK-452/add-engines-to-core-packagejson#agent-session-471689d1](https://github.com//linear.app/puckeditor/issue/PUCK-452/add-engines-to-core-packagejson/issues/agent-session-471689d1)
* don't drop last fields when updating config ([4bf6887](https://github.com/puckeditor/puck/commit/4bf6887d6ef08964c520a172a8db20da5329d1d5))
* don't drop transformed fields on updates ([9bf3e00](https://github.com/puckeditor/puck/commit/9bf3e00a1cca9b8d496806b3ca265c003a264f66))
* prevent unbounded cache growth in resolveAllData ([d8d77eb](https://github.com/puckeditor/puck/commit/d8d77eb5dc24e37c575f6267d9b7a1de059b0767))
* run field transforms for fields without default props ([1a601e7](https://github.com/puckeditor/puck/commit/1a601e7048af8f5e72f76eb3d1b336965e36ffb5)), closes [/linear.app/puckeditor/issue/PUCK-316/field-transforms-not-called-if-no-default-props-are-set#agent-session-57b9b235](https://github.com//linear.app/puckeditor/issue/PUCK-316/field-transforms-not-called-if-no-default-props-are-set/issues/agent-session-57b9b235)


### Features

* add dictionary ([65790c8](https://github.com/puckeditor/puck/commit/65790c826cfdb51364da14ae9a7d96d43548edae))
* add draggable outline and streamline UI ([db035ce](https://github.com/puckeditor/puck/commit/db035ce57a94425da9d0e82d3f1c06ecabd4c350))





## Reviewer checklist

- [ ] Changelog entries look right
- [ ] Version bump is the expected level (major/minor/patch)