### PR TITLE
fix: use the latest component position in inline fields

### DIFF
--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { memo, useEffect, useRef, useState } from "react";
+
 import { registerOverlayPortal } from "../../lib/overlay-portal";
 import { useAppStoreApi } from "../../store";
-import styles from "./styles.module.css";
-import { getClassNameFactory } from "../../lib";
-import { setDeep } from "../../lib/data/set-deep";
+
+import getClassNameFactory from "../../lib/get-class-name-factory";
+import { resolveAndReplaceData } from "../../lib/data/resolve-and-replace-data";
 import { getSelectorForId } from "../../lib/get-selector-for-id";
+import { setDeep } from "../../lib/data/set-deep";
+
+import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("InlineTextField", styles);
 
@@ -53,12 +57,6 @@ const InlineTextFieldInternal = ({
         const appStore = appStoreApi.getState();
         const node = appStore.state.indexes.nodes[componentId];
 
-        const zoneCompound = `${node.parentId}:${node.zone}`;
-        const index =
-          appStore.state.indexes.zones[zoneCompound]?.contentIds.indexOf(
-            componentId
-          );
-
         let value = e.target.innerText;
 
         if (disableLineBreaks) {
@@ -67,17 +65,12 @@ const InlineTextFieldInternal = ({
 
         const newProps = setDeep(node.data.props, propPath, value);
 
-        const resolvedData = await appStore.resolveComponentData(
+        await resolveAndReplaceData(
           { ...node.data, props: newProps },
-          "replace"
+          appStoreApi.getState,
+          "replace",
+          true
         );
-
-        appStore.dispatch({
-          type: "replace",
-          data: resolvedData.node,
-          destinationIndex: index,
-          destinationZone: zoneCompound,
-        });
       };
 
       ref.current.addEventListener("input", handleInput);

--- a/packages/core/lib/data/__tests__/resolve-and-replace-data.spec.tsx
+++ b/packages/core/lib/data/__tests__/resolve-and-replace-data.spec.tsx
@@ -27,6 +27,11 @@ const config: Config = {
       resolveData: childResolveData,
       render: () => <div />,
     },
+    StaticChild: {
+      fields: { label: { type: "text" } },
+      resolveData: async (data) => data, // Return the same data to simulate a no-op resolve
+      render: () => <div />,
+    },
   },
 };
 
@@ -74,6 +79,13 @@ function resetStores() {
                 props: {
                   id: "Parent-2",
                   items: [],
+                },
+              },
+              {
+                type: "StaticChild",
+                props: {
+                  id: "Static-1",
+                  label: "old",
                 },
               },
             ],
@@ -144,5 +156,60 @@ describe("resolveAndReplaceData", () => {
     // Then: ---------------
     expect(consoleWarnMock).toHaveBeenCalledTimes(1);
     consoleWarnMock.mockRestore();
+  });
+
+  describe("writeThrough", () => {
+    const editedStaticChild = {
+      type: "StaticChild",
+      props: { id: "Static-1", label: "new" },
+    };
+
+    const getLabel = () =>
+      appStore.getState().state.indexes.nodes["Static-1"].data.props.label;
+
+    it("commits the edit when writeThrough is true even though the resolver reports no change", async () => {
+      // When: ---------------
+      await act(() =>
+        resolveAndReplaceData(
+          editedStaticChild, // Resolver returns same data, so didChange === false, keeping `old` in store.
+          appStore.getState,
+          "replace",
+          true
+        )
+      );
+
+      // Then: the edit is written through to the store
+      expect(getLabel()).toBe("new");
+    });
+
+    it("does not commit the edit when writeThrough is false and the resolver reports no change", async () => {
+      // When: ---------------
+      await act(() =>
+        resolveAndReplaceData(
+          editedStaticChild,
+          appStore.getState,
+          "replace",
+          false
+        )
+      );
+
+      // Then: the no-op resolve is skipped and the store keeps the original data.
+      // (This passing also proves didChange was false for the case above.)
+      expect(getLabel()).toBe("old");
+    });
+
+    it("still commits when the resolver does change the data, regardless of writeThrough", async () => {
+      // Given: Child's resolver always rewrites props (didChange === true)
+      // When: writeThrough is false
+      await act(() =>
+        resolveAndReplaceData(child1, appStore.getState, "replace", false)
+      );
+
+      // Then: the resolved data is committed
+      expect(
+        appStore.getState().state.indexes.nodes["Child-1"].data.props
+          .resolvedProp
+      ).toBe("replace");
+    });
   });
 });

