### PR TITLE
fix: don't reset caret position in custom and overriden fields

### DIFF
--- a/packages/core/components/AutoField/fields/DefaultField/index.tsx
+++ b/packages/core/components/AutoField/fields/DefaultField/index.tsx
@@ -17,7 +17,9 @@ export const DefaultField = ({
   labelIcon,
   Label,
 }: FieldPropsInternal) => {
-  const [localValue, onChangeLocal] = useLocalValue(name, onChange);
+  const [localValue, onChangeLocal] = useLocalValue(name, onChange, {
+    fallback: "",
+  });
 
   return (
     <Label

--- a/packages/core/components/AutoField/fields/TextareaField/index.tsx
+++ b/packages/core/components/AutoField/fields/TextareaField/index.tsx
@@ -16,7 +16,9 @@ export const TextareaField = ({
   labelIcon,
   Label,
 }: FieldPropsInternal) => {
-  const [localValue, onChangeLocal] = useLocalValue(name, onChange);
+  const [localValue, onChangeLocal] = useLocalValue(name, onChange, {
+    fallback: "",
+  });
 
   return (
     <Label
@@ -29,7 +31,7 @@ export const TextareaField = ({
         className={getClassName("input")}
         autoComplete="off"
         name={name}
-        value={typeof localValue === "undefined" ? "" : localValue}
+        value={localValue}
         onChange={(e) => onChangeLocal(e.currentTarget.value)}
         readOnly={readOnly}
         tabIndex={readOnly ? -1 : undefined}

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -1,5 +1,5 @@
 import getClassNameFactory from "../../lib/get-class-name-factory";
-import { Field, FieldProps } from "../../types";
+import { Field, FieldProps, UiState } from "../../types";
 
 import styles from "./styles.module.css";
 import {
@@ -24,13 +24,14 @@ import { useAppStore } from "../../store";
 import { useSafeId } from "../../lib/use-safe-id";
 import { NestedFieldContext } from "./context";
 import { useShallow } from "zustand/react/shallow";
-import { getDeep } from "../../lib/data/get-deep";
+import { setDeep } from "../../lib/data/set-deep";
 import type {
   FieldLabelPropsInternal,
   FieldPropsInternalOptional,
 } from "./FieldLabel";
 import { FieldLabelInternal } from "./FieldLabel";
-import { useFieldStore, useFieldStoreApi, fieldContextStore } from "./store";
+import { useFieldStoreApi, fieldContextStore } from "./store";
+import { useLocalValue } from "./lib/use-local-value";
 
 const getClassName = getClassNameFactory("Input", styles);
 const getClassNameWrapper = getClassNameFactory("InputWrapper", styles);
@@ -99,12 +100,42 @@ function AutoFieldInternal<
     [overrides]
   );
 
-  const fieldValue = useFieldStore((s) => {
-    // Always set a value for custom fields, or when an override is provided
-    if (field.type === "custom" || overrides.fieldTypes?.[field.type]) {
-      return getDeep(s, props.name ?? resolvedId);
+  // Custom fields and overridden field types are handed their value directly,
+  // out of the field store. Built-in fields read it themselves.
+  const readsValueFromStore =
+    field.type === "custom" || !!overrides.fieldTypes?.[field.type];
+
+  const fieldPath = props.name ?? resolvedId;
+
+  const fieldStore = useFieldStoreApi();
+
+  const onChangeWithStoreSync = useMemo(() => {
+    if (!readsValueFromStore) {
+      return props.onChange;
     }
-  });
+
+    return (value: any, uiState?: Partial<UiState>) => {
+      // Call the parent first, so nested (object/array) fields compute their
+      // update against the pre-change store value.
+      props.onChange?.(value, uiState);
+
+      // Race condition mitigation:
+      // Object and array fields build their update by merging the changed
+      // subfield over its siblings, which they read out of this store.
+      // The store is only written after resolving data asynchronously, so without
+      // this sync write, editing two siblings within objects/arrays in quick succession could make the
+      // second merge carry the first sibling's pre-change value and undo it.
+      fieldStore.setState(setDeep(fieldStore.getState(), fieldPath, value));
+    };
+  }, [readsValueFromStore, props.onChange, fieldPath, fieldStore]);
+
+  // Same local tracking the built-in fields use, so custom and overridden fields get their
+  // new value on the same render to avoid caret jumps and resolved data overriding the new value.
+  const [fieldValue, onChange] = useLocalValue(
+    fieldPath,
+    onChangeWithStoreSync,
+    { tracked: readsValueFromStore }
+  );
 
   const mergedProps = useMemo(
     () => ({
@@ -115,8 +146,9 @@ function AutoFieldInternal<
       Label,
       id: resolvedId,
       value: fieldValue,
+      onChange,
     }),
-    [props, field, label, labelIcon, Label, resolvedId, fieldValue]
+    [props, field, label, labelIcon, Label, resolvedId, fieldValue, onChange]
   );
 
   const onFocus = useCallback(

--- a/packages/core/components/AutoField/lib/use-deep-field.ts
+++ b/packages/core/components/AutoField/lib/use-deep-field.ts
@@ -1,6 +1,12 @@
 import { getDeep } from "../../../lib/data/get-deep";
 import { useFieldStore } from "../store";
 
-export const useDeepField = (path: string) => {
-  return useFieldStore((s) => getDeep(s, path));
+/**
+ * Read a value out of the field store by dot-notated path.
+ *
+ * Pass `enabled: false` to opt out: the selector then returns a stable
+ * `undefined`, so the caller doesn't re-render when the value changes.
+ */
+export const useDeepField = (path: string, enabled: boolean = true) => {
+  return useFieldStore((s) => (enabled ? getDeep(s, path) : undefined));
 };

--- a/packages/core/components/AutoField/lib/use-local-value.ts
+++ b/packages/core/components/AutoField/lib/use-local-value.ts
@@ -2,26 +2,69 @@ import { useCallback, useEffect, useState } from "react";
 import { useDeepField } from "./use-deep-field";
 import { useIsFocused } from "./use-is-focused";
 
-export const useLocalValue = (path: string, onChange: (val: any) => void) => {
-  const value = useDeepField(path);
+type UseLocalValueOptions = {
+  /**
+   * Set false to skip tracking store updates. When false, returns a stable
+   * `undefined` value and the untouched `onChange`, so callers won't re-render
+   * when the field store value changes.
+   */
+  tracked?: boolean;
+  /**
+   * Returned in place of a nullish value.
+   */
+  fallback?: any;
+};
+
+/**
+ * Track a field's value in local state, seeded and kept in sync from the field
+ * store.
+ *
+ * The store is a shared channel: the subscription in Fields writes every
+ * committed change into it. Because `resolveData` is async, a commit can land
+ * carrying the value from a keystroke the user has already typed past, which
+ * would overwrite what they're typing and reset the caret. Local state is
+ * private, so holding the value here and ignoring the store while the field is
+ * focused keeps the edit intact. On blur it re-syncs from the store.
+ */
+export const useLocalValue = (
+  path: string,
+  onChange: (value: any, ...rest: any[]) => void,
+  { tracked = true, fallback }: UseLocalValueOptions = {}
+) => {
+  const value = useDeepField(path, tracked);
   const isFocused = useIsFocused(path);
 
-  const [localValue, setLocalValue] = useState(value?.toString());
+  const [localValue, setLocalValue] = useState(value);
 
   const onChangeLocal = useCallback(
-    (val: any) => {
+    (val: any, ...rest: any[]) => {
       setLocalValue(val);
-      onChange(val);
+
+      onChange(val, ...rest);
     },
     [onChange]
   );
 
   useEffect(() => {
+    // Nothing is tracked, so there is no local state to keep in sync.
+    if (!tracked) {
+      return;
+    }
+
     // Prevent global state from setting local state if this field is focused
     if (!isFocused) {
       setLocalValue(value);
     }
-  }, [isFocused, value]);
+  }, [tracked, isFocused, value]);
 
-  return [localValue ?? "", onChangeLocal];
+  if (!tracked) {
+    return [undefined, onChange] as const;
+  }
+
+  return [
+    typeof fallback !== "undefined" && localValue == null
+      ? fallback
+      : localValue,
+    onChangeLocal,
+  ] as const;
 };


### PR DESCRIPTION
Closes puckeditor/puck#1642

Requires the changes from puckeditor/puck#1757.

## Description

This PR fixes an issue where controlled custom and overridden fields lost their caret position on every edit.

This happened because the value of a custom or overridden field was persisted to the field store only through a subscription to `appStore`. The problem with this approach was that `appStore` was updated only after the data had been resolved, making it an asynchronous operation.

As a result, the value received while typing in the field was always behind the value being displayed. This caused strange visual effects with long-running resolvers and made the field lose its caret position.

## Changes made

* Custom and overridden fields now reuse the same logic as text and text area fields. They keep a local copy of the value and pass it to the override or custom field render function. This ensures that the fields always receive the most recently edited value for display while synchronizing with the store value on blur.
  * They now reuse the `useLocalValue` utility.
  * `useLocalValue` was updated to accept values other than strings.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization for custom and overridden field values, including nested objects and arrays.
  * Prevented stale field renders and ensured change handlers run in the correct order.
  * Improved handling of empty and nullish values in text and default fields.
  * Disabled fields no longer track or update local state unnecessarily.