### PR TITLE
feat: add optional drag handle to component action bar

### DIFF
--- a/apps/docs/pages/docs/api-reference/components.mdx
+++ b/apps/docs/pages/docs/api-reference/components.mdx
@@ -20,6 +20,7 @@ Puck provides several components to support different integration approaches.
 
 - [\<ActionBar\>](components/action-bar) - An action bar containing a series of actions, normally used with the [actionBar override](/docs/api-reference/overrides/action-bar).
 - [\<ActionBar.Action\>](components/action-bar-action) - An action for use within the ActionBar component.
+- [\<ActionBar.DragHandle\>](components/action-bar-drag-handle) - A drag handle for use within the ActionBar component.
 - [\<ActionBar.Group\>](components/action-bar-group) - A group of actions for use within the ActionBar component.
 - [\<ActionBar.Label\>](components/action-bar-label) - A label for use within the ActionBar component.
 - [\<ActionBar.Separator\>](components/action-bar-separator) - A separator to divide elements in the ActionBar component.

--- a/apps/docs/pages/docs/api-reference/components/_meta.js
+++ b/apps/docs/pages/docs/api-reference/components/_meta.js
@@ -1,6 +1,7 @@
 const menu = {
   "action-bar": {},
   "action-bar-action": {},
+  "action-bar-drag-handle": {},
   "action-bar-group": {},
   "action-bar-label": {},
   "action-bar-separator": {},

--- a/apps/docs/pages/docs/api-reference/components/action-bar-drag-handle.mdx
+++ b/apps/docs/pages/docs/api-reference/components/action-bar-drag-handle.mdx
@@ -1,0 +1,50 @@
+---
+title: <ActionBar.DragHandle>
+---
+
+import { PuckPreview } from "@/docs/components/Preview";
+import { ActionBar } from "@/puck";
+
+# \<ActionBar.DragHandle\>
+
+Render a drag handle in the [`<ActionBar>`](action-bar). Used by the [actionBar override](/docs/api-reference/overrides/action-bar) when [`dnd.enableDragHandle`](/docs/api-reference/components/puck#enabledraghandle) is set.
+
+Dragging is driven by Puck's drag-and-drop sensors, so the handle must be registered via the [`ref`](#ref) provided by the [`dragHandle`](/docs/api-reference/overrides/action-bar#draghandle) prop. In most cases you should render that prop directly rather than using this component.
+
+```tsx showLineNumbers {2} copy
+<ActionBar>
+  <ActionBar.Group>{dragHandle}</ActionBar.Group>
+</ActionBar>
+```
+
+<PuckPreview>
+  <div style={{ display: "flex" }}>
+    <ActionBar>
+      <ActionBar.Group>
+        <ActionBar.DragHandle label="Drag to reorder" />
+      </ActionBar.Group>
+    </ActionBar>
+  </div>
+</PuckPreview>
+
+## Props
+
+| Prop                    | Example             | Type    | Status |
+| ----------------------- | ------------------- | ------- | ------ |
+| [`label`](#label)       | `"Drag to reorder"` | String  | -      |
+| [`disabled`](#disabled) | `true`              | Boolean | -      |
+| [`ref`](#ref)           | `dragHandleRef`     | Ref     | -      |
+
+## Optional Props
+
+### `label`
+
+A label to provide an accessible label for the handle. Defaults to the [`action-drag`](/docs/api-reference/dictionary) dictionary token when rendered by Puck.
+
+### `disabled`
+
+Prevent the handle from initiating a drag.
+
+### `ref`
+
+A [ref](https://react.dev/learn/manipulating-the-dom-with-refs) to the underlying `button`, used to register the handle with Puck's drag-and-drop sensors.

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -143,6 +143,7 @@ Configure drag-and-drop behavior.
 | ------------------------------------------- | -------------------------- | ------- | ------ |
 | [`disableAutoScroll`](#disableautoscroll)   | `disableAutoScroll: true`  | boolean | -      |
 | [`disableOutlineDrag`](#disableoutlinedrag) | `disableOutlineDrag: true` | boolean | -      |
+| [`enableDragHandle`](#enabledraghandle)     | `enableDragHandle: true`   | boolean | -      |
 
 ##### `disableAutoScroll`
 
@@ -151,6 +152,14 @@ Disable auto-scroll when the user drags an item near the edge of the preview are
 ##### `disableOutlineDrag`
 
 Disable drag-and-drop in the [outline](/docs/api-reference/components/puck-outline). Items can still be selected and expanded.
+
+##### `enableDragHandle`
+
+Show a drag handle in the component action bar. Dragging from the handle starts immediately, without the short press-and-hold delay required when dragging from the component itself.
+
+The component body remains draggable, so the handle adds a second place to start a drag rather than restricting drags to itself. The handle is hidden when the user doesn't have the `drag` [permission](/docs/api-reference/permissions).
+
+To change where the handle renders, use the [`dragHandle`](/docs/api-reference/overrides/action-bar#draghandle) prop of the [`actionBar` override](/docs/api-reference/overrides/action-bar).
 
 ### `fieldTransforms`
 

--- a/apps/docs/pages/docs/api-reference/dictionary.mdx
+++ b/apps/docs/pages/docs/api-reference/dictionary.mdx
@@ -46,11 +46,12 @@ Many tokens set an element's HTML `title` attribute, a tooltip that only appears
 
 ### Actions
 
-| Token                 | Default           | Used for                       |
-| --------------------- | ----------------- | ------------------------------ |
-| `action-selectparent` | `"Select parent"` | Component action bar (tooltip) |
-| `action-duplicate`    | `"Duplicate"`     | Component action bar (tooltip) |
-| `action-delete`       | `"Delete"`        | Component action bar (tooltip) |
+| Token                 | Default             | Used for                       |
+| --------------------- | ------------------- | ------------------------------ |
+| `action-selectparent` | `"Select parent"`   | Component action bar (tooltip) |
+| `action-drag`         | `"Drag to reorder"` | Component action bar (tooltip) |
+| `action-duplicate`    | `"Duplicate"`       | Component action bar (tooltip) |
+| `action-delete`       | `"Delete"`          | Component action bar (tooltip) |
 
 ### Labels
 

--- a/apps/docs/pages/docs/api-reference/overrides/action-bar.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/action-bar.mdx
@@ -23,12 +23,19 @@ const overrides = {
 | Prop                            | Example          | Type      |
 | ------------------------------- | ---------------- | --------- |
 | [`children`](#children)         | `<div />`        | ReactNode |
+| [`dragHandle`](#dragHandle)     | `<div />`        | ReactNode |
 | [`label`](#label)               | `"HeadingBlock"` | String    |
 | [`parentAction`](#parentAction) | `<div />`        | ReactNode |
 
 ### `children`
 
 A fragment containing the default [actions](/docs/api-reference/components/action-bar-action). This should normally be rendered inside an [`<ActionBar.Group>`](/docs/api-reference/components/action-bar-group).
+
+### `dragHandle`
+
+A pre-wired [`<ActionBar.DragHandle>`](/docs/api-reference/components/action-bar-drag-handle) to drag the current component.
+
+`undefined` unless [`dnd.enableDragHandle`](/docs/api-reference/components/puck#enabledraghandle) is set, or if the user doesn't have the `drag` [permission](/docs/api-reference/permissions).
 
 ### `label`
 

--- a/packages/core/components/ActionBar/__tests__/index.spec.tsx
+++ b/packages/core/components/ActionBar/__tests__/index.spec.tsx
@@ -1,0 +1,42 @@
+import { createRef } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ActionBar } from "../index";
+
+jest.mock("../styles.module.css");
+
+describe("ActionBar.DragHandle", () => {
+  it("renders a labelled button", () => {
+    render(<ActionBar.DragHandle label="Drag to reorder" />);
+
+    const handle = screen.getByRole("button", { name: "Drag to reorder" });
+    expect(handle).toBeInTheDocument();
+    expect(handle).toHaveAttribute("title", "Drag to reorder");
+  });
+
+  it("forwards its ref so callers can register a drag handle", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(<ActionBar.DragHandle label="Drag" ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it("can be disabled when the user lacks drag permission", () => {
+    render(<ActionBar.DragHandle label="Drag" disabled />);
+
+    expect(screen.getByRole("button", { name: "Drag" })).toBeDisabled();
+  });
+
+  it("stops click propagation so grabbing does not bubble to selection", () => {
+    const onParentClick = jest.fn();
+
+    render(
+      <div onClick={onParentClick}>
+        <ActionBar.DragHandle label="Drag" />
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Drag" }));
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/components/ActionBar/index.tsx
+++ b/packages/core/components/ActionBar/index.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, ReactNode, SyntheticEvent } from "react";
+import { GripVertical } from "lucide-react";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import styles from "./styles.module.css";
 const getClassName = getClassNameFactory("ActionBar", styles);
@@ -52,6 +53,29 @@ export const Action = forwardRef<
 
 Action.displayName = "Action";
 
+export const DragHandle = forwardRef<
+  HTMLButtonElement,
+  {
+    label?: string;
+    disabled?: boolean;
+  }
+>(({ label, disabled, ...rest }, ref) => (
+  <button
+    type="button"
+    {...rest}
+    ref={ref}
+    className={getActionClassName({ disabled, grab: !disabled })}
+    onClick={(e) => e.stopPropagation()}
+    title={label}
+    tabIndex={0}
+    disabled={disabled}
+  >
+    <GripVertical className={getActionClassName("icon")} />
+  </button>
+));
+
+DragHandle.displayName = "DragHandle";
+
 export const Group = ({ children }: { children: ReactNode }) => (
   <div className={getClassName("group")}>{children}</div>
 );
@@ -66,3 +90,4 @@ ActionBar.Action = Action;
 ActionBar.Label = Label;
 ActionBar.Group = Group;
 ActionBar.Separator = Separator;
+ActionBar.DragHandle = DragHandle;

--- a/packages/core/components/ActionBar/index.tsx
+++ b/packages/core/components/ActionBar/index.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, ReactNode, SyntheticEvent } from "react";
+import { GripVertical } from "lucide-react";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import styles from "./styles.module.css";
 const getClassName = getClassNameFactory("ActionBar", styles);
@@ -52,6 +53,31 @@ export const Action = forwardRef<
 
 Action.displayName = "Action";
 
+export const DragHandle = forwardRef<
+  HTMLButtonElement,
+  {
+    label?: string;
+    disabled?: boolean;
+  }
+>(({ label, disabled, ...rest }, ref) => (
+  <button
+    type="button"
+    {...rest}
+    ref={ref}
+    className={getActionClassName({ disabled, grab: !disabled })}
+    title={label}
+    aria-label={label}
+    tabIndex={0}
+    disabled={disabled}
+    // Drags are driven by the DnD sensor; stop clicks selecting the component.
+    onClick={(e) => e.stopPropagation()}
+  >
+    <GripVertical size={16} />
+  </button>
+));
+
+DragHandle.displayName = "DragHandle";
+
 export const Group = ({ children }: { children: ReactNode }) => (
   <div className={getClassName("group")}>{children}</div>
 );
@@ -66,3 +92,4 @@ ActionBar.Action = Action;
 ActionBar.Label = Label;
 ActionBar.Group = Group;
 ActionBar.Separator = Separator;
+ActionBar.DragHandle = DragHandle;

--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -80,6 +80,15 @@
   opacity: var(--puck-actionbar-opacity-action-disabled, 0.54);
 }
 
+.ActionBarAction--grab {
+  cursor: grab;
+  touch-action: none;
+}
+
+.ActionBarAction--grab:active {
+  cursor: grabbing;
+}
+
 .ActionBarAction svg {
   max-width: none !important; /* Explicit definition to prevent some SVG style pollution */
 }

--- a/packages/core/components/ActionBar/styles.module.css
+++ b/packages/core/components/ActionBar/styles.module.css
@@ -80,6 +80,20 @@
   opacity: var(--puck-actionbar-opacity-action-disabled, 0.54);
 }
 
+.ActionBarAction--grab {
+  cursor: grab;
+  touch-action: none;
+}
+
+.ActionBarAction--grab:active {
+  cursor: grabbing;
+}
+
+.ActionBarAction-icon {
+  height: var(--puck-actionbar-action-size, var(--puck-icon-size-s));
+  width: var(--puck-actionbar-action-size, var(--puck-icon-size-s));
+}
+
 .ActionBarAction svg {
   max-width: none !important; /* Explicit definition to prevent some SVG style pollution */
 }

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -307,7 +307,13 @@ const DragDropContextClient = ({
     ),
   ]);
 
-  const sensors = useSensors();
+  // Allow dragging from the component body or a registered handle (action bar).
+  const sensors = useSensors({
+    activatorElements: (source) =>
+      source.handle && source.handle !== source.element
+        ? [source.element, source.handle]
+        : [source.element],
+  });
 
   const [dragListeners, setDragListeners] = useState<DragCbs>({});
 

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -54,12 +54,15 @@ const DefaultActionBar = ({
   label,
   children,
   parentAction,
+  dragHandle,
 }: {
   label: string | undefined;
   children: ReactNode;
   parentAction: ReactNode;
+  dragHandle?: ReactNode;
 }) => (
   <ActionBar>
+    {dragHandle && <ActionBar.Group>{dragHandle}</ActionBar.Group>}
     <ActionBar.Group>
       {parentAction}
       {label && <ActionBar.Label label={label} />}
@@ -127,6 +130,7 @@ export const DraggableComponent = ({
     (s) => s._experimentalFullScreenCanvas
   );
   const overrides = useAppStore((s) => s.overrides);
+  const enableDragHandle = useAppStore((s) => s.dnd?.enableDragHandle ?? false);
   const dispatch = useAppStore((s) => s.dispatch);
   const iframe = useAppStore((s) => s.iframe);
   const lastMeasureRef = useRef(0);
@@ -190,6 +194,7 @@ export const DraggableComponent = ({
   const {
     ref: sortableRef,
     isDragging: thisIsDragging,
+    handleRef,
     sortable,
   } = useSortable<ComponentDndData>({
     id,
@@ -709,6 +714,7 @@ export const DraggableComponent = ({
   }, [ref, userDragAxis, autoDragAxis]);
 
   const selectParentLabel = useMessage("action-selectparent");
+  const dragLabel = useMessage("action-drag");
   const duplicateLabel = useMessage("action-duplicate");
   const deleteLabel = useMessage("action-delete");
 
@@ -721,6 +727,14 @@ export const DraggableComponent = ({
         </ActionBar.Action>
       ),
     [ctx?.areaId, selectParentLabel]
+  );
+
+  const dragHandle = useMemo(
+    () =>
+      enableDragHandle && permissions.drag ? (
+        <ActionBar.DragHandle ref={handleRef} label={dragLabel} />
+      ) : undefined,
+    [enableDragHandle, permissions.drag, handleRef, dragLabel]
   );
 
   const nextContextValue = useMemo<DropZoneContext>(
@@ -790,6 +804,7 @@ export const DraggableComponent = ({
                 <CustomActionBar
                   parentAction={parentAction}
                   label={DEBUG ? id : label}
+                  dragHandle={dragHandle}
                 >
                   {richText && (
                     <>

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -54,12 +54,15 @@ const DefaultActionBar = ({
   label,
   children,
   parentAction,
+  dragHandle,
 }: {
   label: string | undefined;
   children: ReactNode;
   parentAction: ReactNode;
+  dragHandle: ReactNode;
 }) => (
   <ActionBar>
+    {dragHandle && <ActionBar.Group>{dragHandle}</ActionBar.Group>}
     <ActionBar.Group>
       {parentAction}
       {label && <ActionBar.Label label={label} />}
@@ -127,6 +130,7 @@ export const DraggableComponent = ({
     (s) => s._experimentalFullScreenCanvas
   );
   const overrides = useAppStore((s) => s.overrides);
+  const enableDragHandle = useAppStore((s) => s.dnd?.enableDragHandle ?? false);
   const dispatch = useAppStore((s) => s.dispatch);
   const iframe = useAppStore((s) => s.iframe);
   const lastMeasureRef = useRef(0);
@@ -190,6 +194,7 @@ export const DraggableComponent = ({
   const {
     ref: sortableRef,
     isDragging: thisIsDragging,
+    handleRef,
     sortable,
   } = useSortable<ComponentDndData>({
     id,
@@ -709,6 +714,7 @@ export const DraggableComponent = ({
   }, [ref, userDragAxis, autoDragAxis]);
 
   const selectParentLabel = useMessage("action-selectparent");
+  const dragLabel = useMessage("action-drag");
   const duplicateLabel = useMessage("action-duplicate");
   const deleteLabel = useMessage("action-delete");
 
@@ -721,6 +727,14 @@ export const DraggableComponent = ({
         </ActionBar.Action>
       ),
     [ctx?.areaId, selectParentLabel]
+  );
+
+  const dragHandle = useMemo(
+    () =>
+      enableDragHandle && permissions.drag ? (
+        <ActionBar.DragHandle ref={handleRef} label={dragLabel} />
+      ) : undefined,
+    [enableDragHandle, permissions.drag, handleRef, dragLabel]
   );
 
   const nextContextValue = useMemo<DropZoneContext>(
@@ -790,6 +804,7 @@ export const DraggableComponent = ({
                 <CustomActionBar
                   parentAction={parentAction}
                   label={DEBUG ? id : label}
+                  dragHandle={dragHandle}
                 >
                   {richText && (
                     <>

--- a/packages/core/components/DraggableComponent/styles.module.css
+++ b/packages/core/components/DraggableComponent/styles.module.css
@@ -101,7 +101,7 @@
 .DraggableComponent-actions {
   position: absolute;
   width: auto;
-  cursor: grab;
+  cursor: default;
   display: flex;
   box-sizing: border-box;
   transform-origin: right top;

--- a/packages/core/lib/dictionary.ts
+++ b/packages/core/lib/dictionary.ts
@@ -15,6 +15,7 @@ export const defaultDictionary = {
   "header-toggle-menubar": "Toggle menu bar",
   // Component action bar
   "action-selectparent": "Select parent",
+  "action-drag": "Drag to reorder",
   "action-duplicate": "Duplicate",
   "action-delete": "Delete",
   // Fallback labels — shared by the breadcrumbs, fields panel and header

--- a/packages/core/lib/dnd/use-sensors.ts
+++ b/packages/core/lib/dnd/use-sensors.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { PointerSensor } from "@dnd-kit/react";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
+import type { PointerSensorOptions } from "@dnd-kit/dom";
 import { isElement } from "@dnd-kit/dom/utilities";
 import type { ActivationConstraint } from "@dnd-kit/abstract";
 
@@ -22,10 +23,13 @@ export const useSensors = (
     other = otherDefault,
     mouse,
     touch = touchDefault,
+    activatorElements,
   }: {
     mouse?: ActivationConstraints;
     touch?: ActivationConstraints;
     other?: ActivationConstraints;
+    // Elements that can start a drag. Defaults to the handle, or the element.
+    activatorElements?: PointerSensorOptions["activatorElements"];
   } = {
     touch: touchDefault,
     other: otherDefault,
@@ -33,6 +37,7 @@ export const useSensors = (
 ) => {
   const [sensors] = useState(() => [
     PointerSensor.configure({
+      activatorElements,
       activationConstraints(event, source) {
         const { pointerType, target } = event;
 

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -30,6 +30,7 @@ export type Overrides<UserConfig extends Config = Config> = OverridesGeneric<{
     label?: string;
     children: ReactNode;
     parentAction: ReactNode;
+    dragHandle?: ReactNode;
   }>;
   headerActions: RenderFunc<{ children: ReactNode }>;
   preview: RenderFunc;

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -25,6 +25,7 @@ export type IframeConfig = {
 export type DndConfig = {
   disableAutoScroll?: boolean;
   disableOutlineDrag?: boolean;
+  enableDragHandle?: boolean;
 };
 
 export type OnAction<UserData extends Data = Data> = (


### PR DESCRIPTION
Closes #1477

 ## Description

This PR adds an opt-in **drag handle** to a component's action bar. This is especially useful for slots that wrap tightly around nested content and are awkward to grab directly (#1477).

The handle is **off by default** and enabled via the existing `dnd` prop: `<Puck dnd={{ enableDragHandle: true }} />`.

Following the consideration in the issue, the handle is exposed to custom action bars as an additional `dragHandle` prop on the`actionBar` override — mirroring how `parentAction` (select parent) is passed — so consumers who override the action bar can place or omit it.

 **Non-breaking:** whole-component-body dragging still works exactly as before. 

<img width="465" height="296" alt="Screenshot 2026-07-29 at 3 06 28 PM" src="https://github.com/user-attachments/assets/b6cc5541-0571-4212-9147-bbafeb72210e" />


 ## Changes made
- `dnd.enableDragHandle` — new opt-in flag, default `false`.
- `ActionBar.DragHandle` — new export. A grip button that forwards its ref.
- `overrides.actionBar` — now gets an optional `dragHandle` prop. Existing overrides are unaffected.
- `DraggableComponent` — renders the handle at the start of the action bar when `enableDragHandle && permissions.drag`.
- `useSensors` / `DragDropContext` — register both the body and the handle as drag activators.
- Added the `action-drag` dictionary key (`"Drag to reorder"`), docs, and tests.

## Known behavior

The action bar (and therefore the handle) is unmounted while the component it belongs to is being dragged. This is existing behavior from the `dragFinished` gate in `DraggableComponent`, not something this PR changes. The document-level `grabbing` cursor persists through the drag and the bar reappears at the dropped position. Making the bar track the drag would mean positioning it against dnd-kit's clone rather than the source element, which felt out of scope here.

  ## How to test
  1. In `apps/demo`, enable the handle:

     ```tsx
     <Puck dnd={{ enableDragHandle: true }} config={config} data={data} />
     ```

  2. Select a component — a grip handle appears at the left of the action bar. Grab it and drag to reorder the component. It should start dragging immediately, with no press-and-hold delay.
  3. Confirm existing behavior is intact: dragging the component body still reorders it (handle is additive, not a replacement),
  and still requires the short press-and-hold.
  4. Set `enableDragHandle: false` (or omit `dnd`) — no handle renders, behavior is unchanged from `main`.
  5. Set `permissions={{ drag: false }}` — the handle does not render.
  6. Override the action bar and place `dragHandle` yourself to confirm the prop is exposed:

     ```tsx
     <Puck
       dnd={{ enableDragHandle: true }}
       overrides={{
         actionBar: ({ label, children, parentAction, dragHandle }) => (
           <ActionBar label={label}>
             <ActionBar.Group>{dragHandle}</ActionBar.Group>
             <ActionBar.Group>{parentAction}</ActionBar.Group>
             <ActionBar.Group>{children}</ActionBar.Group>
           </ActionBar>
         ),
       }}
     />
     ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional drag handle for reordering components.
  * Dragging can start from the handle while preserving body-dragging behavior.
  * Added accessibility labels, disabled-state handling, grab cursors, and customizable action-bar rendering.
  * Added the default “Drag to reorder” tooltip text.

* **Documentation**
  * Documented drag handles, configuration options, customization, accessibility, and usage in the API reference.

* **Tests**
  * Added coverage for rendering, labeling, refs, disabled behavior, and click handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->