### PR TITLE
Fede/puck 493 root slot content unmounts and remounts on every default

### DIFF
--- a/packages/core/components/Puck/components/Preview/components/editor-page.tsx
+++ b/packages/core/components/Puck/components/Preview/components/editor-page.tsx
@@ -1,0 +1,83 @@
+import { memo, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { useAppStore } from "../../../../../store";
+import { toComponent } from "../../../../../lib/data/to-component";
+import { getSlotTransform } from "../../../../../lib/field-transforms/default-transforms/slot-transform";
+import { useFieldTransformsTracked } from "../../../../../lib/field-transforms/use-field-transforms-tracked";
+import { expandNode } from "../../../../../lib/data/flatten-node";
+import { rootDroppableId } from "../../../../../lib/root-droppable-id";
+import {
+  ComponentData,
+  DefaultRootRenderProps,
+  RootData,
+} from "../../../../../types";
+
+import { useRichtextProps } from "../../../../RichTextEditor/lib/use-richtext-props";
+import { DropZoneEditPure, DropZonePure } from "../../../../DropZone";
+
+const slotFieldTransforms = getSlotTransform(DropZoneEditPure);
+
+/**
+ * Renders the puck data in the editor where this component is rendered as an editable page.
+ */
+const EditorPage = memo(() => {
+  // All the props, slot props are defaulted to null
+  const flatRootProps = useAppStore(
+    useShallow((s) => s.state.indexes.nodes.root?.flatData.props)
+  );
+  const config = useAppStore((s) => s.config);
+  const metadata = useAppStore((s) => s.metadata);
+
+  // Root as object with slots still defaulted to null
+  const rootAsComponent = useMemo(() => {
+    const rootAsComponent = toComponent({
+      props: flatRootProps ?? {},
+    } as RootData);
+
+    return expandNode(rootAsComponent) as ComponentData;
+  }, [flatRootProps]);
+
+  // Get the props with stable slot render functions
+  // (tracked only sees `null` for slot props across calls, so prev always === next)
+  const propsWithSlots = useFieldTransformsTracked(
+    config,
+    rootAsComponent,
+    slotFieldTransforms
+  );
+
+  // Build the final props to be passed to the user provided root render
+  const renderProps: DefaultRootRenderProps = useMemo(() => {
+    return {
+      ...propsWithSlots,
+      children: <DropZonePure zone={rootDroppableId} />,
+      puck: {
+        renderDropZone: DropZonePure,
+        isEditing: true,
+        dragRef: null,
+        metadata,
+      },
+      editMode: true, // DEPRECATED
+    };
+  }, [propsWithSlots, metadata]);
+
+  // Get the richtext props for the root render
+  const richtextProps = useRichtextProps(
+    config.root?.fields ?? {},
+    renderProps
+  );
+
+  return config.root?.render ? (
+    config.root?.render({
+      ...renderProps,
+      ...richtextProps,
+      id: "puck-root",
+    })
+  ) : (
+    <>{renderProps.children}</>
+  );
+});
+
+EditorPage.displayName = "EditorPage";
+
+export default EditorPage;

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -1,25 +1,13 @@
-import { useShallow } from "zustand/react/shallow";
-import { RefObject, useEffect, useRef, useMemo, memo } from "react";
+import { RefObject, useEffect, useRef, useMemo } from "react";
 
-import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { useAppStore } from "../../../../store";
 import { getClassNameFactory } from "../../../../lib";
-import {
-  ComponentData,
-  RootData,
-  DefaultRootRenderProps,
-} from "../../../../types";
 import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
-import { useFieldTransformsTracked } from "../../../../lib/field-transforms/use-field-transforms-tracked";
-import { getSlotTransform } from "../../../../lib/field-transforms/default-transforms/slot-transform";
-import { expandNode } from "../../../../lib/data/flatten-node";
-import { toComponent } from "../../../../lib/data/to-component";
 
-import { DropZoneEditPure, DropZonePure } from "../../../DropZone";
 import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
 import { Render } from "../../../Render";
-import { useRichtextProps } from "../../../RichTextEditor/lib/use-richtext-props";
 
+import EditorPage from "./components/editor-page";
 import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("PuckPreview", styles);
@@ -93,42 +81,8 @@ const usePreviewModeAttribute = (ref: RefObject<HTMLIFrameElement | null>) => {
   }, [previewMode, status, iframeEnabled]);
 };
 
