### PR TITLE
Upgrade `@puckeditor/cloud-client` `@puckeditor/plugin-ai` and fix recipe builds

### DIFF
--- a/packages/create-puck-app/templates/next-ai/package.json.hbs
+++ b/packages/create-puck-app/templates/next-ai/package.json.hbs
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@puckeditor/core": "{{puckVersion}}",
     "@puckeditor/cloud-client": "^0",
+    "@puckeditor/core": "{{puckVersion}}",
     "@puckeditor/plugin-ai": "^0",
     "classnames": "^2.3.2",
     "next": "^16.0.8",

--- a/packages/create-puck-app/templates/react-router-ai/package.json.hbs
+++ b/packages/create-puck-app/templates/react-router-ai/package.json.hbs
@@ -10,8 +10,8 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@puckeditor/core": "{{puckVersion}}",
     "@puckeditor/cloud-client": "^0",
+    "@puckeditor/core": "{{puckVersion}}",
     "@puckeditor/plugin-ai": "^0",
     "@react-router/node": "^7.5.3",
     "@react-router/serve": "^7.5.3",

--- a/recipes/next-ai/app/puck/[...puckPath]/client.tsx
+++ b/recipes/next-ai/app/puck/[...puckPath]/client.tsx
@@ -19,7 +19,7 @@ const aiPlugin = createAiPlugin({
 // Place the ai plugin in the first position in the side nav.
 const plugins = [aiPlugin, blocksPlugin(), outlinePlugin()];
 
-export function Client({ path, data }: { path: string; data: Partial<Data> }) {
+export function Client({ path, data }: { path: string; data: Data }) {
   const configWithDesignedComponents = withDynamicConfig(config, data);
 
   return (

--- a/recipes/next-ai/app/puck/[...puckPath]/page.tsx
+++ b/recipes/next-ai/app/puck/[...puckPath]/page.tsx
@@ -13,9 +13,20 @@
 
 import "@puckeditor/core/puck.css";
 import "@puckeditor/plugin-ai/styles.css";
-import { Client } from "./client";
+import type { Data } from "@puckeditor/core";
 import { Metadata } from "next";
+import { Client } from "./client";
 import { getPage } from "../../../lib/get-page";
+
+// Empty data for new pages
+const EMPTY_PAGE_DATA: Data = {
+  content: [],
+  root: {
+    props: {
+      title: "",
+    },
+  },
+};
 
 export async function generateMetadata({
   params,
@@ -37,9 +48,10 @@ export default async function Page({
 }) {
   const { puckPath = [] } = await params;
   const path = `/${puckPath.join("/")}`;
+
   const data = getPage(path);
 
-  return <Client path={path} data={data || {}} />;
+  return <Client path={path} data={data || EMPTY_PAGE_DATA} />;
 }
 
 export const dynamic = "force-dynamic";

--- a/recipes/next-ai/package.json
+++ b/recipes/next-ai/package.json
@@ -9,8 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@puckeditor/core": "*",
     "@puckeditor/cloud-client": "^0",
+    "@puckeditor/core": "*",
     "@puckeditor/plugin-ai": "^0",
     "classnames": "^2.3.2",
     "next": "^16.2.5",

--- a/recipes/next/app/puck/[...puckPath]/client.tsx
+++ b/recipes/next/app/puck/[...puckPath]/client.tsx
@@ -4,7 +4,7 @@ import type { Data } from "@puckeditor/core";
 import { Puck } from "@puckeditor/core";
 import config from "../../../puck.config";
 
-export function Client({ path, data }: { path: string; data: Partial<Data> }) {
+export function Client({ path, data }: { path: string; data: Data }) {
   return (
     <Puck
       config={config}

--- a/recipes/next/app/puck/[...puckPath]/page.tsx
+++ b/recipes/next/app/puck/[...puckPath]/page.tsx
@@ -12,9 +12,20 @@
  */
 
 import "@puckeditor/core/puck.css";
-import { Client } from "./client";
+import type { Data } from "@puckeditor/core";
 import { Metadata } from "next";
+import { Client } from "./client";
 import { getPage } from "../../../lib/get-page";
+
+// Empty data for new pages.
+const EMPTY_PAGE_DATA: Data = {
+  content: [],
+  root: {
+    props: {
+      title: "",
+    },
+  },
+};
 
 export async function generateMetadata({
   params,
@@ -38,7 +49,7 @@ export default async function Page({
   const path = `/${puckPath.join("/")}`;
   const data = getPage(path);
 
-  return <Client path={path} data={data || {}} />;
+  return <Client path={path} data={data || EMPTY_PAGE_DATA} />;
 }
 
 export const dynamic = "force-dynamic";

--- a/recipes/react-router-ai/app/routes/puck-splat.tsx
+++ b/recipes/react-router-ai/app/routes/puck-splat.tsx
@@ -6,6 +6,7 @@ import { createAiPlugin, withDynamicConfig } from "@puckeditor/plugin-ai";
 
 import type { Route } from "./+types/puck-splat";
 import { config } from "../../puck.config";
+import type { UserData } from "../../puck.config";
 import { resolvePuckPath } from "~/lib/resolve-puck-path.server";
 import { getPage, savePage } from "~/lib/pages.server";
 import { PuckRender } from "~/components/puck-render";
@@ -92,9 +93,7 @@ function Editor() {
         data={loaderData.data}
         onPublish={async (data) => {
           await fetcher.submit(
-            {
-              data,
-            },
+            { data: data as UserData },
             {
               action: "",
               method: "post",

--- a/recipes/react-router-ai/package.json
+++ b/recipes/react-router-ai/package.json
@@ -10,8 +10,8 @@
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
-    "@puckeditor/core": "*",
     "@puckeditor/cloud-client": "^0",
+    "@puckeditor/core": "*",
     "@puckeditor/plugin-ai": "^0",
     "@react-router/node": "^7.5.3",
     "@react-router/serve": "^7.5.3",

--- a/recipes/react-router-ai/puck.config.tsx
+++ b/recipes/react-router-ai/puck.config.tsx
@@ -1,8 +1,10 @@
-import type { Config } from "@puckeditor/core";
+import type { Config, Data } from "@puckeditor/core";
 
-type Props = {
+export type Props = {
   HeadingBlock: { title: string };
 };
+
+export type UserData = Data<Props>;
 
 export const config: Config<Props> = {
   components: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,23 +12,24 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
   integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
 
-"@ai-sdk/gateway@3.0.152":
-  version "3.0.152"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.152.tgz#fe6bc052c2015d909d419c700371255372326b82"
-  integrity sha512-IM9D6if0CXsNkiyyIqoaD3/80gZVpCI3/tKpsq1N+vNa2O1ZeUfJmaUcIr92qqPO1G8u5YHah+0EayhIkk3ACA==
+"@ai-sdk/gateway@3.0.160":
+  version "3.0.160"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.160.tgz#8eee4be5ae36346392942f3465f817a9ab9b9b0d"
+  integrity sha512-yL024nICtDX74vFkfFJl8t7uHlA3BXl/5C+Ah92dPunI0U2WPCPhTnmiWu4zEYTjZmmvFOC3pDojniLsHkUFqA==
   dependencies:
     "@ai-sdk/provider" "3.0.14"
-    "@ai-sdk/provider-utils" "4.0.39"
+    "@ai-sdk/provider-utils" "4.0.41"
     "@vercel/oidc" "3.2.0"
 
-"@ai-sdk/provider-utils@4.0.39":
-  version "4.0.39"
-  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.39.tgz#920f0109ace2e1baec6f5478043f8b9f5772ba6d"
-  integrity sha512-XPR6o7561RYUkfYlLYouWsvm6Gv2tYIQy5pttGRkvML98u138ClPThn5yiQg5rMQutTtZLB+GUC8qFFCzDKQQQ==
+"@ai-sdk/provider-utils@4.0.41":
+  version "4.0.41"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz#77038b614d4147fde9d903e34bafbb46ca9d668b"
+  integrity sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==
   dependencies:
     "@ai-sdk/provider" "3.0.14"
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.8"
+    undici "^5.29.0"
 
 "@ai-sdk/provider@3.0.14":
   version "3.0.14"
@@ -1104,6 +1105,11 @@
   dependencies:
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
+
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
 "@floating-ui/core@^1.7.5":
   version "1.7.5"
@@ -2661,21 +2667,25 @@
   integrity sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==
 
 "@puckeditor/cloud-client@^0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@puckeditor/cloud-client/-/cloud-client-0.7.0.tgz#0d8e12d2ad287eb8c771a85522972186464f824b"
-  integrity sha512-9y5AKtn9IlYG9X/+MqNwKckgIq2/Mq8p+/MSI+f4mOrgIg8BcBLfphOqTZWwoFEK6yxJkXA179utBCICw6dnKQ==
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@puckeditor/cloud-client/-/cloud-client-0.8.1.tgz#030b3af20ca7448add0bc5b09f7091689ff46624"
+  integrity sha512-vJqjD1l1brJuxv+SM3pOGZQsvSpxykWV7heM0mU9GDnf5NyIYeWBT/ZxaULdTc8XeKyWpBwgqbjuJOHhaqJtDg==
 
 "@puckeditor/plugin-ai@^0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@puckeditor/plugin-ai/-/plugin-ai-0.7.0.tgz#02f55c444748cc813481d21934d7f964773add0f"
-  integrity sha512-TS6e59EwYs7+Ssn8My3XkuAkxYxIlcW/GC9wfJwNOTJh27itSl1oszJYvD+50T8/GVQl4MgkPyc8qYMaqw8R4w==
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@puckeditor/plugin-ai/-/plugin-ai-0.8.1.tgz#016b3cfb269bed09f50f8abfe9ab6607507440d7"
+  integrity sha512-yAsBhHIzi5WHKYd/QI9JBylqsYCK2F2qPYAL1YfF6UI1Et+qy5pqrLOtIo+B0WF0n518zu7jT/F1JVa0tt4iaQ==
   dependencies:
-    ai "^6.0.61"
+    ai "^6.0.228"
+    domhandler "^6.0.1"
+    domutils "^4.0.2"
     html2canvas-pro "^1.5.13"
+    htmlparser2 "^12.0.0"
     qler "^0.6.2"
     react-markdown "^10.1.0"
     react-textarea-autosize "^8.5.9"
     ulid "^3.0.1"
+    use-debounce "^9.0.4"
     use-stick-to-bottom "^1.1.1"
 
 "@puppeteer/browsers@2.13.2":
@@ -4352,14 +4362,14 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ai@^6.0.61:
-  version "6.0.229"
-  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.229.tgz#44741d6d25ab2f01adb5034a0c92407230b2eda7"
-  integrity sha512-bDi36L2RdEFMS7z2WIhBr7fpQhMkjzd6mgRKgtlmBSs2zZwUI22s6ZBOak/XN/LpKiJnS7SrlVqKDcqqvzTW8A==
+ai@^6.0.228:
+  version "6.0.238"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.238.tgz#9f45ea774db9e1c6add7a3a754d494b205a1200c"
+  integrity sha512-XBIrxDzOrUAOqf+mkvzpOY67SRJoa5X99iMGAuCIcsey302+QW4AWpAJIyRuE3jJxmslWO4K3ToSeBUl1DeguA==
   dependencies:
-    "@ai-sdk/gateway" "3.0.152"
+    "@ai-sdk/gateway" "3.0.160"
     "@ai-sdk/provider" "3.0.14"
-    "@ai-sdk/provider-utils" "4.0.39"
+    "@ai-sdk/provider-utils" "4.0.41"
     "@opentelemetry/api" "^1.9.0"
 
 ajv@^6.14.0:
@@ -6269,12 +6279,42 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
+dom-serializer@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-3.1.1.tgz#54be70ee4fcc2da010f488165e62294798dc57d3"
+  integrity sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==
+  dependencies:
+    domelementtype "^3.0.0"
+    domhandler "^6.0.0"
+    entities "^8.0.0"
+
+domelementtype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-3.0.0.tgz#e6c0a24bd39ca5eb7ea67a98d2f699497d7bcc55"
+  integrity sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==
+
+domhandler@^6.0.0, domhandler@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-6.0.1.tgz#75f351a03a6e10c35e08418f9cf0d287e00797cf"
+  integrity sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==
+  dependencies:
+    domelementtype "^3.0.0"
+
 dompurify@^3.3.1:
   version "3.4.11"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
   integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
+
+domutils@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-4.0.2.tgz#0c1ac1fdbe8f554a60a6f5eb143ee85630327c94"
+  integrity sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==
+  dependencies:
+    dom-serializer "^3.0.0"
+    domelementtype "^3.0.0"
+    domhandler "^6.0.0"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -6384,6 +6424,11 @@ entities@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
+entities@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
+  integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
@@ -8095,6 +8140,16 @@ html2canvas-pro@^1.5.13:
   dependencies:
     css-line-break "^2.1.0"
     text-segmentation "^1.0.3"
+
+htmlparser2@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-12.0.0.tgz#6a679d0f57c525990f9cbad8a585b320ecc6d198"
+  integrity sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==
+  dependencies:
+    domelementtype "^3.0.0"
+    domhandler "^6.0.0"
+    domutils "^4.0.2"
+    entities "^8.0.0"
 
 http-cache-semantics@^4.1.1:
   version "4.2.0"
@@ -14357,6 +14412,13 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^5.29.0:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 undici@^6.25.0:
   version "6.27.0"


### PR DESCRIPTION
This PR fixes the CI. Builds are currently failing because the lockfile is still pointing to older versions of `plugin-ai` and `cloud-client`. These versions did not include `withDynamicConfig` and other APIs we added.

The root cause was that running `yarn upgrade @puckeditor/cloud-client @puckeditor/plugin-ai` is not enough to upgrade with the wider version range. `^0` matches `0.7.0`, so the lockfile was never updated. 
The solution was to remove the entries for the Puck AI packages from the lockfile and let `yarn install` regenerate them. I guess this means we should verify whether `^0` is the version range we want here.

This was never surfaced in the `npm create puck-app` output because, in those cases, the lockfiles are created from scratch.

Upgrading surfaced another issue with the types in the new versions, so this PR fixes those issues as well.