### PR TITLE
feat: support user defined component labels by istance

### DIFF
--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -38,6 +38,7 @@ import { LoadedRichTextMenu } from "../RichTextMenu";
 import type { NodeHandle } from "../../store/slices/nodes";
 import { assignRefs } from "../../lib/assign-refs";
 import { useMessage } from "../../lib/use-message";
+import { InlineLabelEdit } from "../InlineLabelEdit";
 
 const getClassName = getClassNameFactory("DraggableComponent", styles);
 
@@ -51,22 +52,26 @@ const actionsTop = -(actionsOverlayTop - 8);
 const actionsSide = space;
 
 const DefaultActionBar = ({
-  label,
+  id,
   children,
   parentAction,
 }: {
-  label: string | undefined;
+  id: string;
   children: ReactNode;
   parentAction: ReactNode;
-}) => (
-  <ActionBar>
-    <ActionBar.Group>
-      {parentAction}
-      {label && <ActionBar.Label label={label} />}
-    </ActionBar.Group>
-    <ActionBar.Group>{children}</ActionBar.Group>
-  </ActionBar>
-);
+}) => {
+  return (
+    <ActionBar>
+      <ActionBar.Group>
+        {parentAction}
+        <InlineLabelEdit componentId={id}>
+          {({ label }) => <ActionBar.Label label={label} />}
+        </InlineLabelEdit>
+      </ActionBar.Group>
+      <ActionBar.Group>{children}</ActionBar.Group>
+    </ActionBar>
+  );
+};
 
 const DefaultOverlay = ({
   children,
@@ -788,6 +793,7 @@ export const DraggableComponent = ({
                 ref={actionBarRef}
               >
                 <CustomActionBar
+                  id={id}
                   parentAction={parentAction}
                   label={DEBUG ? id : label}
                 >

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -56,6 +56,7 @@ import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
 import { MemoizeComponent } from "../MemoizeComponent";
 import { VirtualizedDropZone } from "./VirtualizedDropZone";
+import { getComponentLabel } from "../../lib/data/get-component-label";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -134,6 +135,10 @@ const DropZoneChild = ({
     useShallow((s) => s.state.indexes.nodes[componentId]?.data.readOnly)
   );
 
+  const nodePuckMetadata = useAppStore(
+    useShallow((s) => s.state.indexes.nodes[componentId]?.data.__puck)
+  );
+
   const appStore = useAppStoreApi();
 
   const item = useMemo(() => {
@@ -141,6 +146,7 @@ const DropZoneChild = ({
       const expanded = expandNode({
         type: nodeType,
         props: nodeProps,
+        ...(nodePuckMetadata ? { __puck: nodePuckMetadata } : {}),
       }) as ComponentData;
 
       return expanded;
@@ -158,7 +164,14 @@ const DropZoneChild = ({
     }
 
     return null;
-  }, [appStore, componentId, zoneCompound, nodeType, nodeProps]);
+  }, [
+    appStore,
+    componentId,
+    zoneCompound,
+    nodeType,
+    nodeProps,
+    nodePuckMetadata,
+  ]);
 
   const componentConfig = useAppStore((s) =>
     item?.type ? s.config.components[item.type] : null
@@ -187,7 +200,9 @@ const DropZoneChild = ({
     type: item?.type?.toString() ?? "",
   });
 
-  let label = componentConfig?.label ?? item?.type.toString() ?? componentLabel;
+  const config = useAppStore((s) => s.config);
+
+  const label = item ? getComponentLabel(item, config) : componentLabel;
 
   const defaultsProps = useMemo(
     () => ({
@@ -203,8 +218,6 @@ const DropZoneChild = ({
     () => ({ type: item?.type ?? nodeType, props: defaultsProps }),
     [item?.type, nodeType, defaultsProps]
   );
-
-  const config = useAppStore((s) => s.config);
 
   const plugins = useAppStore((s) => s.plugins);
   const userFieldTransforms = useAppStore((s) => s.fieldTransforms);

--- a/packages/core/components/InlineLabelEdit/index.tsx
+++ b/packages/core/components/InlineLabelEdit/index.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import styles from "./styles.module.css";
+import { getClassNameFactory } from "../../lib";
+import { useAppStore } from "../../store";
+import { getComponentLabel } from "../../lib/data/get-component-label";
+import { useMessage } from "../../lib/use-message";
+
+const getClassName = getClassNameFactory("InlineLabelEdit", styles);
+
+/**
+ * Component label editor that reads from the Puck store and dispatches
+ * `setComponentLabel` automatically.
+ *
+ * When `componentId` is omitted or the node is not found nothing is rendered.
+ *
+ * Usage:
+ * ```tsx
+ * <!-- Default rendering (label as plain text) -->
+ * <InlineLabelEdit componentId={id} />
+ *
+ * <!-- Custom rendering via render-prop -->
+ * <InlineLabelEdit componentId={id}>
+ *   {({ label }) => <ActionBar.Label label={label} />}
+ * </InlineLabelEdit>
+ * ```
+ */
+export const InlineLabelEdit = ({
+  componentId,
+  children,
+}: {
+  componentId?: string;
+  children?: (params: { label: string }) => ReactNode;
+}) => {
+  const nodeData = useAppStore((s) =>
+    componentId ? s.state.indexes.nodes[componentId]?.data : undefined
+  );
+  const config = useAppStore((s) => s.config);
+  const dispatch = useAppStore((s) => s.dispatch);
+  const label =
+    nodeData && "type" in nodeData ? getComponentLabel(nodeData, config) : "";
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(label);
+  const renameMsg = useMessage("label-rename");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const saveLabel = useCallback(() => {
+    const trimmed = editValue.trim();
+
+    if (componentId) {
+      dispatch({
+        type: "setComponentLabel",
+        id: componentId,
+        label: trimmed || undefined,
+      });
+    }
+
+    setIsEditing(false);
+  }, [editValue, componentId, dispatch]);
+
+  const cancelEdit = useCallback(() => {
+    setEditValue(label);
+    setIsEditing(false);
+  }, [label]);
+
+  const startEditing = useCallback(() => {
+    setEditValue(label);
+    setIsEditing(true);
+  }, [label]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  if (!componentId || !nodeData || !("type" in nodeData)) return null;
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        className={getClassName("input")}
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onBlur={saveLabel}
+        onKeyDown={(e) => {
+          // Stop propagation so global hotkeys (e.g. Backspace → delete
+          // component) don't fire while the user is editing a label.
+          e.stopPropagation();
+
+          if (e.key === "Enter") {
+            saveLabel();
+          } else if (e.key === "Escape") {
+            cancelEdit();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <span
+      onDoubleClick={startEditing}
+      title={renameMsg}
+      className={getClassName("label")}
+    >
+      {typeof children === "function" ? children({ label }) : label}
+    </span>
+  );
+};

--- a/packages/core/components/InlineLabelEdit/styles.module.css
+++ b/packages/core/components/InlineLabelEdit/styles.module.css
@@ -1,0 +1,21 @@
+.InlineLabelEdit-label {
+  cursor: pointer;
+}
+
+.InlineLabelEdit-input {
+  background: none;
+  border: none;
+  outline: none;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+  border-bottom: 1px solid var(--puck-color-border);
+  width: 100%;
+  min-width: 0;
+}
+
+.InlineLabelEdit-input:focus {
+  border-bottom-color: var(--puck-color-focus-ring);
+  border-bottom-width: 2px;
+}

--- a/packages/core/components/LayerTree/components/layer/index.tsx
+++ b/packages/core/components/LayerTree/components/layer/index.tsx
@@ -18,6 +18,7 @@ import { DropLine } from "../drop-line";
 import { LayerActions } from "../layer-actions";
 import { LayerTreeZone } from "../layer-tree-zone";
 import { useMessage } from "../../../../lib/use-message";
+import { InlineLabelEdit } from "../../../InlineLabelEdit";
 
 const getClassName = getClassNameFactory("Layer", styles);
 
@@ -193,7 +194,9 @@ export const Layer = forwardRef(function Layer(
                   <LayoutGrid />
                 )}
               </div>
-              <div className={getClassName("name")}>{node.label}</div>
+              <div className={getClassName("name")}>
+                <InlineLabelEdit componentId={node.itemId} />
+              </div>
             </div>
           </button>
           <LayerActions node={node} visible={isHovering && !isDragSource} />

--- a/packages/core/components/LayerTree/lib/build-layer-tree.ts
+++ b/packages/core/components/LayerTree/lib/build-layer-tree.ts
@@ -1,6 +1,7 @@
 import { Config } from "../../../types";
 import { NodeIndex, ZoneIndex } from "../../../types/Internal";
 import { getSlotField } from "../../../lib/data/get-slot-field";
+import { getNodeLabel } from "../../../lib/data/get-component-label";
 import { LayerNode, LayerZone } from "../types";
 
 const getZonesByParent = (zones: ZoneIndex): Record<string, string[]> => {
@@ -60,7 +61,7 @@ const buildLayerNode = ({
   const nodeData = nodes[itemId];
   const componentType =
     nodeData?.data.type?.toString() ?? componentFallbackLabel;
-  const label = config.components[componentType]?.label ?? componentType;
+  const label = getNodeLabel(nodeData, config, componentFallbackLabel);
   const childZoneCompounds = zonesByParent[itemId] || [];
 
   return {

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -34,6 +34,7 @@ import { blocksPlugin } from "../../../../plugins/blocks";
 import { outlinePlugin } from "../../../../plugins/outline";
 import { fieldsPlugin } from "../../../../plugins/fields";
 import { normalizeIframeConfig } from "../../../../lib/style-config";
+import { getComponentLabel } from "../../../../lib/data/get-component-label";
 
 const getClassName = getClassNameFactory("Puck", styles);
 const getLayoutClassName = getClassNameFactory("PuckLayout", styles);
@@ -45,8 +46,7 @@ const FieldSideBar = () => {
   const pageLabel = useMessage("label-page");
   const title = useAppStore((s) =>
     s.selectedItem
-      ? s.config.components[s.selectedItem.type]?.["label"] ??
-        s.selectedItem.type.toString()
+      ? getComponentLabel(s.selectedItem, s.config)
       : s.config.root?.label
   );
 

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -31,13 +31,19 @@ export const SidebarSection = ({
         <div className={getClassName("breadcrumbs")}>
           {showBreadcrumbs && <Breadcrumbs />}
           <div className={getClassName("heading")}>
-            <InlineLabelEdit componentId={selectedItem?.props.id}>
-              {({ label }) => (
-                <Heading rank="2" size="xs">
-                  {label}
-                </Heading>
-              )}
-            </InlineLabelEdit>
+            {selectedItem?.props.id ? (
+              <InlineLabelEdit componentId={selectedItem.props.id}>
+                {({ label }) => (
+                  <Heading rank="2" size="xs">
+                    {label}
+                  </Heading>
+                )}
+              </InlineLabelEdit>
+            ) : (
+              <Heading rank="2" size="xs">
+                {title}
+              </Heading>
+            )}
           </div>
         </div>
       </div>

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -4,6 +4,8 @@ import getClassNameFactory from "../../lib/get-class-name-factory";
 import { Heading } from "../Heading";
 import { Loader } from "../Loader";
 import { Breadcrumbs } from "../Breadcrumbs";
+import { InlineLabelEdit } from "../InlineLabelEdit";
+import { useAppStore } from "../../store";
 
 const getClassName = getClassNameFactory("SidebarSection", styles);
 
@@ -22,15 +24,20 @@ export const SidebarSection = ({
   noBorderTop?: boolean;
   isLoading?: boolean | null;
 }) => {
+  const selectedItem = useAppStore((s) => s.selectedItem);
   return (
     <div className={getClassName({ noBorderTop })} style={{ background }}>
       <div className={getClassName("title")}>
         <div className={getClassName("breadcrumbs")}>
           {showBreadcrumbs && <Breadcrumbs />}
           <div className={getClassName("heading")}>
-            <Heading rank="2" size="xs">
-              {title}
-            </Heading>
+            <InlineLabelEdit componentId={selectedItem?.props.id}>
+              {({ label }) => (
+                <Heading rank="2" size="xs">
+                  {label}
+                </Heading>
+              )}
+            </InlineLabelEdit>
           </div>
         </div>
       </div>

--- a/packages/core/components/SidebarSection/index.tsx
+++ b/packages/core/components/SidebarSection/index.tsx
@@ -31,19 +31,13 @@ export const SidebarSection = ({
         <div className={getClassName("breadcrumbs")}>
           {showBreadcrumbs && <Breadcrumbs />}
           <div className={getClassName("heading")}>
-            {selectedItem?.props.id ? (
-              <InlineLabelEdit componentId={selectedItem.props.id}>
-                {({ label }) => (
-                  <Heading rank="2" size="xs">
-                    {label}
-                  </Heading>
-                )}
-              </InlineLabelEdit>
-            ) : (
-              <Heading rank="2" size="xs">
-                {title}
-              </Heading>
-            )}
+            <Heading rank="2" size="xs">
+              {selectedItem?.props.id ? (
+                <InlineLabelEdit componentId={selectedItem.props.id} />
+              ) : (
+                title
+              )}
+            </Heading>
           </div>
         </div>
       </div>

--- a/packages/core/lib/data/get-component-label.ts
+++ b/packages/core/lib/data/get-component-label.ts
@@ -1,0 +1,34 @@
+import { Config, ComponentData } from "../../types";
+import { PuckNodeData } from "../../types/Internal";
+
+/**
+ * Resolves the display label for a component instance.
+ *
+ * Priority:
+ * 1. `__puck.label` — user-set custom label on the instance
+ * 2. `config.components[type].label` — developer-defined label for the component type
+ * 3. `type.toString()` — raw component type string as fallback
+ */
+export const getComponentLabel = (
+  item: Pick<ComponentData, '__puck' | 'type'>,
+  config: Config,
+  fallback?: string
+): string => {
+  const type = item.type.toString();
+  return (
+    item.__puck?.label ?? config.components[type]?.label ?? type ?? fallback
+  );
+};
+
+/**
+ * Same as getComponentLabel but accepts a node from the store index
+ * (where data is the ComponentData).
+ */
+export const getNodeLabel = (
+  node: PuckNodeData,
+  config: Config,
+  fallback?: string
+): string => {
+  if (!node.data) return fallback ?? "Component";
+  return getComponentLabel(node.data, config, fallback);
+};

--- a/packages/core/lib/data/get-component-label.ts
+++ b/packages/core/lib/data/get-component-label.ts
@@ -10,7 +10,7 @@ import { PuckNodeData } from "../../types/Internal";
  * 3. `type.toString()` — raw component type string as fallback
  */
 export const getComponentLabel = (
-  item: Pick<ComponentData, '__puck' | 'type'>,
+  item: Pick<ComponentData, "__puck" | "type">,
   config: Config,
   fallback?: string
 ): string => {

--- a/packages/core/lib/dictionary.ts
+++ b/packages/core/lib/dictionary.ts
@@ -19,6 +19,7 @@ export const defaultDictionary = {
   "action-delete": "Delete",
   // Fallback labels — shared by the breadcrumbs, fields panel and header
   "label-page": "Page",
+  "label-rename": "Rename",
   "label-component": "Component",
   // Outline
   "outline-empty": "No items",

--- a/packages/core/lib/use-breadcrumbs.ts
+++ b/packages/core/lib/use-breadcrumbs.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useAppStore, useAppStoreApi } from "../store";
 import { useMessage } from "./use-message";
+import { getNodeLabel } from "./data/get-component-label";
 import { ItemSelector } from "./data/get-item";
 
 export type Breadcrumb = {
@@ -36,9 +37,7 @@ export const useBreadcrumbs = (renderCount?: number) => {
           appStore.getState().state.indexes.zones[parentId]?.contentIds || [];
         const index = contentIds.indexOf(componentId);
 
-        const label = node
-          ? config.components[node.data.type]?.label ?? node.data.type
-          : componentLabel;
+        const label = getNodeLabel(node, config, componentLabel);
 
         return {
           label,

--- a/packages/core/plugins/fields/index.tsx
+++ b/packages/core/plugins/fields/index.tsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from "../../components/Breadcrumbs";
 import { Fields } from "../../components/Puck/components/Fields";
 import styles from "./styles.module.css";
 import { getClassNameFactory } from "../../lib";
+import { getComponentLabel } from "../../lib/data/get-component-label";
 
 const getClassName = getClassNameFactory("FieldsPlugin", styles);
 
@@ -15,9 +16,7 @@ const CurrentTitle = () => {
   const label = useAppStore((s) => {
     const selectedItem = s.selectedItem;
 
-    return selectedItem
-      ? s.config.components[selectedItem.type]?.label ?? selectedItem.type
-      : null;
+    return selectedItem ? getComponentLabel(selectedItem, s.config) : null;
   });
 
   return label ?? pageLabel;

--- a/packages/core/reducer/actions.tsx
+++ b/packages/core/reducer/actions.tsx
@@ -74,6 +74,12 @@ export type RegisterZoneAction = {
   zone: string;
 };
 
+export type SetComponentLabelAction = {
+  type: "setComponentLabel";
+  id: string;
+  label: string | undefined;
+};
+
 export type UnregisterZoneAction = {
   type: "unregisterZone";
   zone: string;
@@ -92,4 +98,5 @@ export type PuckAction = { recordHistory?: boolean } & (
   | SetUiAction
   | RegisterZoneAction
   | UnregisterZoneAction
+  | SetComponentLabelAction
 );

--- a/packages/core/reducer/actions/set-component-label.ts
+++ b/packages/core/reducer/actions/set-component-label.ts
@@ -14,7 +14,7 @@ export const setComponentLabelAction = <UserData extends Data>(
 
     const type = item.type.toString();
     const defaultLabel = appStore.config.components[type]?.label ?? type;
-    const newLabel = action.label || undefined;
+    const newLabel = action.label?.trim() || undefined;
 
     // If the new label matches the default, remove the custom override
     if (!newLabel || newLabel === defaultLabel) {

--- a/packages/core/reducer/actions/set-component-label.ts
+++ b/packages/core/reducer/actions/set-component-label.ts
@@ -1,0 +1,44 @@
+import { Data } from "../../types";
+import { SetComponentLabelAction } from "../actions";
+import { PrivateAppState } from "../../types/Internal";
+import { walkAppState } from "../../lib/data/walk-app-state";
+import { AppStore } from "../../store";
+
+export const setComponentLabelAction = <UserData extends Data>(
+  state: PrivateAppState<UserData>,
+  action: SetComponentLabelAction,
+  appStore: AppStore
+): PrivateAppState<UserData> => {
+  return walkAppState(state, appStore.config, undefined, (item) => {
+    if (item.props.id !== action.id) return item;
+
+    const type = item.type.toString();
+    const defaultLabel = appStore.config.components[type]?.label ?? type;
+    const newLabel = action.label || undefined;
+
+    // If the new label matches the default, remove the custom override
+    if (!newLabel || newLabel === defaultLabel) {
+      // Remove __puck.label
+      const { label: _removed, ...restPuck } = item.__puck ?? {};
+      const hasAnyPuckProp = Object.keys(restPuck).length > 0;
+
+      if (hasAnyPuckProp) {
+        // Keep __puck but without the label property
+        return { ...item, __puck: restPuck };
+      }
+
+      // __puck is empty — remove it entirely
+      const { __puck: _removedPuck, ...itemWithoutPuck } = item;
+      return itemWithoutPuck;
+    }
+
+    // Custom label differs from default — store it
+    return {
+      ...item,
+      __puck: {
+        ...item.__puck,
+        label: newLabel,
+      },
+    };
+  });
+};

--- a/packages/core/reducer/index.ts
+++ b/packages/core/reducer/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./actions/register-zone";
 import { setDataAction } from "./actions/set-data";
 import { setUiAction } from "./actions/set-ui";
+import { setComponentLabelAction } from "./actions/set-component-label";
 import { makeStatePublic } from "../lib/data/make-state-public";
 
 export * from "./actions";
@@ -119,6 +120,10 @@ export function createReducer<UserData extends Data>({
 
       if (action.type === "setUi") {
         return setUiAction(state, action);
+      }
+
+      if (action.type === "setComponentLabel") {
+        return setComponentLabelAction(state, action, appStore);
       }
 
       return state;

--- a/packages/core/types/Data.tsx
+++ b/packages/core/types/Data.tsx
@@ -7,6 +7,11 @@ export type BaseData<
   Props extends { [key: string]: any } = { [key: string]: any }
 > = {
   readOnly?: Partial<Record<keyof Props, boolean>>;
+  /** Per-instance metadata. The __puck property is removed from all components in the tree when passing data down to the Render component, before the components are actually rendered. This avoids polluting data sent to user pages when doing SSR. */
+  __puck?: {
+    /** User-set custom label for this component instance. */
+    label?: string;
+  };
 };
 
 export type RootDataWithProps<


### PR DESCRIPTION
Closes #1752

## Description
This PR adds per-instance custom labels for Puck components. Users can now rename individual component instances directly from the UI — the sidebar, the canvas action bar, and the outline panel — with the label persisting in the component data via a `__puck.label` field.

A new `InlineLabelEdit` component centralizes the label editing logic (read store, resolve label, dispatch updates), and a `getComponentLabel` utility provides a consistent resolution priority: `__puck.label → config.components[type].label → type.toString()`.


## Changes made
Core: label storage & resolution
- Added `__puck?: { label?: string }` to `BaseData` in `Data.tsx` — per-instance metadata stored outside props so it never leaks to rendered output
- Created `lib/data/get-component-label.ts` with `getComponentLabel(item, config, fallback)` — resolves label with priority `__puck.label → component config label → type string` — and `getNodeLabel(node, config, fallback)` for the store index node format
- Implemented `setComponentLabel` reducer action — stores the custom label in `__puck.label`, and auto-strips it when the label matches the type default or is empty

New shared component: `InlineLabelEdit`
- Reads component data from the Puck store via `componentId` prop and resolves the label internally with `getComponentLabel`
- Double-click on it to start editing label
- Dispatches `setComponentLabel` automatically on save
- Optional render-prop `children({ label })` for custom display; defaults to plain text when omitted
- Styled with a minimal inline input (underline on focus)

UI integration
- `SidebarSection` — when a component is selected, the breadcrumb heading title becomes editable via `InlineLabelEdit`
- `DraggableComponent` (DefaultActionBar) — the action bar label uses `InlineLabelEdit` with a render-prop for ActionBar.Label
- `LayerTree/layer` — the outline panel shows the editable label via `InlineLabelEdit`
- Fields plugin — `CurrentTitle` now respects `__puck.label`

## How to test
1. Open any Puck editor with a component on the canvas
2. Double-click the component's title in the right sidebar (or the action bar, or the outline) and type a custom label, then press Enter
3. Confirm the custom label appears in:
- The right sidebar breadcrumb
- The canvas action bar
- The outline panel
4. Reset the label to the default value (the component type name) and confirm __puck is stripped from the data
5. Verify __puck does not appear in the rendered output (SSR safety — it lives on ComponentData, not inside props)

## Note
Tests and documentation will be added when you think the implementation is ready to be approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline renaming for components, layers, and sidebar sections.
  * Double-click labels to edit them; press Enter or click away to save, or Escape to cancel.
  * Custom labels now appear consistently across breadcrumbs, sidebars, layer trees, and component titles.
  * Labels automatically fall back to configured names or component types when no custom label is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->