-const slotFieldTransforms = getSlotTransform(DropZoneEditPure);
-
-type PageProps = DefaultRootRenderProps & { config: any };
-
-const Page = memo(({ config, ...pageProps }: PageProps) => {
-  const rootAsComponent = toComponent({ props: pageProps });
-
-  // Get the props with stable slot render functions
-  // (tracked only sees `null` for slot props across calls, so prev always === next)
-  const propsWithSlots = useFieldTransformsTracked(
-    config,
-    rootAsComponent,
-    slotFieldTransforms
-  );
-
-  const richtextProps = useRichtextProps(config.root?.fields ?? {}, pageProps);
-
-  return config.root?.render ? (
-    config.root?.render({
-      ...propsWithSlots,
-      ...richtextProps,
-      id: "puck-root",
-    })
-  ) : (
-    <>{propsWithSlots.children}</>
-  );
-});
-
-Page.displayName = "Page";
-
 export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const dispatch = useAppStore((s) => s.dispatch);
-  // All the props, slot props are defaulted to null
-  const flatRootProps = useAppStore(
-    useShallow((s) => s.state.indexes.nodes.root?.flatData.props)
-  );
   const config = useAppStore((s) => s.config);
   const setStatus = useAppStore((s) => s.setStatus);
   const iframe = useAppStore((s) => s.iframe);
@@ -140,34 +94,13 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
 
   const Frame = useMemo(() => overrides.iframe, [overrides]);
 
-  // Root as object with slots still defaulted to null
-  const expandedRootAsComponent = useMemo(() => {
-    const rootAsComponent = toComponent({
-      props: flatRootProps ?? {},
-    } as RootData);
-
-    return expandNode(rootAsComponent) as ComponentData;
-  }, [flatRootProps]);
-
   const ref = useRef<HTMLIFrameElement>(null);
 
   useBubbleIframeEvents(ref);
   usePreviewModeAttribute(ref);
 
   const inner = !renderData ? (
-    <Page
-      {...expandedRootAsComponent.props}
-      config={config}
-      puck={{
-        renderDropZone: DropZonePure,
-        isEditing: true,
-        dragRef: null,
-        metadata,
-      }}
-      editMode={true} // DEPRECATED
-    >
-      <DropZonePure zone={rootDroppableId} />
-    </Page>
+    <EditorPage />
   ) : (
     <Render data={renderData} config={config} metadata={metadata} />
   );

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -1,19 +1,28 @@
-import { DropZoneEditPure, DropZonePure } from "../../../DropZone";
-import { rootDroppableId } from "../../../../lib/root-droppable-id";
+import { useShallow } from "zustand/react/shallow";
 import { RefObject, useEffect, useRef, useMemo, memo } from "react";
+
+import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { useAppStore } from "../../../../store";
-import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
-import styles from "./styles.module.css";
 import { getClassNameFactory } from "../../../../lib";
-import { DefaultRootRenderProps } from "../../../../types";
-import { Render } from "../../../Render";
+import {
+  ComponentData,
+  RootData,
+  DefaultRootRenderProps,
+} from "../../../../types";
 import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
-import { useSlots } from "../../../../lib/use-slots";
+import { useFieldTransformsTracked } from "../../../../lib/field-transforms/use-field-transforms-tracked";
+import { getSlotTransform } from "../../../../lib/field-transforms/default-transforms/slot-transform";
+import { expandNode } from "../../../../lib/data/flatten-node";
+import { toComponent } from "../../../../lib/data/to-component";
+
+import { DropZoneEditPure, DropZonePure } from "../../../DropZone";
+import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
+import { Render } from "../../../Render";
 import { useRichtextProps } from "../../../RichTextEditor/lib/use-richtext-props";
 
