### PR TITLE
refine outline styles and restore empty state

### DIFF
--- a/packages/core/components/LayerTree/components/empty-zone-placeholder/index.tsx
+++ b/packages/core/components/LayerTree/components/empty-zone-placeholder/index.tsx
@@ -1,4 +1,6 @@
 import getClassNameFactory from "../../../../lib/get-class-name-factory";
+import mergeClassNames from "../../../../lib/merge-class-names";
+import { rootAreaId } from "../../../../lib/root-droppable-id";
 import { useMessage } from "../../../../lib/use-message";
 
 import useOutlineDropZone from "../../lib/dnd/use-outline-drop-zone";
@@ -23,10 +25,15 @@ export const EmptyZonePlaceholder = ({
   });
 
   const noItemsMsg = useMessage("outline-empty");
+  const [parentId] = zoneCompound.split(":");
+  const isRoot = parentId === rootAreaId;
 
   return (
     <li
-      className={getClassName("helper")}
+      className={mergeClassNames(
+        getClassName("helper"),
+        isRoot ? getClassName("helperRoot") : undefined
+      )}
       data-puck-drop-target={isDropTarget || undefined}
       ref={ref}
     >

--- a/packages/core/components/LayerTree/components/empty-zone-placeholder/styles.module.css
+++ b/packages/core/components/LayerTree/components/empty-zone-placeholder/styles.module.css
@@ -8,6 +8,10 @@
   border: var(--_puck-outline-border-width) solid transparent;
 }
 
+.LayerTree-helperRoot {
+  padding-inline-start: var(--puck-space-3);
+}
+
 /* Drag and drop: hosts a DropLine while targeted */
 .LayerTree-helper[data-puck-drop-target] {
   position: relative;

--- a/packages/core/components/LayerTree/components/layer-actions/styles.module.css
+++ b/packages/core/components/LayerTree/components/layer-actions/styles.module.css
@@ -7,11 +7,12 @@
   display: flex;
   visibility: hidden;
   flex-shrink: 0;
-  gap: var(--puck-space-1);
   color: var(--_puck-outline-color-text);
   /* Set to the row's bg by the Layer hover/selected rules so the sticky
      actions cover the text scrolling beneath them */
   background: var(--_puck-outline-actions-color-bg);
+  border-top-right-radius: var(--_puck-outline-radius);
+  border-bottom-right-radius: var(--_puck-outline-radius);
 }
 
 .LayerActions--visible {

--- a/packages/core/components/LayerTree/components/layer/styles.module.css
+++ b/packages/core/components/LayerTree/components/layer/styles.module.css
@@ -121,7 +121,7 @@
   }
 }
 
-.Layer--isSelected {
+.Layer--isSelected > .Layer-inner {
   border-color: var(
     --puck-outline-color-border-selected,
     var(--puck-color-selection-border)

--- a/packages/core/components/LayerTree/index.tsx
+++ b/packages/core/components/LayerTree/index.tsx
@@ -25,23 +25,20 @@ export const LayerTree = ({
     (s) => s.dnd?.disableOutlineDrag ?? false
   );
 
-  const hasItems = trees.length > 0 && trees[0].items.length > 0;
-
   return (
     <OutlineDndProvider>
       <div
         className={getClassNameDragRoot()}
         data-puck-dnd-disabled={disableOutlineDrag || undefined}
       >
-        {hasItems &&
-          trees.map((tree) => (
-            <LayerTreeZone
-              depth={0}
-              key={tree.zoneCompound}
-              selectedId={selectedId}
-              tree={tree}
-            />
-          ))}
+        {trees.map((tree) => (
+          <LayerTreeZone
+            depth={0}
+            key={tree.zoneCompound}
+            selectedId={selectedId}
+            tree={tree}
+          />
+        ))}
       </div>
     </OutlineDndProvider>
   );

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -5,7 +5,7 @@
 
   --_puck-outline-color-text: var(
     --puck-outline-color-text,
-    var(--puck-color-text-secondary)
+    var(--puck-color-text-primary)
   );
   --_puck-outline-border-width: var(
     --puck-outline-border-width,
@@ -63,7 +63,7 @@
   /* Caret slot + the row title's inline margin + one border width: lines
      zone titles and helpers up with row titles at the same depth */
   --_puck-outline-label-indent: calc(
-    var(--_puck-outline-caret-slot) + var(--puck-space-1) +
+    var(--_puck-outline-caret-slot) + var(--puck-space-2) +
       var(--_puck-outline-border-width)
   );
 }

--- a/packages/core/components/Puck/components/Outline/components/outline-header/index.tsx
+++ b/packages/core/components/Puck/components/Outline/components/outline-header/index.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from "react";
 import { getClassNameFactory } from "../../../../../../lib";
 import { useMessage } from "../../../../../../lib/use-message";
+import { Heading } from "../../../../../Heading";
 
 import styles from "./styles.module.css";
 
@@ -22,7 +23,9 @@ const OutlineHeader = ({
 
   return (
     <div className={getClassName()}>
-      <div className={getClassName("title")}>{outlineHeaderMsg ?? title}</div>
+      <Heading rank="2" size="xs">
+        {outlineHeaderMsg ?? title}
+      </Heading>
       {children}
     </div>
   );

--- a/packages/core/components/Puck/components/Outline/components/outline-header/styles.module.css
+++ b/packages/core/components/Puck/components/Outline/components/outline-header/styles.module.css
@@ -8,11 +8,3 @@
   border-bottom: var(--puck-border-width-regular) solid var(--puck-color-border);
   box-sizing: border-box;
 }
-
-.OutlineHeader-title {
-  color: var(--puck-color-text-secondary);
-  font-size: var(--puck-font-size-xs);
-  font-weight: var(--puck-font-weight-regular);
-  line-height: var(--puck-line-height-m);
-  margin: 0;
-}


### PR DESCRIPTION
## Description

This PR aligns the outline panel typography with the sidebar, restores the empty-page message, and refines outline row styling. Root empty states use compact 12px inline padding while nested slot placeholders retain their contextual indentation.

## Changes made

- Render the outline title with the shared sidebar heading component.
- Render empty root zones and distinguish their spacing from nested empty slots.
- Refine outline text color, label spacing, selected borders, and action corners.

## How to test

- Run `yarn workspace @puckeditor/core test --runInBand`.
- Open an empty page and confirm the outline title matches the sidebar title and “No items” appears with 12px inline padding.
- Add and expand a component with an empty slot and confirm its “No items” placeholder keeps the nested indentation.
- Hover and select outline rows to verify the action and border styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty areas in the layer tree now display helpful placeholders, including at the root level.
  * Empty layer-tree sections now render consistently.
  * Selected-layer outlines and action controls display with improved alignment and rounded corners.

* **Style**
  * Improved layer-tree text contrast and indentation.
  * Updated outline header typography for more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->