### PR TITLE
fix: don't mutate nested values in `setDeep`

### DIFF
--- a/apps/docs/pages/docs/api-reference/functions/set-deep.mdx
+++ b/apps/docs/pages/docs/api-reference/functions/set-deep.mdx
@@ -8,6 +8,8 @@ A convenience utility for setting the value of a key deep within an object.
 
 Useful when implementing [field transforms](/docs/api-reference/field-transforms).
 
+This function only duplicates the objects and arrays along the path to the key being set, leaving the rest of the input object or array unchanged.
+
 ```tsx
 import { setDeep } from "@puckeditor/core";
 

--- a/packages/core/lib/data/__tests__/set-deep.spec.tsx
+++ b/packages/core/lib/data/__tests__/set-deep.spec.tsx
@@ -1,0 +1,118 @@
+import { setDeep } from "../set-deep";
+
+describe("setDeep", () => {
+  describe("assignment", () => {
+    it("sets a top-level prop", () => {
+      expect(setDeep({ a: 1 }, "b", 2)).toEqual({ a: 1, b: 2 });
+    });
+
+    it("sets a nested object prop", () => {
+      expect(setDeep({ a: { b: 1, c: 3 } }, "a.b", 2)).toEqual({
+        a: { b: 2, c: 3 },
+      });
+    });
+
+    it("sets an array item", () => {
+      expect(setDeep({ arr: [1, 2] }, "arr[1]", 9)).toEqual({ arr: [1, 9] });
+    });
+
+    it("sets a nested prop inside an array item", () => {
+      expect(setDeep({ arr: [{ x: 1 }, { x: 2 }] }, "arr[0].x", 9)).toEqual({
+        arr: [{ x: 9 }, { x: 2 }],
+      });
+    });
+
+    it("sets a deeply nested mixed path", () => {
+      expect(
+        setDeep(
+          { a: { b: [{ c: { d: 1 } }, { c: { d: 2 } }] } },
+          "a.b[1].c.d",
+          9
+        )
+      ).toEqual({ a: { b: [{ c: { d: 1 } }, { c: { d: 9 } }] } });
+    });
+
+    it("creates missing objects along the path", () => {
+      expect(setDeep({}, "a.b.c", 1)).toEqual({ a: { b: { c: 1 } } });
+    });
+
+    it("creates missing arrays along the path", () => {
+      expect(setDeep({}, "a[0].b", 1)).toEqual({ a: [{ b: 1 }] });
+    });
+
+    it("replaces non-array values with an array when using index syntax", () => {
+      expect(setDeep({ a: "string" }, "a[0]", 1)).toEqual({ a: [1] });
+    });
+
+    it("replaces non-object intermediate values with an object", () => {
+      const original = { a: 5 };
+
+      expect(setDeep(original, "a.b", 1)).toEqual({ a: { b: 1 } });
+      expect(original).toEqual({ a: 5 });
+    });
+  });
+
+  describe("immutability", () => {
+    it("does not mutate nested objects on the input", () => {
+      const original = { composite: { focal: "original" }, other: "unchanged" };
+
+      const result = setDeep(original, "composite.focal", "A-value");
+
+      expect(result.composite.focal).toBe("A-value");
+      expect(original.composite.focal).toBe("original");
+    });
+
+    it("does not mutate arrays on the input", () => {
+      const original = { items: [{ label: "one" }, { label: "two" }] };
+
+      const result = setDeep(original, "items[0].label", "changed");
+
+      expect(result.items[0].label).toBe("changed");
+      expect(original.items[0].label).toBe("one");
+    });
+
+    it("does not mutate the input when assigning to a leaf array index", () => {
+      const original = { arr: [1, 2] };
+
+      const result = setDeep(original, "arr[1]", 9);
+
+      expect(result.arr).toEqual([1, 9]);
+      expect(original.arr).toEqual([1, 2]);
+      expect(result.arr).not.toBe(original.arr);
+    });
+
+    it("does not mutate deeply nested structure on the input", () => {
+      const original = { a: { b: [{ c: { d: "original" } }] } };
+
+      const result = setDeep(original, "a.b[0].c.d", "changed");
+
+      expect(result.a.b[0].c.d).toBe("changed");
+      expect(original.a.b[0].c.d).toBe("original");
+    });
+
+    it("returns a new object at every level of the assignment path", () => {
+      const original = { a: { b: [{ c: 1 }] } };
+
+      const result = setDeep(original, "a.b[0].c", 2);
+
+      expect(result).not.toBe(original);
+      expect(result.a).not.toBe(original.a);
+      expect(result.a.b).not.toBe(original.a.b);
+      expect(result.a.b[0]).not.toBe(original.a.b[0]);
+    });
+
+    it("preserves references for values outside the assignment path", () => {
+      const original = {
+        target: { value: 1 },
+        sibling: { value: 2 },
+        items: [{ label: "one" }, { label: "two" }],
+      };
+
+      const result = setDeep(original, "items[0].label", "changed");
+
+      expect(result.target).toBe(original.target);
+      expect(result.sibling).toBe(original.sibling);
+      expect(result.items[1]).toBe(original.items[1]);
+    });
+  });
+});

--- a/packages/core/lib/data/set-deep.ts
+++ b/packages/core/lib/data/set-deep.ts
@@ -1,5 +1,14 @@
+import { isPlainObject } from "../is-plain-object";
+
+const copyContainer = (value: any) =>
+  Array.isArray(value) ? [...value] : isPlainObject(value) ? { ...value } : {};
+
 /**
- * Helper function to set a value based on a dot-notated path
+ * Helper function to set a value based on a dot-notated path.
+ *
+ * Copies every level along the assignment path (leaving all other
+ * references untouched), so shared structures such as history
+ * snapshots are never mutated in place.
  */
 export function setDeep<T extends Record<string, any>>(
   node: T,
@@ -12,15 +21,13 @@ export function setDeep<T extends Record<string, any>>(
   let cur: Record<string, any> = newNode;
 
   for (let i = 0; i < parts.length; i++) {
-    // Separate the “prop” piece and an optional “[index]” part.
+    // Separate the “prop” piece and an optional “[index]” part (e.g. "myArr[0]" -> ["myArr", "0"]).
     const [prop, idxStr] = parts[i].replace("]", "").split("[");
     const isLast = i === parts.length - 1;
 
+    // If it has an index, treat it as an array
     if (idxStr !== undefined) {
-      if (!Array.isArray(cur[prop])) {
-        cur[prop] = [];
-      }
-
+      cur[prop] = Array.isArray(cur[prop]) ? [...cur[prop]] : [];
       const idx = Number(idxStr);
 
       if (isLast) {
@@ -29,8 +36,7 @@ export function setDeep<T extends Record<string, any>>(
         continue;
       }
 
-      // Ensure the next level container exists.
-      if (cur[prop][idx] === undefined) cur[prop][idx] = {};
+      cur[prop][idx] = copyContainer(cur[prop][idx]);
 
       cur = cur[prop][idx];
 
@@ -38,16 +44,16 @@ export function setDeep<T extends Record<string, any>>(
     }
 
     if (isLast) {
+      // We’ve reached the leaf → assign.
       cur[prop] = newVal;
       continue;
     }
 
-    if (cur[prop] === undefined) {
-      cur[prop] = {};
-    }
+    // Otherwise, treat it as an object.
+    cur[prop] = copyContainer(cur[prop]);
 
     cur = cur[prop];
   }
 
-  return { ...node, ...newNode };
+  return newNode;
 }

--- a/packages/core/lib/is-plain-object.ts
+++ b/packages/core/lib/is-plain-object.ts
@@ -1,0 +1,10 @@
+/**
+ * Checks if a value is a plain object (i.e., an object created by the Object constructor or with a null prototype).
+ * @param val The value to check.
+ * @returns True if the value is a plain object, false otherwise.
+ */
+export const isPlainObject = (val: any): val is Record<string, any> => {
+  if (typeof val !== "object" || val === null) return false;
+  const prototype = Object.getPrototypeOf(val);
+  return prototype === Object.prototype || prototype === null;
+};


### PR DESCRIPTION
Closes #1596 and #1736

## Description

This PR spreads values that are in the assigment path of `setDeep` to avoid unwanted mutations to object references.

This also performs better due to removing the redudant spread at the return statement.

## Changes made

- `setDeep` now creates a new object or array before iterating to the next path part.
- `isPlainObject` checks if an object is a POJO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deep value assignment to preserve immutability by cloning only containers along the modified path.
  * Preserved unrelated objects, arrays, and values instead of modifying them in place.

* **Documentation**
  * Clarified that deep assignments leave unchanged portions of the input intact.

* **Tests**
  * Added coverage for nested, array-based, missing-path, replacement, and immutability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->