### PR TITLE
fix: remove external Inter font import from no-external.css and runtime CSS

### DIFF
--- a/packages/core/bundle/__tests__/no-external-css.spec.ts
+++ b/packages/core/bundle/__tests__/no-external-css.spec.ts
@@ -1,15 +1,82 @@
+/**
+ * @jest-environment node
+ */
 import * as fs from "fs";
 import * as path from "path";
+import { build, type Plugin } from "esbuild";
 
 const bundleDir = path.resolve(__dirname, "..");
+const packageRoot = path.resolve(bundleDir, "..");
 
 const readBundleFile = (filename: string): string =>
   fs.readFileSync(path.join(bundleDir, filename), "utf-8");
 
 const EXTERNAL_URL_PATTERN = /https?:\/\//;
 
+// --- Helpers to build CSS the same way tsup.config.ts does ---
+
+const runtimeCssStubPlugin: Plugin = {
+  name: "runtime-css-stub",
+  setup(buildApi) {
+    buildApi.onResolve({ filter: /generated\/runtime-css$/ }, () => ({
+      path: "runtime-css-stub",
+      namespace: "runtime-css-stub",
+    }));
+
+    buildApi.onLoad({ filter: /.*/, namespace: "runtime-css-stub" }, () => ({
+      contents: `
+          export const defaultUiStyles = "";
+          export const iframeInteractionStyles = "";
+        `,
+      loader: "js" as const,
+    }));
+  },
+};
+
+/**
+ * Build an entry point with esbuild and return the emitted CSS string.
+ * Mirrors the `readBundledCss` function from tsup.config.ts.
+ */
+const buildCss = async (entryPoint: string): Promise<string> => {
+  const isCssEntry = entryPoint.endsWith(".css");
+  const result = await build({
+    absWorkingDir: packageRoot,
+    bundle: true,
+    format: "iife",
+    logLevel: "silent",
+    packages: "external",
+    platform: "browser",
+    plugins: [runtimeCssStubPlugin],
+    target: ["es2020"],
+    outdir: "out",
+    write: false,
+    ...(isCssEntry
+      ? {
+          stdin: {
+            contents: `import "./${entryPoint}";`,
+            loader: "ts" as const,
+            resolveDir: packageRoot,
+            sourcefile: "runtime-css-entry.ts",
+          },
+        }
+      : {
+          entryPoints: [entryPoint],
+        }),
+  });
+
+  return result.outputFiles
+    .filter((file) => file.path.endsWith(".css"))
+    .map((file) => file.text.trim())
+    .filter(Boolean)
+    .join("\n\n");
+};
+
+// ===========================================================================
+// Source file contract tests
+// ===========================================================================
+
 describe("CSS bundle external dependency contract", () => {
-  describe("no-external.css", () => {
+  describe("no-external.css (source)", () => {
     it("should NOT contain any external URL references", () => {
       const content = readBundleFile("no-external.css");
       expect(content).not.toMatch(EXTERNAL_URL_PATTERN);
@@ -21,7 +88,7 @@ describe("CSS bundle external dependency contract", () => {
     });
   });
 
-  describe("index.css", () => {
+  describe("index.css (source)", () => {
     it("should NOT contain any external URL references", () => {
       const content = readBundleFile("index.css");
       expect(content).not.toMatch(EXTERNAL_URL_PATTERN);
@@ -33,7 +100,7 @@ describe("CSS bundle external dependency contract", () => {
     });
   });
 
-  describe("fonts.css", () => {
+  describe("fonts.css (source)", () => {
     it("should contain the Inter font external import", () => {
       const content = readBundleFile("fonts.css");
       expect(content).toContain("rsms.me/inter/inter.css");
@@ -43,12 +110,12 @@ describe("CSS bundle external dependency contract", () => {
   describe("index.ts (entry point)", () => {
     it("should import fonts.css for the full bundle", () => {
       const content = readBundleFile("index.ts");
-      expect(content).toContain('./fonts.css');
+      expect(content).toContain("./fonts.css");
     });
 
     it("should import index.css", () => {
       const content = readBundleFile("index.ts");
-      expect(content).toContain('./index.css');
+      expect(content).toContain("./index.css");
     });
   });
 
@@ -67,7 +134,7 @@ describe("CSS bundle external dependency contract", () => {
   describe("runtime CSS source (tsup.config.ts)", () => {
     it("should generate runtime CSS from no-external.ts, not index.ts", () => {
       const tsupConfig = fs.readFileSync(
-        path.resolve(bundleDir, "..", "tsup.config.ts"),
+        path.resolve(packageRoot, "tsup.config.ts"),
         "utf-8"
       );
 
@@ -78,6 +145,27 @@ describe("CSS bundle external dependency contract", () => {
       expect(tsupConfig).not.toMatch(
         /readBundledCss\(\s*["']bundle\/index\.ts["']\s*\)/
       );
+    });
+  });
+
+  // ===========================================================================
+  // Built CSS artifact tests (addresses CodeRabbit review feedback)
+  // ===========================================================================
+
+  describe("built CSS artifacts", () => {
+    it("no-external.ts emitted CSS should NOT contain the rsms.me Inter import", async () => {
+      const css = await buildCss("bundle/no-external.ts");
+      expect(css).not.toContain("rsms.me");
+    });
+
+    it("no-external.ts emitted CSS should NOT contain @import rules", async () => {
+      const css = await buildCss("bundle/no-external.ts");
+      expect(css).not.toMatch(/@import\s/);
+    });
+
+    it("index.ts emitted CSS should contain the Inter font import", async () => {
+      const css = await buildCss("bundle/index.ts");
+      expect(css).toContain("rsms.me/inter/inter.css");
     });
   });
 });

--- a/packages/core/bundle/__tests__/no-external-css.spec.ts
+++ b/packages/core/bundle/__tests__/no-external-css.spec.ts
@@ -1,0 +1,83 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const bundleDir = path.resolve(__dirname, "..");
+
+const readBundleFile = (filename: string): string =>
+  fs.readFileSync(path.join(bundleDir, filename), "utf-8");
+
+const EXTERNAL_URL_PATTERN = /https?:\/\//;
+
+describe("CSS bundle external dependency contract", () => {
+  describe("no-external.css", () => {
+    it("should NOT contain any external URL references", () => {
+      const content = readBundleFile("no-external.css");
+      expect(content).not.toMatch(EXTERNAL_URL_PATTERN);
+    });
+
+    it("should import core.css", () => {
+      const content = readBundleFile("no-external.css");
+      expect(content).toContain("core.css");
+    });
+  });
+
+  describe("index.css", () => {
+    it("should NOT contain any external URL references", () => {
+      const content = readBundleFile("index.css");
+      expect(content).not.toMatch(EXTERNAL_URL_PATTERN);
+    });
+
+    it("should import core.css", () => {
+      const content = readBundleFile("index.css");
+      expect(content).toContain("core.css");
+    });
+  });
+
+  describe("fonts.css", () => {
+    it("should contain the Inter font external import", () => {
+      const content = readBundleFile("fonts.css");
+      expect(content).toContain("rsms.me/inter/inter.css");
+    });
+  });
+
+  describe("index.ts (entry point)", () => {
+    it("should import fonts.css for the full bundle", () => {
+      const content = readBundleFile("index.ts");
+      expect(content).toContain('./fonts.css');
+    });
+
+    it("should import index.css", () => {
+      const content = readBundleFile("index.ts");
+      expect(content).toContain('./index.css');
+    });
+  });
+
+  describe("no-external.ts (entry point)", () => {
+    it("should NOT import fonts.css", () => {
+      const content = readBundleFile("no-external.ts");
+      expect(content).not.toContain("fonts.css");
+    });
+
+    it("should import no-external.css", () => {
+      const content = readBundleFile("no-external.ts");
+      expect(content).toContain("no-external.css");
+    });
+  });
+
+  describe("runtime CSS source (tsup.config.ts)", () => {
+    it("should generate runtime CSS from no-external.ts, not index.ts", () => {
+      const tsupConfig = fs.readFileSync(
+        path.resolve(bundleDir, "..", "tsup.config.ts"),
+        "utf-8"
+      );
+
+      // The runtime CSS should be generated from no-external.ts (no external deps)
+      expect(tsupConfig).toContain('readBundledCss("bundle/no-external.ts")');
+
+      // It should NOT use index.ts (which would include fonts.css / external import)
+      expect(tsupConfig).not.toMatch(
+        /readBundledCss\(\s*["']bundle\/index\.ts["']\s*\)/
+      );
+    });
+  });
+});

--- a/packages/core/bundle/fonts.css
+++ b/packages/core/bundle/fonts.css
@@ -1,0 +1,1 @@
+@import url("https://rsms.me/inter/inter.css");

--- a/packages/core/bundle/fonts.css
+++ b/packages/core/bundle/fonts.css
@@ -1,1 +1,1 @@
-@import url("https://rsms.me/inter/inter.css");
+@import "https://rsms.me/inter/inter.css";

--- a/packages/core/bundle/index.css
+++ b/packages/core/bundle/index.css
@@ -1,2 +1,1 @@
-@import url("https://rsms.me/inter/inter.css");
 @import "./core.css";

--- a/packages/core/bundle/index.ts
+++ b/packages/core/bundle/index.ts
@@ -1,3 +1,4 @@
+import "./fonts.css";
 import "./index.css";
 
 export * from "./core";

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -85,7 +85,7 @@ const runtimeCssPlugin: Plugin = {
       async () => {
         if (!cachedContents) {
           const [defaultStyles, interactionStyles] = await Promise.all([
-            readBundledCss("bundle/index.ts"),
+            readBundledCss("bundle/no-external.ts"),
             readBundledCss("bundle/iframe-styles.ts"),
           ]);
 


### PR DESCRIPTION
## Summary

Fixes #1769 — `no-external.css` imports Inter from rsms.me (render-blocking).

The `no-external.css` bundle is intended to be free of external network dependencies, but two issues caused the external Inter font `@import` to leak through:

1. **Runtime CSS**: The dynamically injected CSS (via `useInjectUiCss`) was generated from `bundle/index.ts`, which included `@import url("https://rsms.me/inter/inter.css")`. This meant even users of the `no-external` variant got a render-blocking cross-origin request.

2. **CSS contract violation**: The external `@import` being baked into the source `index.css` meant it could also appear in runtime CSS strings injected as `<style>` tags, where `@import` statements are non-functional anyway.

## Changes

| File | Change |
|------|--------|
| `bundle/fonts.css` | **[NEW]** Dedicated file for the external Inter font `@import` |
| `bundle/index.css` | Removed external `@import` — now identical to `no-external.css` |
| `bundle/index.ts` | Imports `fonts.css` before `index.css` (preserves backward compat for `dist/index.css`) |
| `tsup.config.ts` | Runtime CSS now generated from `bundle/no-external.ts` instead of `bundle/index.ts` |
| `bundle/__tests__/no-external-css.spec.ts` | **[NEW]** 10 unit tests enforcing the CSS external dependency contract |

## How it works

- `dist/index.css` (aka `puck.css`) still includes the Inter font import — **no breaking change** for existing users
- `dist/no-external.css` is guaranteed free of external URLs — its contract is now enforced by tests
- Runtime-injected CSS never includes external `@import` statements (they're non-functional inside `<style>` tags anyway)

## Testing

- ✅ 10 new unit tests — all passing
- ✅ Full test suite (42 suites, 225 tests) — all passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Default styles now load without external font or stylesheet URLs, improving reliability in restricted or offline environments.
  - The complete style bundle continues to support the Inter font and associated styles when explicitly included.
- **Bug Fixes**
  - Corrected runtime style generation to use the no-external bundle by default.
  - Improved separation between standard, no-external, and iframe styling options.
- **Tests**
  - Added coverage to verify stylesheet imports and prevent unintended external resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->