-const getClassName = getClassNameFactory("PuckPreview", styles);
+import styles from "./styles.module.css";
 
-type PageProps = DefaultRootRenderProps;
+const getClassName = getClassNameFactory("PuckPreview", styles);
 
 const useBubbleIframeEvents = (ref: RefObject<HTMLIFrameElement | null>) => {
   const status = useAppStore((s) => s.status);
@@ -84,20 +93,28 @@ const usePreviewModeAttribute = (ref: RefObject<HTMLIFrameElement | null>) => {
   }, [previewMode, status, iframeEnabled]);
 };
 
-const Page = memo(({ config, ...pageProps }: { config: any } & PageProps) => {
-  const propsWithSlots = useSlots(
+const slotFieldTransforms = getSlotTransform(DropZoneEditPure);
+
+type PageProps = DefaultRootRenderProps & { config: any };
+
+const Page = memo(({ config, ...pageProps }: PageProps) => {
+  const rootAsComponent = toComponent({ props: pageProps });
+
+  // Get the props with stable slot render functions
+  // (tracked only sees `null` for slot props across calls, so prev always === next)
+  const propsWithSlots = useFieldTransformsTracked(
     config,
-    { type: "root", props: pageProps },
-    DropZoneEditPure
+    rootAsComponent,
+    slotFieldTransforms
   );
 
   const richtextProps = useRichtextProps(config.root?.fields ?? {}, pageProps);
 
   return config.root?.render ? (
     config.root?.render({
-      id: "puck-root",
       ...propsWithSlots,
       ...richtextProps,
+      id: "puck-root",
     })
   ) : (
     <>{propsWithSlots.children}</>
@@ -108,7 +125,10 @@ Page.displayName = "Page";
 
 export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const dispatch = useAppStore((s) => s.dispatch);
-  const root = useAppStore((s) => s.state.data.root);
+  // All the props, slot props are defaulted to null
+  const flatRootProps = useAppStore(
+    useShallow((s) => s.state.indexes.nodes.root?.flatData.props)
+  );
   const config = useAppStore((s) => s.config);
   const setStatus = useAppStore((s) => s.setStatus);
   const iframe = useAppStore((s) => s.iframe);
@@ -120,8 +140,14 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
 
   const Frame = useMemo(() => overrides.iframe, [overrides]);
 
-  // DEPRECATED
-  const rootProps = root.props || root;
+  // Root as object with slots still defaulted to null
+  const expandedRootAsComponent = useMemo(() => {
+    const rootAsComponent = toComponent({
+      props: flatRootProps ?? {},
+    } as RootData);
+
+    return expandNode(rootAsComponent) as ComponentData;
+  }, [flatRootProps]);
 
   const ref = useRef<HTMLIFrameElement>(null);
 
@@ -130,7 +156,7 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
 
   const inner = !renderData ? (
     <Page
-      {...rootProps}
+      {...expandedRootAsComponent.props}
       config={config}
       puck={{
         renderDropZone: DropZonePure,

--- a/packages/core/lib/data/walk-app-state.ts
+++ b/packages/core/lib/data/walk-app-state.ts
@@ -190,6 +190,7 @@ export function walkAppState<UserData extends Data = Data>(
   }, newZones);
 
   let rootAsComponent: ComponentData = toComponent({
+    // DEPRECATED root props without a `props` key, for backwards compatibility
     props: { ...(state.data.root.props ?? state.data.root) },
   });
 

--- a/packages/core/lib/field-transforms/build-mappers.ts
+++ b/packages/core/lib/field-transforms/build-mappers.ts
@@ -26,33 +26,32 @@ export function buildMappers<
   readOnly?: T["readOnly"],
   forceReadOnly?: boolean
 ) {
-  return Object.keys(transforms).reduce<Mappers>((acc, _fieldType) => {
+  const newMappers: Mappers = {};
+
+  Object.keys(transforms).forEach((_fieldType) => {
     const fieldType = _fieldType as Field["type"]; // Not strictly true, as could include user fields, but this should be safe enough
 
-    return {
-      ...acc,
-      [fieldType]: ({
-        parentId,
-        ...params
-      }: MapFnParams<ExtractField<G["UserField"], Field["type"]>>) => {
-        const wildcardPath = params.propPath.replace(/\[\d+\]/g, "[*]");
+    newMappers[fieldType] = ({ parentId, ...params }: MapFnParams<Field>) => {
+      const wildcardPath = params.propPath.replace(/\[\d+\]/g, "[*]");
 
-        const isReadOnly =
-          readOnly?.[params.propPath] ||
-          readOnly?.[wildcardPath] ||
-          forceReadOnly ||
-          false;
+      const isReadOnly =
+        readOnly?.[params.propPath] ||
+        readOnly?.[wildcardPath] ||
+        forceReadOnly ||
+        false;
 
-        const fn = transforms[fieldType] as FieldTransformFn<
-          ExtractField<G["UserField"], Field["type"]>
-        >;
+      const fn = transforms[fieldType] as FieldTransformFn<
+        ExtractField<G["UserField"], Field["type"]>
+      >;
 
-        return fn?.({
-          ...params,
-          isReadOnly,
-          componentId: parentId,
-        });
-      },
+      return fn?.({
+        ...params,
+        field: params.field as ExtractField<G["UserField"], Field["type"]>,
+        isReadOnly,
+        componentId: parentId,
+      });
     };
-  }, {});
+  });
+
+  return newMappers;
 }


### PR DESCRIPTION
Closes puckeditor/puck#1745 and puckeditor/puck#1665

## Description

This PR fixes an issue where modifying any props would remount components that lived within root slots. This would also cause caret positions to be lost when `contentEditable` fields lived within root slots.

The reason was that the editor path used to render the root called the plain `useSlots` hook with the entire `root` data object. This function does not track props, and it recreated the transform functions on every change because `root` is a plain object that is recreated on every render. As a result, the slot render functions changed references between re-renders and were recreated, causing the components to remount.

## Changes made

* Refactored build mappers for performance and readability by replacing the `reduce` call with a plain `forEach`.
* Updated the preview to follow the same approach used to render component slots:
  1. The preview subscribes to the flattened root data, which defaults slots to `null`.
  2. The flattened root data is expanded and passed to `useTransformSlotsTracked`.
  3. `useTransformSlots` creates stable slot render functions because the slot props are equal between calls (`null`).
  4. Each `DropZonePure` renders an individual `DropZoneChild` for each `contentId` in `indexes`.
  5. Each `DropZoneChild` subscribes to its flattened props.

## How to test

* Render Puck with a root slot and some other components that log when they unmount:

```tsx
export const config: Config<Props> = {
  components: {
    HeadingBlock: {
      fields: {
        title: { type: "text" },
      },
      render: ({ title }) => {
        useEffect(() => {
          return () => console.log(`Unmounting ${title}`);
        }, []);

        return (
          <div style={{ padding: 64 }}>
            <h1>{title}</h1>
          </div>
        );
      },
    },
  },
  root: {
    fields: {
      body: { type: "slot" },
      title: { type: "text" },
    },
    render: ({ body: Body, children }) => (
      <div>
        <Body />
        {children}
      </div>
    ),
  },
};

export default config;
```

* Add some components to the root slot and the default slot, then modify the components in the root slot.
* Observe that the root slot components do not remount.
* Modify the components in the default slot.
* Observe that the root slot components do not remount.
* Modify the root title.
* Observe that the root slot components do not remount.