--- a/packages/core/lib/data/resolve-and-replace-data.ts
+++ b/packages/core/lib/data/resolve-and-replace-data.ts
@@ -1,18 +1,31 @@
 import { useAppStoreApi } from "../../store";
-import { ComponentData, ResolveDataTrigger } from "../../types";
+import { ComponentData, ResolveDataTrigger, UiState } from "../../types";
+
 import { getSelectorForId } from "../get-selector-for-id";
+
 import { toComponent } from "./to-component";
 
+/**
+ * Resolves the data of a component and replaces it in the appStore state.
+ * @param currentData - The current data of the component to resolve.
+ * @param getState - The function to get the current state of the appStore.
+ * @param trigger - The trigger for resolving the data. Defaults to "force".
+ * @param writeThrough - Whether to write through the resolved data even if it hasn't changed. Defaults to false.
+ * @param ui - Optional UI state to set after replacing the component.
+ * @returns A promise that resolves when the data has been replaced.
+ */
 export async function resolveAndReplaceData(
   currentData: ComponentData,
   getState: ReturnType<typeof useAppStoreApi>["getState"],
-  trigger: ResolveDataTrigger = "force"
+  trigger: ResolveDataTrigger = "force",
+  writeThrough: boolean = false,
+  ui?: Partial<UiState>
 ) {
   const resolvedResult = await getState().resolveComponentData(
     currentData,
     trigger
   );
-  if (!resolvedResult.didChange) return;
+  if (!resolvedResult.didChange && !writeThrough) return;
 
   const itemSelector = getSelectorForId(
     getState().state,
@@ -30,5 +43,6 @@ export async function resolveAndReplaceData(
     data: toComponent(resolvedResult.node),
     destinationIndex: itemSelector.index,
     destinationZone: itemSelector.zone,
+    ui,
   });
 }

--- a/packages/core/lib/field-transforms/default-transforms/rich-text-transform.tsx
+++ b/packages/core/lib/field-transforms/default-transforms/rich-text-transform.tsx
@@ -1,10 +1,6 @@
 "use client";
