### PR TITLE
fix: don't call generate-id at module import time

### DIFF
--- a/packages/core/__tests__/edge-runtime.spec.ts
+++ b/packages/core/__tests__/edge-runtime.spec.ts
@@ -1,0 +1,25 @@
+/** Tests package import side effects */
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserverMock;
+
+describe("store edge runtime safety", () => {
+  it("does not call generateId at package import time", async () => {
+    jest.mock("../lib/generate-id", () => ({
+      generateId: jest.fn(() => {
+        return "test-id";
+      }),
+    }));
+
+    const { generateId } = await import("../lib/generate-id");
+
+    // The package import must NOT call generateId() because it uses crypto.randomUUID()
+    // under the hood, which is not available in edge runtimes.
+    await import("../index");
+
+    expect(generateId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/components/Puck/__tests__/index.tsx
+++ b/packages/core/components/Puck/__tests__/index.tsx
@@ -87,7 +87,7 @@ describe("Puck", () => {
   const componentBRender = jest.fn(() => null);
   const rootRender = jest.fn(() => null);
 
-  const config: Config = {
+  const config: Config<{}> = {
     root: {
       render: ({ children }) => {
         rootRender();
@@ -147,6 +147,24 @@ describe("Puck", () => {
     const { appStore } = getInternal();
 
     expect(appStore.getState()).toMatchSnapshot();
+  });
+
+  it("creates a new store every time it is mounted", async () => {
+    const { container } = render(
+      <>
+        <Puck config={config} data={{}} iframe={{ enabled: false }} />
+        <Puck config={config} data={{}} iframe={{ enabled: false }} />
+      </>
+    );
+
+    await flush();
+
+    const ids = Array.from(container.querySelectorAll("div.Puck"))
+      .map((el) => el.id)
+      .filter(Boolean);
+
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
   });
 
   it("applies min-content height to a plugin selected on mount", async () => {

--- a/packages/core/store/index.ts
+++ b/packages/core/store/index.ts
@@ -21,7 +21,7 @@ import { createReducer, PuckAction } from "../reducer";
 import { getItem } from "../lib/data/get-item";
 import { defaultViewports } from "../components/ViewportControls/default-viewports";
 import { Viewports } from "../types";
-import { create, StoreApi, useStore } from "zustand";
+import { create, useStore } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { createContext, useContext } from "react";
 import { createHistorySlice, type HistorySlice } from "./slices/history";
@@ -105,8 +105,6 @@ export type AppStore<
     id: string;
   } | null;
 };
-
-export type AppStoreApi = StoreApi<AppStore>;
 
 const defaultPageFields: Record<string, Field> = {
   title: { type: "text" },
@@ -357,14 +355,31 @@ export const createAppStore = (initialAppStore?: Partial<AppStore>) =>
     }))
   );
 
-export const appStoreContext = createContext(createAppStore());
+// Derived from createAppStore so it keeps the zustand middleware augmentations
+// (e.g. subscribeWithSelector's two-argument subscribe overload).
+export type AppStoreApi = ReturnType<typeof createAppStore>;
+
+export const appStoreContext = createContext<AppStoreApi | null>(null);
+
+// Fallback store used only when a component reads the store outside of a <Puck> provider (e.g. <Render> for SSR).
+// Created lazily instead of at module scope so that importing @puckeditor/core has no side effects that might
+// be unsupported in edge runtimes
+let defaultAppStore: AppStoreApi | null = null;
+
+const getDefaultAppStore = (): AppStoreApi => {
+  if (!defaultAppStore) {
+    defaultAppStore = createAppStore();
+  }
+
+  return defaultAppStore;
+};
 
 export function useAppStore<T>(selector: (state: AppStore) => T) {
-  const context = useContext(appStoreContext);
+  const context = useContext(appStoreContext) ?? getDefaultAppStore();
 
   return useStore(context, selector);
 }
 
 export function useAppStoreApi() {
-  return useContext(appStoreContext);
+  return useContext(appStoreContext) ?? getDefaultAppStore();
 }


### PR DESCRIPTION
Closes puckeditor/puck#1602

## Description

This PR fixes an issue where importing from `@puckeditor/core` would break in Cloudflare Workers and other edge runtimes.

The problem was that we were calling `createAppStore` at the module level. This invoked `generateId`, which then invoked `uuid` and used `crypto.getRandomValues`, which is not supported in edge runtimes. This is fine for the editor, but it is a problem when rendering at the edge.

## Changes made

* The `appStore` context is now initialized with a null value and lazily initialized when needed.
  * Previously, we always initialized it with a default store, but that called `generateId`, which triggered the chain described above. In the editor (`Puck`), the `appStoreContext` is initialized before being provided to the children at render time, so this change does not affect it. In `Render`, it is not provided and should never be used in the first place, so this change does not affect it either.