### PR TITLE
fix: render explicit viewport height at actual size (#883)

### DIFF
--- a/packages/core/lib/__tests__/get-zoom-config.spec.ts
+++ b/packages/core/lib/__tests__/get-zoom-config.spec.ts
@@ -32,7 +32,11 @@ describe("getZoomConfig", () => {
 
   // Regression guard: auto-height viewports keep the existing auto-zoom-to-fit-width behaviour.
   it("auto-fits the width for an auto-height viewport wider than the frame", () => {
-    const { zoom, autoZoom, rootHeight } = getZoomConfig(vp(1600, "auto"), frame, 1);
+    const { zoom, autoZoom, rootHeight } = getZoomConfig(
+      vp(1600, "auto"),
+      frame,
+      1
+    );
     expect(zoom).toBeCloseTo(0.5); // 800 / 1600
     expect(autoZoom).toBeCloseTo(0.5);
     expect(rootHeight).toBeCloseTo(1200); // viewportHeight(600) / zoom(0.5)

--- a/packages/core/lib/__tests__/get-zoom-config.spec.ts
+++ b/packages/core/lib/__tests__/get-zoom-config.spec.ts
@@ -1,0 +1,48 @@
+import { getZoomConfig } from "../get-zoom-config";
+import type { AppState } from "../../types";
+
+// getZoomConfig reads the frame's rendered box; stub it to a fixed 800×600 preview area.
+jest.mock("css-box-model", () => ({
+  getBox: () => ({ contentBox: { width: 800, height: 600 } }),
+}));
+
+const frame = {} as HTMLElement;
+type Viewport = AppState["ui"]["viewports"]["current"];
+const vp = (width: Viewport["width"], height: Viewport["height"]): Viewport =>
+  ({ width, height } as Viewport);
+
+describe("getZoomConfig", () => {
+  // #883: an explicit height is a concrete target, so render at actual size (both axes scroll),
+  // instead of fitting the width while the height overflows.
+  it("renders an explicit height at 1:1 with both axes scrollable (#883, Option A)", () => {
+    expect(getZoomConfig(vp(1920, 1080), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 1080,
+    });
+  });
+
+  it("keeps an explicit height even when it is smaller than the frame", () => {
+    expect(getZoomConfig(vp(400, 300), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 300,
+    });
+  });
+
+  // Regression guard: auto-height viewports keep the existing auto-zoom-to-fit-width behaviour.
+  it("auto-fits the width for an auto-height viewport wider than the frame", () => {
+    const { zoom, autoZoom, rootHeight } = getZoomConfig(vp(1600, "auto"), frame, 1);
+    expect(zoom).toBeCloseTo(0.5); // 800 / 1600
+    expect(autoZoom).toBeCloseTo(0.5);
+    expect(rootHeight).toBeCloseTo(1200); // viewportHeight(600) / zoom(0.5)
+  });
+
+  it("does not zoom an auto-height viewport that fits within the frame", () => {
+    expect(getZoomConfig(vp(400, "auto"), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 600,
+    });
+  });
+});

--- a/packages/core/lib/get-zoom-config.ts
+++ b/packages/core/lib/get-zoom-config.ts
@@ -15,6 +15,15 @@ export const getZoomConfig = (
   const viewportHeight =
     uiViewport.height === "auto" ? frameHeight : uiViewport.height;
 
+  // #883: When an explicit (non-"auto") height is set alongside the width, both dimensions have
+  // concrete target values (e.g. 1920×1080). Render the preview at its ACTUAL size and let the
+  // canvas scroll on both axes, instead of auto-fitting the width to the frame while the height
+  // overflows — the inconsistent mix reported in the issue. This is the reporter's preferred
+  // "Option A": explicit width + height → 1:1, both scrollable.
+  if (uiViewport.height !== "auto") {
+    return { autoZoom: 1, zoom: 1, rootHeight: viewportHeight };
+  }
+
   let rootHeight = 0;
   let autoZoom = 1;
 


### PR DESCRIPTION
## Problem

Fixes #883.

When a custom viewport has both an explicit **width and height**, the preview scales inconsistently: the width is auto-fitted to the frame, but the height is rendered at its physical pixel value and overflows the preview. The same happens with manual zoom: zooming out shrinks the width but not the height, so the preview never reflects the target resolution.

## Fix (Option B)

`rootHeight` is the *unscaled* height of the canvas root, which is then multiplied by `transform: scale(zoom)`. Dividing it by `zoom` is correct for `height: "auto"` (the root must fill the frame at any zoom), but for an explicit height it pinned the rendered height while the width was scaled down.

An explicit height now keeps its real value, so it scales by the same factor as the width and the aspect ratio is preserved — e.g. a 1920×1080 viewport renders as 16:9 at any zoom level:

```ts
if (widthZoom < heightZoom) {
  rootHeight =
    uiViewport.height === "auto" ? viewportHeight / zoom : viewportHeight;
}
```

The existing fit-to-width auto-zoom is untouched, so there's no zoom-in behaviour, no horizontal overflow, and drag-and-drop is unaffected. Auto-height viewports are unchanged.

> Earlier revisions of this PR implemented Option A (render at actual size, both axes scrollable). That was switched to Option B per review feedback.

## Verification

Measured in the demo (frame 1484×753):

| Viewport | zoom | Rendered | Aspect | Overflow |
|---|---|---|---|---|
| 1920×1080 | 0.697 | 1339×753 | 1.778 | none |
| 4000×2000 | 0.371 | 1484×742 | 2.000 | none, both edges visible |
| 800×2000 | 0.377 | 301×753 | 0.400 | none |
| 1920×1080, manual zoom 50% / 25% | 0.5 / 0.25 | 960×540 / 480×270 | 1.778 | none |
| `auto` height (Small / Large / Full) | unchanged | unchanged | — | none |
| `auto` height, manual zoom 75% | 0.75 | 960×753 | — | "Constrain height" effect intact |

## Tests

Adds `get-zoom-config.spec.ts` (this helper was previously untested):

- explicit height, width is the constraint → fits width, `rootHeight` stays real (the fixed branch)
- explicit height, height is the constraint → fits height
- explicit height, both exceed the frame → most constrained axis wins
- explicit height within the frame → 1:1
- auto-fit ignores the previous zoom
- non-numeric width (`"100%"`) → no auto-zoom
- auto-height regression guards (fit width + stretch to frame, fits, `"100%"`)