-import { EditorFallback } from "../../../components/RichTextEditor/components/EditorFallback";
-import { RichTextRenderFallback } from "../../../components/RichTextEditor/components/RenderFallback";
-import { FieldTransforms } from "../../../types/API/FieldTransforms";
-import { useAppStoreApi } from "../../../store";
-import { setDeep } from "../../../lib/data/set-deep";
-import { registerOverlayPortal } from "../../../lib/overlay-portal";
+
+import type { Editor as TipTapEditor, JSONContent } from "@tiptap/react";
 import {
   useEffect,
   useRef,
@@ -14,9 +10,19 @@ import {
   lazy,
   Suspense,
 } from "react";
-import type { Editor as TipTapEditor, JSONContent } from "@tiptap/react";
-import { getSelectorForId } from "../../get-selector-for-id";
+import { resolveAndReplaceData } from "../../data/resolve-and-replace-data";
+
+import { EditorFallback } from "../../../components/RichTextEditor/components/EditorFallback";
+import { RichTextRenderFallback } from "../../../components/RichTextEditor/components/RenderFallback";
+import { FieldTransforms } from "../../../types/API/FieldTransforms";
+import { useAppStoreApi } from "../../../store";
+
 import { RichtextField, UiState } from "../../../types";
+
+import { setDeep } from "../../data/set-deep";
+import { registerOverlayPortal } from "../../overlay-portal";
+
+import { getSelectorForId } from "../../get-selector-for-id";
 
 const Editor = lazy(() =>
   import("../../../components/RichTextEditor/components/Editor").then((m) => ({
@@ -77,26 +83,16 @@ const InlineEditorWrapper = memo(
       async (content: string | JSONContent, ui?: Partial<UiState>) => {
         const appStore = appStoreApi.getState();
         const node = appStore.state.indexes.nodes[componentId];
-        const zoneCompound = `${node.parentId}:${node.zone}`;
-        const index =
-          appStore.state.indexes.zones[zoneCompound]?.contentIds.indexOf(
-            componentId
-          );
 
         const newProps = setDeep(node.data.props, propPath, content);
 
-        const resolvedData = await appStore.resolveComponentData(
+        await resolveAndReplaceData(
           { ...node.data, props: newProps },
-          "replace"
+          appStoreApi.getState,
+          "replace",
+          true,
+          ui
         );
-
-        appStore.dispatch({
-          type: "replace",
-          data: resolvedData.node,
-          destinationIndex: index,
-          destinationZone: zoneCompound,
-          ui,
-        });
       },
       [appStoreApi, componentId, propPath]
     );

--- a/packages/core/lib/insert-component.ts
+++ b/packages/core/lib/insert-component.ts
@@ -1,11 +1,20 @@
 import { InsertAction } from "../reducer";
 import { insertAction } from "../reducer/actions/insert";
 import { useAppStoreApi } from "../store";
+
 import { generateId } from "./generate-id";
 import { getItem } from "./data/get-item";
-import { getSelectorForId } from "./get-selector-for-id";
+import { resolveAndReplaceData } from "./data/resolve-and-replace-data";
 
-// Makes testing easier without mocks
+/**
+ * Inserts a new component of the specified type into the specified zone at the specified index, and resolves its data.
+ *
+ * @param componentType - The type of the component to insert.
+ * @param zone - The zone in which to insert the component.
+ * @param index - The index at which to insert the component within the zone.
+ * @param appStore - The app store API to use for dispatching actions and getting state.
+ * @returns A promise that resolves when the component has been inserted and its data has been resolved.
+ */
 export const insertComponent = async (
   componentType: string,
   zone: string,
@@ -47,19 +56,5 @@ export const insertComponent = async (
   const itemData = getItem(itemSelector, insertedState);
   if (!itemData) return;
 
-  // Run any resolvers
-  const resolveComponentData = getState().resolveComponentData;
-  const resolved = await resolveComponentData(itemData, "insert");
-  if (!resolved.didChange) return;
-
-  // Use latest position, in case it has moved
-  const latestItemSelector = getSelectorForId(getState().state, id);
-  if (!latestItemSelector) return;
-
-  dispatch({
-    type: "replace",
-    destinationZone: latestItemSelector.zone,
-    destinationIndex: latestItemSelector.index,
-    data: resolved.node,
-  });
+  await resolveAndReplaceData(itemData, getState, "insert");
 };

--- a/packages/core/lib/move-component.ts
+++ b/packages/core/lib/move-component.ts
@@ -1,6 +1,7 @@
 import { useAppStoreApi } from "../store";
+
 import { ItemSelector } from "./data/get-item";
-import { getSelectorForId } from "./get-selector-for-id";
+import { resolveAndReplaceData } from "./data/resolve-and-replace-data";
 import { rootDroppableId } from "./root-droppable-id";
 
 /**
@@ -30,21 +31,5 @@ export const moveComponent = async (
   const componentData = appStore.getState().state.indexes.nodes[id]?.data;
   if (!componentData) return;
 
-  const resolveComponentData = appStore.getState().resolveComponentData;
-  const resolvedData = await resolveComponentData(componentData, "move");
-
-  // Use latest position, in case it has moved
-  const latestItemSelector = getSelectorForId(
-    appStore.getState().state,
-    componentData.props.id
-  );
-  if (!latestItemSelector) return;
-
-  if (resolvedData.didChange)
-    dispatch({
-      type: "replace",
-      data: resolvedData.node,
-      destinationIndex: latestItemSelector.index,
-      destinationZone: latestItemSelector.zone ?? rootDroppableId,
-    });
+  await resolveAndReplaceData(componentData, appStore.getState, "move");
 };


### PR DESCRIPTION
Closes #1756 

## Description

This PR makes sure to use the latest position of a component while editing them inline.

It also adds a small set of refactors for consistency across resolving behavior.

## Changes made

- Inline fields now use `resolveAndReplaceData` so that they use the latest component position after resolving.
- `moveComponent` and `insertComponent` now use `resolveAndReplaceData` for consistency.
- `resolveAndReplaceData` now receives an optional `ui` object (to be passed through to the dispatcher), and a `writeThrough` prop to bypass the `didChanged` flag.
