### PR TITLE
fix: respect plugin mobilePanelHeight on first load

### DIFF
--- a/packages/core/components/Puck/__tests__/index.tsx
+++ b/packages/core/components/Puck/__tests__/index.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { Config } from "../../../types";
+import { Config, Plugin } from "../../../types";
 import "@testing-library/jest-dom";
 import {
   PUCK_STYLE_ID_ATTRIBUTE,
@@ -147,6 +147,40 @@ describe("Puck", () => {
     const { appStore } = getInternal();
 
     expect(appStore.getState()).toMatchSnapshot();
+  });
+
+  it("applies min-content height to a plugin selected on mount", async () => {
+    const previousMatchMedia = window.matchMedia;
+
+    window.matchMedia = jest.fn((query: string) => ({
+      ...previousMatchMedia(query),
+      matches: true,
+    }));
+
+    const plugin: Plugin = {
+      name: "custom",
+      render: () => <div>Custom plugin</div>,
+      mobilePanelHeight: "min-content",
+    };
+
+    try {
+      render(
+        <Puck
+          config={config}
+          data={{}}
+          iframe={{ enabled: false }}
+          plugins={[plugin]}
+          ui={{ plugin: { current: "custom" } }}
+        />
+      );
+
+      await flush();
+
+      expect(screen.getByText("Custom plugin")).toBeInTheDocument();
+      expect(screen.queryByTitle("maximize")).not.toBeInTheDocument();
+    } finally {
+      window.matchMedia = previousMatchMedia;
+    }
   });
 
   it("should index slots on mount", async () => {

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -185,10 +185,6 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
   const currentPlugin = useAppStore((s) => s.state.ui.plugin?.current);
   const appStoreApi = useAppStoreApi();
 
-  const [mobilePanelHeightMode, setMobilePanelHeightMode] = useState<
-    "toggle" | "min-content"
-  >("toggle");
-
   const hasLegacySideBarPlugin = useMemo(
     () => !!plugins?.find((p) => p.name === "legacy-side-bar"),
     [plugins]
@@ -200,8 +196,13 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
   const fieldsLabel = useMessage("plugin-fields");
 
   const pluginItems = useMemo(() => {
-    const details: Record<string, MenuItem & { render: () => ReactElement }> =
-      {};
+    const details: Record<
+      string,
+      MenuItem & {
+        render: () => ReactElement;
+        mobilePanelHeight: "toggle" | "min-content";
+      }
+    > = {};
 
     const defaultPlugins: PluginInternal[] = [
       blocksPlugin({ label: blocksLabel }),
@@ -233,8 +234,6 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
           label: plugin.label ?? plugin.name,
           icon: plugin.icon ?? <ToyBrick />,
           onClick: () => {
-            setMobilePanelHeightMode(plugin.mobilePanelHeight ?? "toggle");
-
             if (plugin.name === currentPlugin) {
               if (leftSideBarVisible) {
                 setUi({ leftSideBarVisible: false });
@@ -252,6 +251,7 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
           },
           isActive: leftSideBarVisible && currentPlugin === plugin.name,
           render: plugin.render,
+          mobilePanelHeight: plugin.mobilePanelHeight ?? "toggle",
           mobileOnly: hasLegacySideBarPlugin || plugin.mobileOnly,
           desktopOnly: plugin.name === "legacy-side-bar" || plugin.desktopOnly,
         };
@@ -268,6 +268,10 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
     outlineLabel,
     fieldsLabel,
   ]);
+
+  const activePlugin = currentPlugin ?? Object.keys(pluginItems)[0];
+  const mobilePanelHeightMode =
+    pluginItems[activePlugin]?.mobilePanelHeight ?? "toggle";
 
   useEffect(() => {
     if (!currentPlugin) {


### PR DESCRIPTION
The `mobilePanelHeight` parameter is not respected on the first mounted plugin until it re-renders by switching to another plugin and back.