### PR TITLE
Improve drag and drop for granular changes follow ons

### DIFF
--- a/apps/demo/app/[...puckPath]/client.tsx
+++ b/apps/demo/app/[...puckPath]/client.tsx
@@ -27,6 +27,13 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
   if (!isClient) return null;
 
   const params = new URL(window.location.href).searchParams;
+  const requestedDndBehavior = params.get("dndBehavior");
+  const dndBehavior =
+    requestedDndBehavior === "auto" ||
+    requestedDndBehavior === "fluid" ||
+    requestedDndBehavior === "static"
+      ? requestedDndBehavior
+      : undefined;
 
   if (isEdit) {
     return (
@@ -41,6 +48,9 @@ export function Client({ path, isEdit }: { path: string; isEdit: boolean }) {
           headerPath={path}
           iframe={{
             enabled: params.get("disableIframe") === "true" ? false : true,
+          }}
+          dnd={{
+            behavior: dndBehavior,
           }}
           fieldTransforms={{
             userField: ({ value }) => value, // Included to check types

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -149,7 +149,7 @@ Configure drag-and-drop behavior.
 
 Control animation behavior while dragging. Defaults to `"auto"`.
 
-- `"auto"`: Use fluid behavior within a slot, then switch to a static when dragging an item between slots.
+- `"auto"` (default): Use fluid behavior within a slot, switching to a static line placeholder when dragging an item between slots or inserting a new component.
 - `"fluid"`: Move the item during a drag, animating other items out of the way.
 - `"static"`: Freeze the item in-place during a drag, showing a line placeholder at the drop destination.
 

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -149,7 +149,7 @@ Configure drag-and-drop behavior.
 
 Control animation behavior while dragging. Defaults to `"auto"`.
 
-- `"auto"` (default): Use fluid behavior within a slot, switching to a static line placeholder when dragging an item between slots or inserting a new component.
+- `"auto"` (default): Use fluid behavior within a slot, then switch to static behavior when dragging an item between slots or inserting a new component.
 - `"fluid"`: Move the item during a drag, animating other items out of the way.
 - `"static"`: Freeze the item in-place during a drag, showing a line placeholder at the drop destination.
 

--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -139,10 +139,19 @@ Configure drag-and-drop behavior.
 
 #### dnd params
 
-| Param                                       | Example                    | Type    | Status |
-| ------------------------------------------- | -------------------------- | ------- | ------ |
-| [`disableAutoScroll`](#disableautoscroll)   | `disableAutoScroll: true`  | boolean | -      |
-| [`disableOutlineDrag`](#disableoutlinedrag) | `disableOutlineDrag: true` | boolean | -      |
+| Param                                       | Example                    | Type                            | Status |
+| ------------------------------------------- | -------------------------- | ------------------------------- | ------ |
+| [`behavior`](#behavior)                     | `behavior: "static"`       | `"auto" \| "fluid" \| "static"` | -      |
+| [`disableAutoScroll`](#disableautoscroll)   | `disableAutoScroll: true`  | boolean                         | -      |
+| [`disableOutlineDrag`](#disableoutlinedrag) | `disableOutlineDrag: true` | boolean                         | -      |
+
+##### `behavior`
+
+Control animation behavior while dragging. Defaults to `"auto"`.
+
+- `"auto"`: Use fluid behavior within a slot, then switch to a static when dragging an item between slots.
+- `"fluid"`: Move the item during a drag, animating other items out of the way.
+- `"static"`: Freeze the item in-place during a drag, showing a line placeholder at the drop destination.
 
 ##### `disableAutoScroll`
 

--- a/apps/docs/pages/docs/api-reference/theming/global.mdx
+++ b/apps/docs/pages/docs/api-reference/theming/global.mdx
@@ -40,7 +40,7 @@ CSS properties for theming the entire Puck user interface.
 | `--puck-color-focus-ring`                 | <Color>#3479be</Color>                                      | Keyboard focus outlines                             |
 | `--puck-color-selection-bg`               | <Color>color-mix(in srgb, #cfdff0 30%, transparent)</Color> | Slot, drop zone and selected overlay background     |
 | `--puck-color-selection-border`           | <Color>#abc7e5</Color>                                      | Selected and drop zone outline borders              |
-| `--puck-color-insertion-indicator`        | <Color>#6499cf</Color>                                      | Drag-and-drop insertion line in the outline         |
+| `--puck-color-line-placeholder`           | <Color>#6499cf</Color>                                      | Drag-and-drop insertion line                        |
 | `--puck-color-highlight`                  | <Color>#d89aba</Color>                                      | Accent color scale step, not currently consumed     |
 | `--puck-color-bg-disabled`                | <Color>#ababab</Color>                                      | Disabled button background                          |
 | `--puck-color-text-disabled`              | <Color>#404040</Color>                                      | Disabled button text                                |

--- a/apps/docs/pages/docs/api-reference/theming/global.mdx
+++ b/apps/docs/pages/docs/api-reference/theming/global.mdx
@@ -121,8 +121,9 @@ CSS properties for theming the entire Puck user interface.
 
 ## Functional
 
-| Token                             | Default                    | Used for                              |
-| --------------------------------- | -------------------------- | ------------------------------------- |
-| `--puck-slot-min-empty-height`    | `128px`                    | Minimum height of empty slots         |
-| `--puck-user-sidebar-left-width`  | `186px–320px (responsive)` | User override for left sidebar width  |
-| `--puck-user-sidebar-right-width` | `186px–320px (responsive)` | User override for right sidebar width |
+| Token                             | Default                    | Used for                                                    |
+| --------------------------------- | -------------------------- | ----------------------------------------------------------- |
+| `--puck-slot-min-empty-height`    | `128px`                    | Minimum height of empty slots                               |
+| `--puck-line-placeholder-width`   | `2px`                      | Drag-and-drop insertion line thickness (canvas and outline) |
+| `--puck-user-sidebar-left-width`  | `186px–320px (responsive)` | User override for left sidebar width                        |
+| `--puck-user-sidebar-right-width` | `186px–320px (responsive)` | User override for right sidebar width                       |

--- a/apps/docs/pages/docs/api-reference/theming/outline.mdx
+++ b/apps/docs/pages/docs/api-reference/theming/outline.mdx
@@ -57,7 +57,7 @@ Defaults shown as `var(--puck-...)` reference [global tokens](/docs/api-referenc
 | `--puck-outline-color-border-hover`    | `var(--puck-color-interactive-subtle)`   | Layer border color on hover              |
 | `--puck-outline-color-bg-selected`     | `var(--puck-color-interactive-subtle)`   | Selected layer background                |
 | `--puck-outline-color-border-selected` | `var(--puck-color-selection-border)`     | Selected layer border color              |
-| `--puck-outline-color-drop-indicator`  | `var(--puck-color-insertion-indicator)`  | Drag-and-drop line indicator color       |
+| `--puck-outline-color-drop-indicator`  | `var(--puck-color-line-placeholder)`     | Drag-and-drop line indicator color       |
 | `--puck-outline-border-width`          | `var(--puck-border-width-regular)`       | Layer border width                       |
 | `--puck-outline-radius`                | `var(--puck-radius-m)`                   | Layer border radius                      |
 | `--puck-outline-font-size`             | `var(--puck-font-size-xxxs)`             | Layer label font size                    |

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -25,6 +25,11 @@ import {
   ZoneStoreProvider,
 } from "../DropZone/context";
 import { createNestedDroppablePlugin } from "../../lib/dnd/NestedDroppablePlugin";
+import { prepareCommitFlip } from "../../lib/dnd/flip-commit";
+import {
+  resolveDndMode,
+  resolveOriginPreviewIndex,
+} from "../../lib/dnd/resolve-dnd-mode";
 import { insertComponent } from "../../lib/insert-component";
 import { moveComponent } from "../../lib/move-component";
 import { useDebouncedCallback } from "use-debounce";
@@ -41,6 +46,8 @@ import {
 import { useSensors } from "../../lib/dnd/use-sensors";
 import { getFrame } from "../../lib/get-frame";
 import { effect } from "@dnd-kit/state";
+import type { DndBehavior } from "../../types";
+import { useLinePlaceholder } from "./use-line-placeholder";
 
 const DEBUG = false;
 
@@ -83,6 +90,7 @@ const AREA_CHANGE_DEBOUNCE_MS = 100;
 type DragDropContextProps = {
   children: ReactNode;
   disableAutoScroll?: boolean;
+  behavior?: DndBehavior;
 };
 
 /**
@@ -114,6 +122,7 @@ const useTempDisableFallback = (timeout: number) => {
 const DragDropContextClient = ({
   children,
   disableAutoScroll,
+  behavior = "auto",
 }: DragDropContextProps) => {
   const dispatch = useAppStore((s) => s.dispatch);
   const instanceId = useAppStore((s) => s.instanceId);
@@ -315,6 +324,14 @@ const DragDropContextClient = ({
 
   const initialSelector = useRef<{ zone: string; index: number }>(undefined);
 
+  const {
+    getTargetIndex: getLinePlaceholderTargetIndex,
+    setActive: setLinePlaceholderActive,
+    startScrollTracking: startLinePlaceholderScrollTracking,
+    stopScrollTracking: stopLinePlaceholderScrollTracking,
+    update: updateLinePlaceholder,
+  } = useLinePlaceholder(zoneStore);
+
   const nextContextValue = useMemo<DropZoneContext>(
     () => ({
       mode: "edit",
@@ -335,12 +352,15 @@ const DragDropContextClient = ({
         plugins={plugins}
         sensors={sensors}
         onDragEnd={(event, manager) => {
+          stopLinePlaceholderScrollTracking();
+
           const entryEl = getFrame()?.querySelector("[data-puck-entry]");
           entryEl?.removeAttribute("data-puck-dragging");
 
           const { source, target } = event.operation;
 
           if (!source) {
+            setLinePlaceholderActive(false);
             zoneStore.setState({ draggedItem: null });
 
             return;
@@ -350,12 +370,40 @@ const DragDropContextClient = ({
 
           const { previewIndex = {} } = zoneStore.getState() || {};
 
+          // Look the preview up by id: during line placeholder (cross-zone)
+          // drags the source stays in its original zone, so the preview key
+          // no longer matches the source's zone. Ghost previews only pin the
+          // item visually and never describe the drop position.
           const thisPreview: Preview | null =
-            previewIndex[zone]?.props.id === source.id
-              ? previewIndex[zone]
+            Object.values(previewIndex).find(
+              (preview) => preview?.props.id === source.id && !preview.ghost
+            ) ?? null;
+
+          // Capture sibling positions now, before dnd-kit tears the drag
+          // state down, so the slide animations measure from what's on
+          // screen at the moment of drop
+          const playCommitFlip =
+            !event.canceled &&
+            target?.type !== "void" &&
+            thisPreview?.linePlaceholder
+              ? prepareCommitFlip({
+                  zones: initialSelector.current
+                    ? [initialSelector.current.zone, thisPreview.zone]
+                    : [thisPreview.zone],
+                  itemId:
+                    thisPreview.type === "move"
+                      ? thisPreview.props.id
+                      : undefined,
+                  targetZone: thisPreview.zone,
+                  getExpectedOrder: () =>
+                    appStore.getState().state.indexes.zones[thisPreview.zone]
+                      ?.contentIds ?? [],
+                })
               : null;
 
           const onAnimationEnd = () => {
+            // Keep the ghost faded until the drop animation lands
+            setLinePlaceholderActive(false);
             zoneStore.setState({ draggedItem: null });
 
             // Tidy up cancellation
@@ -377,6 +425,18 @@ const DragDropContextClient = ({
               return;
             }
 
+            // Line placeholder indices count the dragged item at its
+            // original position, so moving to a later gap within the same
+            // zone lands one index lower once the item is removed
+            const commitIndex =
+              thisPreview &&
+              thisPreview.linePlaceholder &&
+              initialSelector.current &&
+              thisPreview.zone === initialSelector.current.zone &&
+              thisPreview.index > initialSelector.current.index
+                ? thisPreview.index - 1
+                : thisPreview?.index ?? index;
+
             // Finalise the drag
             if (thisPreview) {
               zoneStore.setState({ previewIndex: {} });
@@ -392,20 +452,24 @@ const DragDropContextClient = ({
                 moveComponent(
                   thisPreview.props.id,
                   initialSelector.current,
-                  thisPreview,
+                  { ...thisPreview, index: commitIndex },
                   appStore
                 );
               }
+
+              playCommitFlip?.();
             }
 
             const movedToNewPosition =
               initialSelector.current?.zone !== thisPreview?.zone ||
-              initialSelector.current?.index !== thisPreview?.index;
+              initialSelector.current?.index !== commitIndex;
 
             dispatch({
               type: "setUi",
               ui: {
-                itemSelector: { index, zone },
+                itemSelector: thisPreview
+                  ? { index: commitIndex, zone: thisPreview.zone }
+                  : { index, zone },
                 isDragging: false,
               },
               recordHistory: movedToNewPosition,
@@ -424,6 +488,16 @@ const DragDropContextClient = ({
               onAnimationEnd();
               dispose?.();
             }
+          });
+        }}
+        onDragMove={(event, manager) => {
+          // Keep the line in the gap nearest the pointer as it moves within
+          // the target zone: collisions only re-fire when the target
+          // changes, which can leave the line in a stale gap
+          updateLinePlaceholder(manager);
+
+          dragListeners.dragmove?.forEach((fn) => {
+            fn(event, manager);
           });
         }}
         onDragOver={(event, manager) => {
@@ -489,6 +563,17 @@ const DragDropContextClient = ({
           }
 
           if (dragMode.current === "new") {
+            const useLinePlaceholder =
+              resolveDndMode(behavior, { isNewComponent: true }) === "static";
+
+            if (useLinePlaceholder) {
+              targetIndex =
+                getLinePlaceholderTargetIndex(targetZone, manager) ??
+                targetIndex;
+            }
+
+            setLinePlaceholderActive(useLinePlaceholder);
+
             zoneStore.setState({
               previewIndex: {
                 [targetZone]: {
@@ -500,6 +585,7 @@ const DragDropContextClient = ({
                   props: {
                     id: source.id.toString(),
                   },
+                  linePlaceholder: useLinePlaceholder,
                 },
               },
             });
@@ -517,18 +603,56 @@ const DragDropContextClient = ({
             );
 
             if (item) {
-              zoneStore.setState({
-                previewIndex: {
-                  [targetZone]: {
-                    componentType: sourceData.componentType,
-                    type: "move",
-                    index: targetIndex,
-                    zone: targetZone,
-                    props: item.props,
-                    element: source.element,
-                  },
+              const originZone = initialSelector.current.zone;
+              const isReparenting = originZone !== targetZone;
+              const useLinePlaceholder =
+                resolveDndMode(behavior, {
+                  isDraggingBetweenSlots: isReparenting,
+                }) === "static";
+
+              if (useLinePlaceholder) {
+                targetIndex =
+                  getLinePlaceholderTargetIndex(targetZone, manager) ??
+                  targetIndex;
+              }
+
+              setLinePlaceholderActive(useLinePlaceholder);
+
+              const previewIndex: Record<string, Preview> = {
+                [targetZone]: {
+                  componentType: sourceData.componentType,
+                  type: "move",
+                  index: targetIndex,
+                  zone: targetZone,
+                  props: item.props,
+                  element: source.element,
+                  linePlaceholder: useLinePlaceholder,
                 },
-              });
+              };
+
+              if (useLinePlaceholder && isReparenting) {
+                // Pin the item at its rendered position in the original zone.
+                // Fluid previews render at their latest index, while static
+                // previews leave the item at its initial index.
+                const originPreview =
+                  zoneStore.getState().previewIndex[originZone];
+                const originIndex = resolveOriginPreviewIndex(
+                  initialSelector.current.index,
+                  originPreview
+                );
+
+                previewIndex[originZone] = {
+                  componentType: sourceData.componentType,
+                  type: "move",
+                  index: originIndex,
+                  zone: originZone,
+                  props: item.props,
+                  element: source.element,
+                  ghost: true,
+                };
+              }
+
+              zoneStore.setState({ previewIndex });
             }
           }
 
@@ -537,20 +661,29 @@ const DragDropContextClient = ({
           });
         }}
         onDragStart={(event, manager) => {
+          // Scrolling moves the content under a stationary pointer without
+          // firing drag events, which would leave the line placeholder
+          // drifting with the page; recompute it on scroll.
+          startLinePlaceholderScrollTracking(manager);
+
           const { source } = event.operation;
 
-          if (source && source.type !== "void") {
+          if (source?.type === "component") {
             const sourceData = source.data as ComponentDndData;
+            const sourceSelector = {
+              zone: sourceData.zone,
+              index: sourceData.index,
+            };
 
-            const item = getItem(
-              {
-                zone: sourceData.zone,
-                index: sourceData.index,
-              },
-              appStore.getState().state
-            );
+            initialSelector.current = sourceSelector;
+
+            const item = getItem(sourceSelector, appStore.getState().state);
 
             if (item) {
+              const useLinePlaceholder = resolveDndMode(behavior) === "static";
+
+              setLinePlaceholderActive(useLinePlaceholder);
+
               zoneStore.setState({
                 previewIndex: {
                   [sourceData.zone]: {
@@ -560,6 +693,7 @@ const DragDropContextClient = ({
                     zone: sourceData.zone,
                     props: item.props,
                     element: source.element,
+                    linePlaceholder: useLinePlaceholder,
                   },
                 },
               });
@@ -601,6 +735,7 @@ const DragDropContextClient = ({
           }
 
           const entryEl = getFrame()?.querySelector("[data-puck-entry]");
+          setLinePlaceholderActive(false);
           entryEl?.setAttribute("data-puck-dragging", "true");
         }}
       >
@@ -617,6 +752,7 @@ const DragDropContextClient = ({
 export const DragDropContext = ({
   children,
   disableAutoScroll,
+  behavior,
 }: DragDropContextProps) => {
   const status = useAppStore((s) => s.status);
 
@@ -625,7 +761,10 @@ export const DragDropContext = ({
   }
 
   return (
-    <DragDropContextClient disableAutoScroll={disableAutoScroll}>
+    <DragDropContextClient
+      disableAutoScroll={disableAutoScroll}
+      behavior={behavior}
+    >
       {children}
     </DragDropContextClient>
   );

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -26,10 +26,9 @@ import {
 } from "../DropZone/context";
 import { createNestedDroppablePlugin } from "../../lib/dnd/NestedDroppablePlugin";
 import { prepareCommitFlip } from "../../lib/dnd/flip-commit";
-import {
-  resolveDndMode,
-  resolveOriginPreviewIndex,
-} from "../../lib/dnd/resolve-dnd-mode";
+import { resolveDndMode } from "../../lib/dnd/resolve-dnd-mode";
+import { getZoneContentIds } from "../../lib/get-zone-content-ids";
+import { getComponentSelector } from "../../lib/dom-selectors";
 import { insertComponent } from "../../lib/insert-component";
 import { moveComponent } from "../../lib/move-component";
 import { useDebouncedCallback } from "use-debounce";
@@ -168,7 +167,7 @@ const DragDropContextClient = ({
           }
         } else {
           const frame = getFrame();
-          const el = frame?.querySelector(`[data-puck-component="${id}"]`);
+          const el = frame?.querySelector(getComponentSelector(id));
           el?.scrollIntoView({ behavior: "smooth" });
         }
       },
@@ -396,8 +395,10 @@ const DragDropContextClient = ({
                       : undefined,
                   targetZone: thisPreview.zone,
                   getExpectedOrder: () =>
-                    appStore.getState().state.indexes.zones[thisPreview.zone]
-                      ?.contentIds ?? [],
+                    getZoneContentIds(
+                      appStore.getState().state,
+                      thisPreview.zone
+                    ),
                 })
               : null;
 
@@ -534,11 +535,13 @@ const DragDropContextClient = ({
 
             const collisionData = manager.collisionObserver.collisions[0]?.data;
 
+            const position = getCollisionPosition(
+              collisionData?.direction,
+              getDeepDir(target.element)
+            );
+
             targetIndex = getInsertIndex({
-              position: getCollisionPosition(
-                collisionData?.direction,
-                getDeepDir(target.element)
-              ),
+              position,
               sourceIndex,
               targetIndex: targetData.index,
               isSameZone: sourceZone === targetZone,
@@ -563,16 +566,16 @@ const DragDropContextClient = ({
           }
 
           if (dragMode.current === "new") {
-            const useLinePlaceholder =
+            const isLinePlaceholder =
               resolveDndMode(behavior, { isNewComponent: true }) === "static";
 
-            if (useLinePlaceholder) {
+            if (isLinePlaceholder) {
               targetIndex =
                 getLinePlaceholderTargetIndex(targetZone, manager) ??
                 targetIndex;
             }
 
-            setLinePlaceholderActive(useLinePlaceholder);
+            setLinePlaceholderActive(isLinePlaceholder);
 
             zoneStore.setState({
               previewIndex: {
@@ -585,7 +588,7 @@ const DragDropContextClient = ({
                   props: {
                     id: source.id.toString(),
                   },
-                  linePlaceholder: useLinePlaceholder,
+                  linePlaceholder: isLinePlaceholder,
                 },
               },
             });
@@ -605,18 +608,18 @@ const DragDropContextClient = ({
             if (item) {
               const originZone = initialSelector.current.zone;
               const isReparenting = originZone !== targetZone;
-              const useLinePlaceholder =
+              const isLinePlaceholder =
                 resolveDndMode(behavior, {
                   isDraggingBetweenSlots: isReparenting,
                 }) === "static";
 
-              if (useLinePlaceholder) {
+              if (isLinePlaceholder) {
                 targetIndex =
                   getLinePlaceholderTargetIndex(targetZone, manager) ??
                   targetIndex;
               }
 
-              setLinePlaceholderActive(useLinePlaceholder);
+              setLinePlaceholderActive(isLinePlaceholder);
 
               const previewIndex: Record<string, Preview> = {
                 [targetZone]: {
@@ -626,20 +629,23 @@ const DragDropContextClient = ({
                   zone: targetZone,
                   props: item.props,
                   element: source.element,
-                  linePlaceholder: useLinePlaceholder,
+                  linePlaceholder: isLinePlaceholder,
                 },
               };
 
-              if (useLinePlaceholder && isReparenting) {
-                // Pin the item at its rendered position in the original zone.
-                // Fluid previews render at their latest index, while static
-                // previews leave the item at its initial index.
+              // If line, pin the item as a ghost at its currently rendered position in the original zone.
+              if (isLinePlaceholder && isReparenting) {
                 const originPreview =
                   zoneStore.getState().previewIndex[originZone];
-                const originIndex = resolveOriginPreviewIndex(
-                  initialSelector.current.index,
-                  originPreview
-                );
+
+                // Assume we were in static mode. Preview didn't move the item.
+                let originIndex = initialSelector.current.index;
+
+                // Current preview isn't line placeholder. We were in fluid mode.
+                // Preview moved the item to its latest index. Pin the ghost preview there.
+                if (originPreview && !originPreview.linePlaceholder) {
+                  originIndex = originPreview.index;
+                }
 
                 previewIndex[originZone] = {
                   componentType: sourceData.componentType,
@@ -661,10 +667,12 @@ const DragDropContextClient = ({
           });
         }}
         onDragStart={(event, manager) => {
-          // Scrolling moves the content under a stationary pointer without
-          // firing drag events, which would leave the line placeholder
-          // drifting with the page; recompute it on scroll.
-          startLinePlaceholderScrollTracking(manager);
+          if (behavior !== "fluid") {
+            // Scrolling moves the content under a stationary pointer without
+            // firing drag events, which would leave the line placeholder
+            // drifting with the page; recompute it on scroll.
+            startLinePlaceholderScrollTracking(manager);
+          }
 
           const { source } = event.operation;
 
@@ -680,9 +688,9 @@ const DragDropContextClient = ({
             const item = getItem(sourceSelector, appStore.getState().state);
 
             if (item) {
-              const useLinePlaceholder = resolveDndMode(behavior) === "static";
+              const showLinePlaceholder = resolveDndMode(behavior) === "static";
 
-              setLinePlaceholderActive(useLinePlaceholder);
+              setLinePlaceholderActive(showLinePlaceholder);
 
               zoneStore.setState({
                 previewIndex: {
@@ -693,7 +701,7 @@ const DragDropContextClient = ({
                     zone: sourceData.zone,
                     props: item.props,
                     element: source.element,
-                    linePlaceholder: useLinePlaceholder,
+                    linePlaceholder: showLinePlaceholder,
                   },
                 },
               });
@@ -735,8 +743,8 @@ const DragDropContextClient = ({
           }
 
           const entryEl = getFrame()?.querySelector("[data-puck-entry]");
-          setLinePlaceholderActive(false);
           entryEl?.setAttribute("data-puck-dragging", "true");
+          setLinePlaceholderActive(false);
         }}
       >
         <ZoneStoreProvider store={zoneStore}>

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -608,24 +608,15 @@ const DragDropContextClient = ({
             if (item) {
               const originZone = initialSelector.current.zone;
               const isReparenting = originZone !== targetZone;
-              let isLinePlaceholder =
+              const isLinePlaceholder =
                 resolveDndMode(behavior, {
                   isDraggingBetweenSlots: isReparenting,
                 }) === "static";
 
               if (isLinePlaceholder) {
-                const linePreviewIndex = getLinePlaceholderTargetIndex(
-                  targetZone,
-                  manager
-                );
-
-                if (linePreviewIndex !== null) {
-                  targetIndex = linePreviewIndex;
-                } else {
-                  // No gap resolved: keep the fluid `targetIndex` and drop the
-                  // line flag so onDragEnd does not offset it a second time.
-                  isLinePlaceholder = false;
-                }
+                targetIndex =
+                  getLinePlaceholderTargetIndex(targetZone, manager) ??
+                  targetIndex;
               }
 
               setLinePlaceholderActive(isLinePlaceholder);

--- a/packages/core/components/DragDropContext/index.tsx
+++ b/packages/core/components/DragDropContext/index.tsx
@@ -608,15 +608,24 @@ const DragDropContextClient = ({
             if (item) {
               const originZone = initialSelector.current.zone;
               const isReparenting = originZone !== targetZone;
-              const isLinePlaceholder =
+              let isLinePlaceholder =
                 resolveDndMode(behavior, {
                   isDraggingBetweenSlots: isReparenting,
                 }) === "static";
 
               if (isLinePlaceholder) {
-                targetIndex =
-                  getLinePlaceholderTargetIndex(targetZone, manager) ??
-                  targetIndex;
+                const linePreviewIndex = getLinePlaceholderTargetIndex(
+                  targetZone,
+                  manager
+                );
+
+                if (linePreviewIndex !== null) {
+                  targetIndex = linePreviewIndex;
+                } else {
+                  // No gap resolved: keep the fluid `targetIndex` and drop the
+                  // line flag so onDragEnd does not offset it a second time.
+                  isLinePlaceholder = false;
+                }
               }
 
               setLinePlaceholderActive(isLinePlaceholder);

--- a/packages/core/components/DragDropContext/use-drop-animation.ts
+++ b/packages/core/components/DragDropContext/use-drop-animation.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import type { StoreApi } from "zustand";
+import type { DropAnimationFunction } from "@dnd-kit/dom";
+import { runDropAnimation } from "../../lib/dnd/drop-animation";
+import { getZoneContentIds } from "../../lib/get-zone-content-ids";
+import { useAppStoreApi } from "../../store";
+import type { ZoneStore } from "../DropZone/context";
+
+/**
+ * Builds the "glide" drop animation callback for components in the canvas/drawer.
+ * 
+ * @param zoneStore - The store for the drop zone where the item is being dropped.
+ * @param id - The ID of the item being dropped. Provide it if using within created components.
+ * @returns A function that can be used as the drop animation callback.
+ */
+export const useDropAnimation = (
+  zoneStore: StoreApi<ZoneStore>,
+  id?: string
+): DropAnimationFunction => {
+  const appStore = useAppStoreApi();
+
+  return useCallback(
+    (context) => {
+      const previews = Object.values(zoneStore.getState().previewIndex ?? {});
+      const preview = id
+        ? previews.find((entry) => entry?.props.id === id && !entry.ghost)
+        : previews.find((entry) => entry?.type === "insert");
+
+      const shouldGlide = id
+        ? preview?.linePlaceholder || preview?.type === "insert"
+        : !!preview;
+
+      return runDropAnimation(
+        context,
+        preview && shouldGlide
+          ? {
+              itemId: preview.type === "move" ? id : undefined,
+              targetZone: preview.zone,
+              getExpectedOrder: () =>
+                getZoneContentIds(appStore.getState().state, preview.zone),
+            }
+          : undefined
+      );
+    },
+    [appStore, zoneStore, id]
+  );
+};

--- a/packages/core/components/DragDropContext/use-drop-animation.ts
+++ b/packages/core/components/DragDropContext/use-drop-animation.ts
@@ -8,7 +8,7 @@ import type { ZoneStore } from "../DropZone/context";
 
 /**
  * Builds the "glide" drop animation callback for components in the canvas/drawer.
- * 
+ *
  * @param zoneStore - The store for the drop zone where the item is being dropped.
  * @param id - The ID of the item being dropped. Provide it if using within created components.
  * @returns A function that can be used as the drop animation callback.

--- a/packages/core/components/DragDropContext/use-line-placeholder.ts
+++ b/packages/core/components/DragDropContext/use-line-placeholder.ts
@@ -1,0 +1,148 @@
+import type { DragDropManager } from "@dnd-kit/dom";
+import { useCallback, useEffect, useRef } from "react";
+import type { StoreApi } from "zustand";
+import { getFrame } from "../../lib/get-frame";
+import { getFramePointer, getNearestGapIndex } from "../../lib/dnd/nearest-gap";
+import { useAppStoreApi } from "../../store";
+import type { ZoneStore } from "../DropZone/context";
+
+const getTargetIndex = (
+  zoneEl: Element,
+  manager: DragDropManager,
+  contentIds: string[]
+) =>
+  getNearestGapIndex(
+    zoneEl,
+    getFramePointer(zoneEl, manager.dragOperation.position.current),
+    contentIds
+  );
+
+/** Owns the DOM state, pointer tracking and scroll handling for line drags. */
+export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
+  const appStore = useAppStoreApi();
+  const scrollCleanup = useRef<(() => void) | null>(null);
+
+  const setActive = useCallback((active: boolean) => {
+    const entryEl = getFrame()?.querySelector("[data-puck-entry]");
+
+    if (active) {
+      entryEl?.setAttribute("data-puck-line-drag", "true");
+    } else {
+      entryEl?.removeAttribute("data-puck-line-drag");
+    }
+  }, []);
+
+  const getTargetIndexForZone = useCallback(
+    (zone: string, manager: DragDropManager) => {
+      const zoneEl = getFrame()?.querySelector(
+        `[data-puck-dropzone="${zone}"]`
+      );
+
+      if (!zoneEl) return null;
+
+      return getTargetIndex(
+        zoneEl,
+        manager,
+        appStore.getState().state.indexes.zones[zone]?.contentIds ?? []
+      );
+    },
+    [appStore]
+  );
+
+  const update = useCallback(
+    (manager: DragDropManager) => {
+      const { previewIndex = {} } = zoneStore.getState();
+      const linePreview = Object.values(previewIndex).find(
+        (preview) => preview?.linePlaceholder
+      );
+
+      if (!linePreview) return;
+
+      const zoneEl = getFrame()?.querySelector(
+        `[data-puck-dropzone="${linePreview.zone}"]`
+      );
+
+      if (!zoneEl) return;
+
+      const pointer = getFramePointer(
+        zoneEl,
+        manager.dragOperation.position.current
+      );
+      const zoneRect = zoneEl.getBoundingClientRect();
+      const insideZone =
+        pointer.x >= zoneRect.left &&
+        pointer.x <= zoneRect.right &&
+        pointer.y >= zoneRect.top &&
+        pointer.y <= zoneRect.bottom;
+
+      if (!insideZone) return;
+
+      const nearestIndex = getNearestGapIndex(
+        zoneEl,
+        pointer,
+        appStore.getState().state.indexes.zones[linePreview.zone]?.contentIds ??
+          []
+      );
+
+      if (nearestIndex !== null && nearestIndex !== linePreview.index) {
+        zoneStore.setState({
+          previewIndex: {
+            ...previewIndex,
+            [linePreview.zone]: { ...linePreview, index: nearestIndex },
+          },
+        });
+      }
+    },
+    [appStore, zoneStore]
+  );
+
+  const stopScrollTracking = useCallback(() => {
+    scrollCleanup.current?.();
+    scrollCleanup.current = null;
+  }, []);
+
+  const startScrollTracking = useCallback(
+    (manager: DragDropManager) => {
+      stopScrollTracking();
+
+      const frameDoc = getFrame();
+
+      if (!frameDoc) return;
+
+      let raf: number | null = null;
+
+      const handleScroll = () => {
+        if (raf !== null) return;
+
+        raf = requestAnimationFrame(() => {
+          raf = null;
+          update(manager);
+        });
+      };
+
+      frameDoc.addEventListener("scroll", handleScroll, {
+        capture: true,
+        passive: true,
+      });
+
+      scrollCleanup.current = () => {
+        if (raf !== null) cancelAnimationFrame(raf);
+
+        frameDoc.removeEventListener("scroll", handleScroll, {
+          capture: true,
+        });
+      };
+    },
+    [stopScrollTracking, update]
+  );
+
+  useEffect(() => stopScrollTracking, [stopScrollTracking]);
+
+  return {
+    getTargetIndex: getTargetIndexForZone,
+    setActive,
+    startScrollTracking,
+    stopScrollTracking,
+    update,
+  };
+};

--- a/packages/core/components/DragDropContext/use-line-placeholder.ts
+++ b/packages/core/components/DragDropContext/use-line-placeholder.ts
@@ -51,7 +51,9 @@ export type UseLinePlaceholderApi = {
  * @param zoneStore The Zustand store for managing dnd.
  * @returns An object with methods to manage the line placeholder.
  */
-export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>): UseLinePlaceholderApi => {
+export const useLinePlaceholder = (
+  zoneStore: StoreApi<ZoneStore>
+): UseLinePlaceholderApi => {
   const appStore = useAppStoreApi();
   const scrollCleanup = useRef<(() => void) | null>(null);
 

--- a/packages/core/components/DragDropContext/use-line-placeholder.ts
+++ b/packages/core/components/DragDropContext/use-line-placeholder.ts
@@ -2,23 +2,56 @@ import type { DragDropManager } from "@dnd-kit/dom";
 import { useCallback, useEffect, useRef } from "react";
 import type { StoreApi } from "zustand";
 import { getFrame } from "../../lib/get-frame";
-import { getFramePointer, getNearestGapIndex } from "../../lib/dnd/nearest-gap";
+import { getNearestGapIndex } from "../../lib/dnd/nearest-gap";
+import { getFramePointer } from "../../lib/dnd/frame-pointer";
+import { getZoneContentIds } from "../../lib/get-zone-content-ids";
+import { getZoneSelector } from "../../lib/dom-selectors";
 import { useAppStoreApi } from "../../store";
 import type { ZoneStore } from "../DropZone/context";
 
-const getTargetIndex = (
-  zoneEl: Element,
-  manager: DragDropManager,
-  contentIds: string[]
-) =>
-  getNearestGapIndex(
-    zoneEl,
-    getFramePointer(zoneEl, manager.dragOperation.position.current),
-    contentIds
-  );
+export type UseLinePlaceholderApi = {
+  /**
+   * Gets the closest target index for a given drop zone based on the cursor position.
+   *
+   * @param zone The ID of the drop zone to get the target index for.
+   * @param manager The drag drop manager instance from dnd-kit.
+   * @returns The index of the nearest gap within the zone, or null if not applicable.
+   */
+  getTargetIndex: (zone: string, manager: DragDropManager) => number | null;
+  /**
+   * Sets the active state of the line placeholder in the editor.
+   *
+   * @param active True if the line placeholder should be active. False otherwise.
+   */
+  setActive: (active: boolean) => void;
+  /**
+   * Tracks scroll events and updates the line placeholder position during drag operations.
+   *
+   * This is needed because dragging while scrolling happens with a fixed cursor position.
+   * If not used, the line placeholder could be positioned incorrectly.
+   *
+   * @param manager The drag drop manager instance from dnd-kit.
+   */
+  startScrollTracking: (manager: DragDropManager) => void;
+  /**
+   * Stops updating the line placeholder position during drag operations.
+   */
+  stopScrollTracking: () => void;
+  /**
+   * Updates the line placeholder position based on the current cursor position.
+   *
+   * @param manager The drag drop manager instance from dnd-kit.
+   */
+  update: (manager: DragDropManager) => void;
+};
 
-/** Owns the DOM state, pointer tracking and scroll handling for line drags. */
-export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
+/**
+ * A hook to manage the line placeholder for drop zones during drag operations.
+ *
+ * @param zoneStore The Zustand store for managing dnd.
+ * @returns An object with methods to manage the line placeholder.
+ */
+export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>): UseLinePlaceholderApi => {
   const appStore = useAppStoreApi();
   const scrollCleanup = useRef<(() => void) | null>(null);
 
@@ -34,23 +67,25 @@ export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
 
   const getTargetIndexForZone = useCallback(
     (zone: string, manager: DragDropManager) => {
-      const zoneEl = getFrame()?.querySelector(
-        `[data-puck-dropzone="${zone}"]`
-      );
+      const zoneEl = getFrame()?.querySelector(getZoneSelector(zone));
 
       if (!zoneEl) return null;
 
-      return getTargetIndex(
+      const pointerPosition = getFramePointer(
         zoneEl,
-        manager,
-        appStore.getState().state.indexes.zones[zone]?.contentIds ?? []
+        manager.dragOperation.position.current
       );
+
+      const zoneContentIds = getZoneContentIds(appStore.getState().state, zone);
+
+      return getNearestGapIndex(zoneEl, pointerPosition, zoneContentIds);
     },
     [appStore]
   );
 
   const update = useCallback(
     (manager: DragDropManager) => {
+      // Find the first zone with a line placeholder
       const { previewIndex = {} } = zoneStore.getState();
       const linePreview = Object.values(previewIndex).find(
         (preview) => preview?.linePlaceholder
@@ -58,8 +93,10 @@ export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
 
       if (!linePreview) return;
 
+      // Find the zone element for the line placeholder
+      // and check if the pointer is inside it.
       const zoneEl = getFrame()?.querySelector(
-        `[data-puck-dropzone="${linePreview.zone}"]`
+        getZoneSelector(linePreview.zone)
       );
 
       if (!zoneEl) return;
@@ -77,11 +114,11 @@ export const useLinePlaceholder = (zoneStore: StoreApi<ZoneStore>) => {
 
       if (!insideZone) return;
 
+      // Get the placeholder index for the current pointer position and update it
       const nearestIndex = getNearestGapIndex(
         zoneEl,
         pointer,
-        appStore.getState().state.indexes.zones[linePreview.zone]?.contentIds ??
-          []
+        getZoneContentIds(appStore.getState().state, linePreview.zone)
       );
 
       if (nearestIndex !== null && nearestIndex !== linePreview.index) {

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -26,7 +26,7 @@ import { dropZoneContext, DropZoneProvider } from "../DropZone";
 import { createDynamicCollisionDetector } from "../../lib/dnd/collision/dynamic";
 import { DragAxis } from "../../types";
 import { UniqueIdentifier } from "@dnd-kit/abstract";
-import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
+import { Feedback } from "@dnd-kit/dom";
 import { getDeepScrollPosition } from "../../lib/get-deep-scroll-position";
 import { DropZoneContext, ZoneStoreContext } from "../DropZone/context";
 import { useShallow } from "zustand/react/shallow";
@@ -34,7 +34,7 @@ import { getItem } from "../../lib/data/get-item";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useContextStore } from "../../lib/use-context-store";
 import { useOnDragFinished } from "../../lib/dnd/use-on-drag-finished";
-import { runDropAnimation } from "../../lib/dnd/drop-animation";
+import { useDropAnimation } from "../DragDropContext/use-drop-animation";
 import { LoadedRichTextMenu } from "../RichTextMenu";
 import type { NodeHandle } from "../../store/slices/nodes";
 import { assignRefs } from "../../lib/assign-refs";
@@ -192,27 +192,7 @@ export const DraggableComponent = ({
   // The default drop animation targets the source placeholder. Line drags and
   // drawer insertion previews instead commit immediately and glide a visual
   // copy to the item's final rendered position.
-  const dropAnimation: DropAnimationFunction = useCallback(
-    (context) => {
-      const preview = Object.values(
-        zoneStore.getState().previewIndex ?? {}
-      ).find((preview) => preview?.props.id === id && !preview.ghost);
-
-      return runDropAnimation(
-        context,
-        preview?.linePlaceholder || preview?.type === "insert"
-          ? {
-              itemId: preview.type === "move" ? id : undefined,
-              targetZone: preview.zone,
-              getExpectedOrder: () =>
-                appStore.getState().state.indexes.zones[preview.zone]
-                  ?.contentIds ?? [],
-            }
-          : undefined
-      );
-    },
-    [zoneStore, appStore, id]
-  );
+  const dropAnimation = useDropAnimation(zoneStore, id);
 
   const {
     ref: sortableRef,

--- a/packages/core/components/DraggableComponent/index.tsx
+++ b/packages/core/components/DraggableComponent/index.tsx
@@ -26,7 +26,7 @@ import { dropZoneContext, DropZoneProvider } from "../DropZone";
 import { createDynamicCollisionDetector } from "../../lib/dnd/collision/dynamic";
 import { DragAxis } from "../../types";
 import { UniqueIdentifier } from "@dnd-kit/abstract";
-import { Feedback } from "@dnd-kit/dom";
+import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
 import { getDeepScrollPosition } from "../../lib/get-deep-scroll-position";
 import { DropZoneContext, ZoneStoreContext } from "../DropZone/context";
 import { useShallow } from "zustand/react/shallow";
@@ -34,6 +34,7 @@ import { getItem } from "../../lib/data/get-item";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useContextStore } from "../../lib/use-context-store";
 import { useOnDragFinished } from "../../lib/dnd/use-on-drag-finished";
+import { runDropAnimation } from "../../lib/dnd/drop-animation";
 import { LoadedRichTextMenu } from "../RichTextMenu";
 import type { NodeHandle } from "../../store/slices/nodes";
 import { assignRefs } from "../../lib/assign-refs";
@@ -179,12 +180,38 @@ export const DraggableComponent = ({
   );
 
   const zoneStore = useContext(ZoneStoreContext);
+  const appStore = useAppStoreApi();
 
   const [dragAxis, setDragAxis] = useState(userDragAxis || autoDragAxis);
 
   const dynamicCollisionDetector = useMemo(
     () => createDynamicCollisionDetector(dragAxis),
     [dragAxis]
+  );
+
+  // The default drop animation targets the source placeholder. Line drags and
+  // drawer insertion previews instead commit immediately and glide a visual
+  // copy to the item's final rendered position.
+  const dropAnimation: DropAnimationFunction = useCallback(
+    (context) => {
+      const preview = Object.values(
+        zoneStore.getState().previewIndex ?? {}
+      ).find((preview) => preview?.props.id === id && !preview.ghost);
+
+      return runDropAnimation(
+        context,
+        preview?.linePlaceholder || preview?.type === "insert"
+          ? {
+              itemId: preview.type === "move" ? id : undefined,
+              targetZone: preview.zone,
+              getExpectedOrder: () =>
+                appStore.getState().state.indexes.zones[preview.zone]
+                  ?.contentIds ?? [],
+            }
+          : undefined
+      );
+    },
+    [zoneStore, appStore, id]
   );
 
   const {
@@ -215,7 +242,7 @@ export const DraggableComponent = ({
     },
     plugins: (defaults) => [
       ...defaults,
-      Feedback.configure({ feedback: "clone" }),
+      Feedback.configure({ feedback: "clone", dropAnimation }),
     ],
   });
 
@@ -446,8 +473,6 @@ export const DraggableComponent = ({
     },
     [index, zoneCompound, id, isSelected, _experimentalFullScreenCanvas]
   );
-
-  const appStore = useAppStoreApi();
 
   const onSelectParent = useCallback(() => {
     const { nodes, zones } = appStore.getState().state.indexes;

--- a/packages/core/components/DraggableComponent/styles.css
+++ b/packages/core/components/DraggableComponent/styles.css
@@ -20,8 +20,10 @@
   cursor: pointer;
 }
 
-/* Placeholder */
-[data-dnd-placeholder] {
+/* Placeholder. The entry carries data-puck-line-drag during line placeholder
+   drags, where the placeholder renders as a faded ghost
+   of the actual content instead of a solid block */
+[data-dnd-placeholder]:not([data-puck-line-drag] *) {
   background: var(
     --puck-slot-component-color-placeholder,
     var(--puck-color-azure-06)
@@ -33,10 +35,16 @@
   transition: none !important;
 }
 
-[data-dnd-placeholder] *,
-[data-dnd-placeholder]::after,
-[data-dnd-placeholder]::before {
+[data-dnd-placeholder]:not([data-puck-line-drag] *) *,
+[data-dnd-placeholder]:not([data-puck-line-drag] *)::after,
+[data-dnd-placeholder]:not([data-puck-line-drag] *)::before {
   opacity: 0 !important;
+}
+
+[data-puck-line-drag] [data-dnd-placeholder] {
+  opacity: 0.4 !important;
+  outline: none !important;
+  transition: none !important;
 }
 
 [data-dnd-dragging][data-puck-component] {

--- a/packages/core/components/DraggableComponent/styles.css
+++ b/packages/core/components/DraggableComponent/styles.css
@@ -47,6 +47,10 @@
   transition: none !important;
 }
 
+[data-puck-line-drag] [data-dnd-dragging][data-puck-component] {
+  opacity: 0.9 !important;
+}
+
 [data-dnd-dragging][data-puck-component] {
   pointer-events: none !important;
   outline: var(

--- a/packages/core/components/Drawer/index.tsx
+++ b/packages/core/components/Drawer/index.tsx
@@ -1,11 +1,23 @@
 import styles from "./styles.module.css";
 import getClassNameFactory from "../../lib/get-class-name-factory";
 import { DragIcon } from "../DragIcon";
-import { ReactElement, ReactNode, Ref, useMemo, useState } from "react";
+import {
+  ReactElement,
+  ReactNode,
+  Ref,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import { generateId } from "../../lib/generate-id";
 import { useDragListener } from "../DragDropContext";
 import { useSafeId } from "../../lib/use-safe-id";
 import { useDraggable, useDroppable } from "@dnd-kit/react";
+import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
+import { ZoneStoreContext } from "../DropZone/context";
+import { useAppStoreApi } from "../../store";
+import { runDropAnimation } from "../../lib/dnd/drop-animation";
 
 const getClassName = getClassNameFactory("Drawer", styles);
 const getClassNameItem = getClassNameFactory("DrawerItem", styles);
@@ -72,11 +84,36 @@ const DrawerItemDraggable = ({
   id: string;
   isDragDisabled?: boolean;
 }) => {
+  const zoneStore = useContext(ZoneStoreContext);
+  const appStore = useAppStoreApi();
+
+  const dropAnimation: DropAnimationFunction = useCallback(
+    (context) => {
+      const preview = Object.values(
+        zoneStore.getState().previewIndex ?? {}
+      ).find((preview) => preview?.type === "insert");
+
+      return runDropAnimation(
+        context,
+        preview
+          ? {
+              targetZone: preview.zone,
+              getExpectedOrder: () =>
+                appStore.getState().state.indexes.zones[preview.zone]
+                  ?.contentIds ?? [],
+            }
+          : undefined
+      );
+    },
+    [appStore, zoneStore]
+  );
+
   const { ref } = useDraggable({
     id,
     data: { componentType: name },
     disabled: isDragDisabled,
     type: "drawer",
+    plugins: [Feedback.configure({ dropAnimation })],
   });
 
   return (

--- a/packages/core/components/Drawer/index.tsx
+++ b/packages/core/components/Drawer/index.tsx
@@ -5,7 +5,6 @@ import {
   ReactElement,
   ReactNode,
   Ref,
-  useCallback,
   useContext,
   useMemo,
   useState,
@@ -14,10 +13,9 @@ import { generateId } from "../../lib/generate-id";
 import { useDragListener } from "../DragDropContext";
 import { useSafeId } from "../../lib/use-safe-id";
 import { useDraggable, useDroppable } from "@dnd-kit/react";
-import { Feedback, type DropAnimationFunction } from "@dnd-kit/dom";
+import { Feedback } from "@dnd-kit/dom";
 import { ZoneStoreContext } from "../DropZone/context";
-import { useAppStoreApi } from "../../store";
-import { runDropAnimation } from "../../lib/dnd/drop-animation";
+import { useDropAnimation } from "../DragDropContext/use-drop-animation";
 
 const getClassName = getClassNameFactory("Drawer", styles);
 const getClassNameItem = getClassNameFactory("DrawerItem", styles);
@@ -85,28 +83,7 @@ const DrawerItemDraggable = ({
   isDragDisabled?: boolean;
 }) => {
   const zoneStore = useContext(ZoneStoreContext);
-  const appStore = useAppStoreApi();
-
-  const dropAnimation: DropAnimationFunction = useCallback(
-    (context) => {
-      const preview = Object.values(
-        zoneStore.getState().previewIndex ?? {}
-      ).find((preview) => preview?.type === "insert");
-
-      return runDropAnimation(
-        context,
-        preview
-          ? {
-              targetZone: preview.zone,
-              getExpectedOrder: () =>
-                appStore.getState().state.indexes.zones[preview.zone]
-                  ?.contentIds ?? [],
-            }
-          : undefined
-      );
-    },
-    [appStore, zoneStore]
-  );
+  const dropAnimation = useDropAnimation(zoneStore);
 
   const { ref } = useDraggable({
     id,

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -1,0 +1,139 @@
+import { CSSProperties, RefObject, useLayoutEffect, useState } from "react";
+import { getClassNameFactory } from "../../lib";
+import type { DragAxis } from "../../types";
+import styles from "./styles.module.css";
+
+const getClassName = getClassNameFactory("DropZone", styles);
+const LINE_PLACEHOLDER_SIZE = 4;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+/**
+ * A thin line rendered at the insertion point during static drags.
+ * Positioned from neighboring item rects so it never affects zone layout.
+ */
+export const LinePlaceholder = ({
+  zoneRef,
+  contentIds,
+  index,
+  dragAxis,
+}: {
+  zoneRef: RefObject<HTMLDivElement | null>;
+  contentIds: string[];
+  index: number;
+  dragAxis: DragAxis;
+}) => {
+  const [style, setStyle] = useState<CSSProperties>();
+
+  useLayoutEffect(() => {
+    const zoneEl = zoneRef.current;
+
+    if (!zoneEl) return;
+
+    const win = zoneEl.ownerDocument.defaultView;
+    const styleOf = (el?: Element | null) =>
+      el && win ? win.getComputedStyle(el) : undefined;
+    const px = (value?: string) => parseFloat(value ?? "") || 0;
+    const getItem = (itemIndex: number) => {
+      const id = contentIds[itemIndex];
+
+      if (typeof id === "undefined") return undefined;
+
+      // Exclude the flying drag element: in same-zone line drags the item's
+      // in-flow position is represented by its placeholder clone.
+      const el = zoneEl.querySelector(
+        `:scope > [data-puck-component="${CSS.escape(
+          id
+        )}"]:not([data-dnd-dragging])`
+      );
+
+      if (!el) return undefined;
+
+      return { el, rect: el.getBoundingClientRect() };
+    };
+
+    const zoneRect = zoneEl.getBoundingClientRect();
+    const zoneStyle = styleOf(zoneEl);
+    const prev = getItem(index - 1);
+    const next = getItem(index);
+    const closest = next ?? prev;
+    const size = LINE_PLACEHOLDER_SIZE;
+
+    if (dragAxis === "y") {
+      const rowGap = px(zoneStyle?.rowGap);
+
+      // Vertical flows insert between rows. At the edges, respect the zone
+      // gap or sibling margin; in empty zones, start after the zone padding.
+      const y = next
+        ? prev && prev.rect.bottom <= next.rect.top
+          ? (prev.rect.bottom + next.rect.top) / 2
+          : next.rect.top -
+            Math.max(px(styleOf(next.el)?.marginTop), rowGap) / 2
+        : prev
+        ? prev.rect.bottom +
+          Math.max(px(styleOf(prev.el)?.marginBottom), rowGap) / 2
+        : zoneRect.top + px(zoneStyle?.paddingTop);
+
+      setStyle({
+        left:
+          (closest?.rect.left ?? zoneRect.left + px(zoneStyle?.paddingLeft)) -
+          zoneRect.left +
+          zoneEl.scrollLeft,
+        width:
+          closest?.rect.width ??
+          zoneRect.width -
+            px(zoneStyle?.paddingLeft) -
+            px(zoneStyle?.paddingRight),
+        top: clamp(
+          y - zoneRect.top + zoneEl.scrollTop - size / 2,
+          0,
+          zoneEl.scrollHeight - size
+        ),
+        height: size,
+      });
+    } else {
+      const columnGap = px(zoneStyle?.columnGap);
+
+      // Horizontal and grid flows use a vertical caret at the insertion edge.
+      // Row wraps and edge positions respect the zone gap or sibling margin.
+      const x = next
+        ? prev && prev.rect.right <= next.rect.left
+          ? (prev.rect.right + next.rect.left) / 2
+          : next.rect.left -
+            Math.max(px(styleOf(next.el)?.marginLeft), columnGap) / 2
+        : prev
+        ? prev.rect.right +
+          Math.max(px(styleOf(prev.el)?.marginRight), columnGap) / 2
+        : zoneRect.left + px(zoneStyle?.paddingLeft);
+
+      setStyle({
+        top:
+          (closest?.rect.top ?? zoneRect.top + px(zoneStyle?.paddingTop)) -
+          zoneRect.top +
+          zoneEl.scrollTop,
+        height:
+          closest?.rect.height ??
+          zoneRect.height -
+            px(zoneStyle?.paddingTop) -
+            px(zoneStyle?.paddingBottom),
+        left: clamp(
+          x - zoneRect.left + zoneEl.scrollLeft - size / 2,
+          0,
+          zoneEl.scrollWidth - size
+        ),
+        width: size,
+      });
+    }
+  }, [zoneRef, contentIds, index, dragAxis]);
+
+  if (!style) return null;
+
+  return (
+    <div
+      className={getClassName("linePlaceholder")}
+      style={style}
+      data-puck-line-placeholder
+    />
+  );
+};

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -82,6 +82,11 @@ export const LinePlaceholder = ({
       return px(styleOf(el)?.[side]);
     };
 
+    const borderLeft = px(zoneStyle.borderLeftWidth);
+    const borderTop = px(zoneStyle.borderTopWidth);
+    const borderRight = px(zoneStyle.borderRightWidth);
+    const borderBottom = px(zoneStyle.borderBottomWidth);
+
     // The caret's position along the main axis, in viewport coordinates.
     let main: number;
 
@@ -101,31 +106,31 @@ export const LinePlaceholder = ({
         end(prev.rect) +
         forward * (Math.max(marginOf(prev.el, "end"), gap) / 2);
     } else {
-      // Empty zone: start after the zone's leading padding.
+      // Empty zone: start after the zone's leading border and padding.
       main = horizontal
         ? reversed
-          ? zoneRect.right - px(zoneStyle.paddingRight)
-          : zoneRect.left + px(zoneStyle.paddingLeft)
+          ? zoneRect.right - borderRight - px(zoneStyle.paddingRight)
+          : zoneRect.left + borderLeft + px(zoneStyle.paddingLeft)
         : reversed
-        ? zoneRect.bottom - px(zoneStyle.paddingBottom)
-        : zoneRect.top + px(zoneStyle.paddingTop);
+        ? zoneRect.bottom - borderBottom - px(zoneStyle.paddingBottom)
+        : zoneRect.top + borderTop + px(zoneStyle.paddingTop);
     }
-
-    const borderLeft = px(zoneStyle.borderLeftWidth);
-    const borderTop = px(zoneStyle.borderTopWidth);
 
     if (horizontal) {
       // Vertical caret: centred at `main` on the x axis, spanning the
       // cross-axis height of the neighbouring item (or the zone's content box).
       setStyle({
         top:
-          (closest?.rect.top ?? zoneRect.top + px(zoneStyle.paddingTop)) -
+          (closest?.rect.top ??
+            zoneRect.top + borderTop + px(zoneStyle.paddingTop)) -
           zoneRect.top +
           zoneEl.scrollTop -
           borderTop,
         height:
           closest?.rect.height ??
           zoneRect.height -
+            borderTop -
+            borderBottom -
             px(zoneStyle.paddingTop) -
             px(zoneStyle.paddingBottom),
         left: clamp(
@@ -141,13 +146,16 @@ export const LinePlaceholder = ({
       // cross-axis width.
       setStyle({
         left:
-          (closest?.rect.left ?? zoneRect.left + px(zoneStyle.paddingLeft)) -
+          (closest?.rect.left ??
+            zoneRect.left + borderLeft + px(zoneStyle.paddingLeft)) -
           zoneRect.left +
           zoneEl.scrollLeft -
           borderLeft,
         width:
           closest?.rect.width ??
           zoneRect.width -
+            borderLeft -
+            borderRight -
             px(zoneStyle.paddingLeft) -
             px(zoneStyle.paddingRight),
         top: clamp(

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -12,7 +12,7 @@ import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
-const LINE_SIZE = "var(--puck-border-width-focus, 2px)";
+const LINE_SIZE = "var(--puck-line-placeholder-width, 2px)";
 
 /**
  * Renders the line preview

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -1,40 +1,43 @@
 import { CSSProperties, RefObject, useLayoutEffect, useState } from "react";
+
 import { getClassNameFactory } from "../../lib";
-import type { DragAxis } from "../../types";
+import { clamp } from "../../lib/math";
+import {
+  getItemEdgeAccessors,
+  resolveZoneFlow,
+} from "../../lib/dnd/resolve-flow";
+import { getComponentSelector } from "../../lib/dom-selectors";
+
 import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("DropZone", styles);
-const LINE_PLACEHOLDER_SIZE = 4;
 
-const clamp = (value: number, min: number, max: number) =>
-  Math.max(min, Math.min(max, value));
+const LINE_SIZE = "var(--puck-border-width-focus, 2px)";
 
 /**
- * A thin line rendered at the insertion point during static drags.
- * Positioned from neighboring item rects so it never affects zone layout.
+ * Renders the line preview
  */
 export const LinePlaceholder = ({
   zoneRef,
   contentIds,
   index,
-  dragAxis,
 }: {
   zoneRef: RefObject<HTMLDivElement | null>;
   contentIds: string[];
   index: number;
-  dragAxis: DragAxis;
 }) => {
   const [style, setStyle] = useState<CSSProperties>();
 
   useLayoutEffect(() => {
     const zoneEl = zoneRef.current;
+    const win = zoneEl?.ownerDocument.defaultView;
 
-    if (!zoneEl) return;
+    if (!zoneEl || !win) return;
 
-    const win = zoneEl.ownerDocument.defaultView;
     const styleOf = (el?: Element | null) =>
-      el && win ? win.getComputedStyle(el) : undefined;
+      el ? win.getComputedStyle(el) : undefined;
     const px = (value?: string) => parseFloat(value ?? "") || 0;
+
     const getItem = (itemIndex: number) => {
       const id = contentIds[itemIndex];
 
@@ -43,9 +46,7 @@ export const LinePlaceholder = ({
       // Exclude the flying drag element: in same-zone line drags the item's
       // in-flow position is represented by its placeholder clone.
       const el = zoneEl.querySelector(
-        `:scope > [data-puck-component="${CSS.escape(
-          id
-        )}"]:not([data-dnd-dragging])`
+        `:scope > ${getComponentSelector(id)}:not([data-dnd-dragging])`
       );
 
       if (!el) return undefined;
@@ -54,78 +55,106 @@ export const LinePlaceholder = ({
     };
 
     const zoneRect = zoneEl.getBoundingClientRect();
-    const zoneStyle = styleOf(zoneEl);
+    const zoneStyle = win.getComputedStyle(zoneEl);
     const prev = getItem(index - 1);
     const next = getItem(index);
     const closest = next ?? prev;
-    const size = LINE_PLACEHOLDER_SIZE;
 
-    if (dragAxis === "y") {
-      const rowGap = px(zoneStyle?.rowGap);
+    const zoneFlow = resolveZoneFlow(zoneEl, win, zoneStyle);
 
-      // Vertical flows insert between rows. At the edges, respect the zone
-      // gap or sibling margin; in empty zones, start after the zone padding.
-      const y = next
-        ? prev && prev.rect.bottom <= next.rect.top
-          ? (prev.rect.bottom + next.rect.top) / 2
-          : next.rect.top -
-            Math.max(px(styleOf(next.el)?.marginTop), rowGap) / 2
-        : prev
-        ? prev.rect.bottom +
-          Math.max(px(styleOf(prev.el)?.marginBottom), rowGap) / 2
-        : zoneRect.top + px(zoneStyle?.paddingTop);
+    const { horizontal, reversed, forward, start, end, isBefore } =
+      getItemEdgeAccessors(zoneFlow);
 
-      setStyle({
-        left:
-          (closest?.rect.left ?? zoneRect.left + px(zoneStyle?.paddingLeft)) -
-          zoneRect.left +
-          zoneEl.scrollLeft,
-        width:
-          closest?.rect.width ??
-          zoneRect.width -
-            px(zoneStyle?.paddingLeft) -
-            px(zoneStyle?.paddingRight),
-        top: clamp(
-          y - zoneRect.top + zoneEl.scrollTop - size / 2,
-          0,
-          zoneEl.scrollHeight - size
-        ),
-        height: size,
-      });
+    const gap = px(horizontal ? zoneStyle.columnGap : zoneStyle.rowGap);
+    const marginOf = (
+      el: Element | null | undefined,
+      edge: "start" | "end"
+    ) => {
+      const side =
+        (edge === "start") === !reversed
+          ? horizontal
+            ? "marginLeft"
+            : "marginTop"
+          : horizontal
+          ? "marginRight"
+          : "marginBottom";
+
+      return px(styleOf(el)?.[side]);
+    };
+
+    // The caret's position along the main axis, in viewport coordinates.
+    let main: number;
+
+    if (next) {
+      if (prev && isBefore(end(prev.rect), start(next.rect))) {
+        // Between two items: the centre of the gap.
+        main = (end(prev.rect) + start(next.rect)) / 2;
+      } else {
+        // Before `next`: back off half the sibling margin or zone gap.
+        main =
+          start(next.rect) -
+          forward * (Math.max(marginOf(next.el, "start"), gap) / 2);
+      }
+    } else if (prev) {
+      // After the last item.
+      main =
+        end(prev.rect) +
+        forward * (Math.max(marginOf(prev.el, "end"), gap) / 2);
     } else {
-      const columnGap = px(zoneStyle?.columnGap);
+      // Empty zone: start after the zone's leading padding.
+      main = horizontal
+        ? reversed
+          ? zoneRect.right - px(zoneStyle.paddingRight)
+          : zoneRect.left + px(zoneStyle.paddingLeft)
+        : reversed
+        ? zoneRect.bottom - px(zoneStyle.paddingBottom)
+        : zoneRect.top + px(zoneStyle.paddingTop);
+    }
 
-      // Horizontal and grid flows use a vertical caret at the insertion edge.
-      // Row wraps and edge positions respect the zone gap or sibling margin.
-      const x = next
-        ? prev && prev.rect.right <= next.rect.left
-          ? (prev.rect.right + next.rect.left) / 2
-          : next.rect.left -
-            Math.max(px(styleOf(next.el)?.marginLeft), columnGap) / 2
-        : prev
-        ? prev.rect.right +
-          Math.max(px(styleOf(prev.el)?.marginRight), columnGap) / 2
-        : zoneRect.left + px(zoneStyle?.paddingLeft);
-
+    if (horizontal) {
+      // Vertical caret: centred at `main` on the x axis, spanning the
+      // cross-axis height of the neighbouring item (or the zone's content box).
       setStyle({
         top:
-          (closest?.rect.top ?? zoneRect.top + px(zoneStyle?.paddingTop)) -
+          (closest?.rect.top ?? zoneRect.top + px(zoneStyle.paddingTop)) -
           zoneRect.top +
           zoneEl.scrollTop,
         height:
           closest?.rect.height ??
           zoneRect.height -
-            px(zoneStyle?.paddingTop) -
-            px(zoneStyle?.paddingBottom),
+            px(zoneStyle.paddingTop) -
+            px(zoneStyle.paddingBottom),
         left: clamp(
-          x - zoneRect.left + zoneEl.scrollLeft - size / 2,
+          main - zoneRect.left + zoneEl.scrollLeft,
           0,
-          zoneEl.scrollWidth - size
+          zoneEl.scrollWidth
         ),
-        width: size,
+        width: LINE_SIZE,
+        transform: "translateX(-50%)",
+      });
+    } else {
+      // Horizontal caret: centred at `main` on the y axis, spanning the
+      // cross-axis width.
+      setStyle({
+        left:
+          (closest?.rect.left ?? zoneRect.left + px(zoneStyle.paddingLeft)) -
+          zoneRect.left +
+          zoneEl.scrollLeft,
+        width:
+          closest?.rect.width ??
+          zoneRect.width -
+            px(zoneStyle.paddingLeft) -
+            px(zoneStyle.paddingRight),
+        top: clamp(
+          main - zoneRect.top + zoneEl.scrollTop,
+          0,
+          zoneEl.scrollHeight
+        ),
+        height: LINE_SIZE,
+        transform: "translateY(-50%)",
       });
     }
-  }, [zoneRef, contentIds, index, dragAxis]);
+  }, [zoneRef, contentIds, index]);
 
   if (!style) return null;
 

--- a/packages/core/components/DropZone/LinePlaceholder.tsx
+++ b/packages/core/components/DropZone/LinePlaceholder.tsx
@@ -111,6 +111,9 @@ export const LinePlaceholder = ({
         : zoneRect.top + px(zoneStyle.paddingTop);
     }
 
+    const borderLeft = px(zoneStyle.borderLeftWidth);
+    const borderTop = px(zoneStyle.borderTopWidth);
+
     if (horizontal) {
       // Vertical caret: centred at `main` on the x axis, spanning the
       // cross-axis height of the neighbouring item (or the zone's content box).
@@ -118,14 +121,15 @@ export const LinePlaceholder = ({
         top:
           (closest?.rect.top ?? zoneRect.top + px(zoneStyle.paddingTop)) -
           zoneRect.top +
-          zoneEl.scrollTop,
+          zoneEl.scrollTop -
+          borderTop,
         height:
           closest?.rect.height ??
           zoneRect.height -
             px(zoneStyle.paddingTop) -
             px(zoneStyle.paddingBottom),
         left: clamp(
-          main - zoneRect.left + zoneEl.scrollLeft,
+          main - zoneRect.left + zoneEl.scrollLeft - borderLeft,
           0,
           zoneEl.scrollWidth
         ),
@@ -139,14 +143,15 @@ export const LinePlaceholder = ({
         left:
           (closest?.rect.left ?? zoneRect.left + px(zoneStyle.paddingLeft)) -
           zoneRect.left +
-          zoneEl.scrollLeft,
+          zoneEl.scrollLeft -
+          borderLeft,
         width:
           closest?.rect.width ??
           zoneRect.width -
             px(zoneStyle.paddingLeft) -
             px(zoneStyle.paddingRight),
         top: clamp(
-          main - zoneRect.top + zoneEl.scrollTop,
+          main - zoneRect.top + zoneEl.scrollTop - borderTop,
           0,
           zoneEl.scrollHeight
         ),

--- a/packages/core/components/DropZone/VirtualizedDropZone.tsx
+++ b/packages/core/components/DropZone/VirtualizedDropZone.tsx
@@ -64,7 +64,13 @@ export const VirtualizedDropZone = ({
 
   const dragTargetParentId = useContextStore(ZoneStoreContext, (s) => {
     if (s.draggedItem?.id) {
-      const parentZone = Object.keys(s.previewIndex ?? {})[0];
+      // Ghost previews only pin the item in its original zone; the drop
+      // target is described by the non-ghost preview
+      const [parentZone] =
+        Object.entries(s.previewIndex ?? {}).find(
+          ([, preview]) => !preview?.ghost
+        ) ?? [];
+
       return parentZone?.split(":")[0];
     }
 

--- a/packages/core/components/DropZone/context.tsx
+++ b/packages/core/components/DropZone/context.tsx
@@ -33,6 +33,17 @@ export type Preview = {
   props: Record<string, any>;
   type: "insert" | "move";
   element: Element | undefined;
+  /**
+   * Render a thin line at the insertion point instead of the full item,
+   * preventing layout shift.
+   */
+  linePlaceholder?: boolean;
+  /**
+   * Pins the dragged item at its last previewed position in its original
+   * zone while a line placeholder shows in another zone, preventing the
+   * original zone from shifting back. Ignored when committing the drag.
+   */
+  ghost?: boolean;
 } | null;
 
 export type RootVirtualizerHandle = {

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -56,6 +56,7 @@ import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
 import { MemoizeComponent } from "../MemoizeComponent";
 import { VirtualizedDropZone } from "./VirtualizedDropZone";
+import { LinePlaceholder } from "./LinePlaceholder";
 
 const getClassName = getClassNameFactory("DropZone", styles);
 
@@ -429,7 +430,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
     const isDropEnabled =
       isEnabled &&
       (preview
-        ? contentIdsWithPreview.length === 1
+        ? contentIdsWithPreview.length === (preview.linePlaceholder ? 0 : 1)
         : contentIdsWithPreview.length === 0);
 
     const zoneStore = useContext(ZoneStoreContext);
@@ -536,6 +537,14 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
               inDroppableZone={targetAccepted}
             />
           ))
+        )}
+        {preview?.linePlaceholder && (
+          <LinePlaceholder
+            zoneRef={ref}
+            contentIds={contentIds}
+            index={preview.index}
+            dragAxis={dragAxis}
+          />
         )}
       </El>
     );

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -427,11 +427,15 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
       zoneCompound
     );
 
-    const isDropEnabled =
-      isEnabled &&
-      (preview
-        ? contentIdsWithPreview.length === (preview.linePlaceholder ? 0 : 1)
-        : contentIdsWithPreview.length === 0);
+    // contentIdsWithPreview counts a non-line preview as one injected
+    // placeholder, but a line placeholder injects nothing. So a zone 
+    // is empty (and a valid drop target) when its only
+    // entry, if any, is that injected placeholder. 
+    // Otherwise the children within the zone should be the targets.
+    const injectedPreviewCount = preview && !preview.linePlaceholder ? 1 : 0;
+    const isZoneEmpty =
+      contentIdsWithPreview.length === injectedPreviewCount;
+    const isDropEnabled = isEnabled && isZoneEmpty;
 
     const zoneStore = useContext(ZoneStoreContext);
 
@@ -543,7 +547,6 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
             zoneRef={ref}
             contentIds={contentIds}
             index={preview.index}
-            dragAxis={dragAxis}
           />
         )}
       </El>

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -428,13 +428,12 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
     );
 
     // contentIdsWithPreview counts a non-line preview as one injected
-    // placeholder, but a line placeholder injects nothing. So a zone 
+    // placeholder, but a line placeholder injects nothing. So a zone
     // is empty (and a valid drop target) when its only
-    // entry, if any, is that injected placeholder. 
+    // entry, if any, is that injected placeholder.
     // Otherwise the children within the zone should be the targets.
     const injectedPreviewCount = preview && !preview.linePlaceholder ? 1 : 0;
-    const isZoneEmpty =
-      contentIdsWithPreview.length === injectedPreviewCount;
+    const isZoneEmpty = contentIdsWithPreview.length === injectedPreviewCount;
     const isDropEnabled = isEnabled && isZoneEmpty;
 
     const zoneStore = useContext(ZoneStoreContext);

--- a/packages/core/components/DropZone/lib/use-content-with-preview.ts
+++ b/packages/core/components/DropZone/lib/use-content-with-preview.ts
@@ -30,7 +30,8 @@ export const useContentIdsWithPreview = (
       preview: Preview | undefined,
       isDragging: boolean,
       draggedItemId?: string,
-      previewExists?: boolean
+      previewExists?: boolean,
+      linePlaceholderActive?: boolean
     ) => {
       // Preview is cleared but context hasn't yet caught up
       // This is necessary because Zustand clears the preview before the dispatcher finishes
@@ -38,27 +39,19 @@ export const useContentIdsWithPreview = (
         return;
       }
 
-      if (preview) {
-        if (preview.type === "insert") {
-          setContentIdsWithPreview(
-            insert(
-              contentIds.filter((id) => id !== preview.props.id),
-              preview.index,
-              preview.props.id
-            )
-          );
-        } else {
-          setContentIdsWithPreview(
-            insert(
-              contentIds.filter((id) => id !== preview.props.id),
-              preview.index,
-              preview.props.id
-            )
-          );
-        }
-      } else {
+      if (preview && !preview.linePlaceholder) {
         setContentIdsWithPreview(
-          previewExists
+          insert(
+            contentIds.filter((id) => id !== preview.props.id),
+            preview.index,
+            preview.props.id
+          )
+        );
+      } else {
+        // Line placeholders render as a zone overlay rather than as content,
+        // and the rendered item order remains unchanged during the drag
+        setContentIdsWithPreview(
+          previewExists && !linePlaceholderActive
             ? contentIds.filter((id) => id !== draggedItemId)
             : contentIds
         );
@@ -76,14 +69,17 @@ export const useContentIdsWithPreview = (
     // the renderedCallback.
     const s = zoneStore.getState();
     const draggedItemId = s.draggedItem?.id;
-    const previewExists = Object.keys(s.previewIndex || {}).length > 0;
+    const previews = Object.values(s.previewIndex || {});
+    const previewExists = previews.length > 0;
+    const linePlaceholderActive = previews.some((p) => p?.linePlaceholder);
 
     updateContent(
       contentIds,
       preview,
       isDragging,
       draggedItemId,
-      previewExists
+      previewExists,
+      linePlaceholderActive
     );
   }, [contentIds, preview, isDragging]);
 

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -40,6 +40,17 @@
   position: relative;
 }
 
+.DropZone-linePlaceholder {
+  background: var(
+    --puck-slot-component-color-placeholder,
+    var(--puck-color-azure-06)
+  );
+  border-radius: 2px;
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+}
+
 .DropZone-hitbox {
   position: absolute;
   bottom: calc(var(--puck-space-3) * -1);
@@ -54,7 +65,7 @@
     var(--puck-slot-color-border, var(--puck-color-selection-border));
 }
 
-.DropZone > *:not([data-puck-component]) {
+.DropZone > *:not([data-puck-component]):not([data-puck-line-placeholder]) {
   opacity: 0;
 }
 

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -45,8 +45,8 @@
     --puck-slot-component-color-placeholder,
     var(--puck-color-line-placeholder)
   );
-  /* Size follows --puck-border-width-focus (see LinePlaceholder.tsx) */
-  border-radius: calc(var(--puck-border-width-focus, 2px) / 2);
+  /* Size follows --puck-line-placeholder-width (see LinePlaceholder.tsx) */
+  border-radius: calc(var(--puck-line-placeholder-width, 2px) / 2);
   pointer-events: none;
   position: absolute;
   z-index: 1;

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -43,9 +43,10 @@
 .DropZone-linePlaceholder {
   background: var(
     --puck-slot-component-color-placeholder,
-    var(--puck-color-azure-06)
+    var(--puck-color-insertion-indicator)
   );
-  border-radius: 2px;
+  /* Size follows --puck-border-width-focus (see LinePlaceholder.tsx) */
+  border-radius: calc(var(--puck-border-width-focus, 2px) / 2);
   pointer-events: none;
   position: absolute;
   z-index: 1;

--- a/packages/core/components/DropZone/styles.module.css
+++ b/packages/core/components/DropZone/styles.module.css
@@ -43,7 +43,7 @@
 .DropZone-linePlaceholder {
   background: var(
     --puck-slot-component-color-placeholder,
-    var(--puck-color-insertion-indicator)
+    var(--puck-color-line-placeholder)
   );
   /* Size follows --puck-border-width-focus (see LinePlaceholder.tsx) */
   border-radius: calc(var(--puck-border-width-focus, 2px) / 2);

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -42,7 +42,7 @@
 
   --_puck-outline-color-drop-indicator: var(
     --puck-outline-color-drop-indicator,
-    var(--puck-color-insertion-indicator)
+    var(--puck-color-line-placeholder)
   );
   --_puck-outline-drop-indicator-size: var(--puck-border-width-focus);
 

--- a/packages/core/components/LayerTree/styles.module.css
+++ b/packages/core/components/LayerTree/styles.module.css
@@ -44,7 +44,7 @@
     --puck-outline-color-drop-indicator,
     var(--puck-color-line-placeholder)
   );
-  --_puck-outline-drop-indicator-size: var(--puck-border-width-focus);
+  --_puck-outline-drop-indicator-size: var(--puck-line-placeholder-width);
 
   --_puck-outline-zone-color-text: var(
     --puck-outline-zone-color-text,

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -300,7 +300,10 @@ export const Layout = ({ children }: { children?: ReactNode }) => {
       id={instanceId}
       style={{ height, visibility: "hidden" }}
     >
-      <DragDropContext disableAutoScroll={dnd?.disableAutoScroll}>
+      <DragDropContext
+        disableAutoScroll={dnd?.disableAutoScroll}
+        behavior={dnd?.behavior}
+      >
         <CustomPuck>
           {children || (
             <FrameProvider>

--- a/packages/core/components/Puck/components/Layout/index.tsx
+++ b/packages/core/components/Puck/components/Layout/index.tsx
@@ -76,11 +76,12 @@ const PluginTab = ({
 export const Layout = ({ children }: { children?: ReactNode }) => {
   const {
     iframe: _iframe,
-    dnd,
     initialHistory: _initialHistory,
     plugins,
     height,
   } = usePropsContext();
+
+  const dnd = useAppStore((s) => s.dnd);
 
   const iframe: IframeConfig = useMemo(
     () => normalizeIframeConfig(_iframe),

--- a/packages/core/components/Sortable/styles.css
+++ b/packages/core/components/Sortable/styles.css
@@ -1,8 +1,11 @@
-[data-dnd-placeholder] * {
+/* Guarded with data-puck-line-drag so canvas placeholders can render as a
+   faded ghost during line placeholder drags — see
+   DraggableComponent/styles.css */
+[data-dnd-placeholder]:not([data-puck-line-drag] *) * {
   opacity: 0 !important;
 }
 
-[data-dnd-placeholder] {
+[data-dnd-placeholder]:not([data-puck-line-drag] *) {
   background: var(
     --_puck-field-array-color-placeholder,
     var(--puck-color-azure-06)

--- a/packages/core/lib/__tests__/get-zone-content-ids.spec.ts
+++ b/packages/core/lib/__tests__/get-zone-content-ids.spec.ts
@@ -1,0 +1,21 @@
+import { getZoneContentIds } from "../get-zone-content-ids";
+import type { PrivateAppState } from "../../types/Internal";
+
+const state = {
+  indexes: {
+    nodes: {},
+    zones: {
+      "root:main": { contentIds: ["a", "b"], type: "dropzone" },
+    },
+  },
+} as unknown as PrivateAppState;
+
+describe("getZoneContentIds", () => {
+  it("returns a zone's content ids", () => {
+    expect(getZoneContentIds(state, "root:main")).toEqual(["a", "b"]);
+  });
+
+  it("defaults to an empty array for an unknown zone", () => {
+    expect(getZoneContentIds(state, "missing")).toEqual([]);
+  });
+});

--- a/packages/core/lib/__tests__/math.spec.ts
+++ b/packages/core/lib/__tests__/math.spec.ts
@@ -1,0 +1,39 @@
+import { clamp, getDistanceToSegment } from "../math";
+
+describe("clamp", () => {
+  it("returns the value when in range", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("clamps to the bounds", () => {
+    expect(clamp(-1, 0, 10)).toBe(0);
+    expect(clamp(11, 0, 10)).toBe(10);
+  });
+});
+
+describe("distanceToSegment", () => {
+  it("returns 0 for a point on the segment", () => {
+    expect(
+      getDistanceToSegment({ x: 5, y: 0 }, { x1: 0, y1: 0, x2: 10, y2: 0 })
+    ).toBe(0);
+  });
+
+  it("measures perpendicular distance to a vertical segment", () => {
+    expect(
+      getDistanceToSegment({ x: 5, y: 5 }, { x1: 0, y1: 0, x2: 0, y2: 10 })
+    ).toBe(5);
+  });
+
+  it("clamps beyond the segment endpoints", () => {
+    // Point is past the top of a horizontal segment.
+    expect(
+      getDistanceToSegment({ x: 5, y: 20 }, { x1: 0, y1: 0, x2: 10, y2: 0 })
+    ).toBe(20);
+  });
+
+  it("handles unordered endpoints", () => {
+    expect(
+      getDistanceToSegment({ x: 5, y: 5 }, { x1: 0, y1: 10, x2: 0, y2: 0 })
+    ).toBe(5);
+  });
+});

--- a/packages/core/lib/__tests__/math.spec.ts
+++ b/packages/core/lib/__tests__/math.spec.ts
@@ -25,10 +25,14 @@ describe("distanceToSegment", () => {
   });
 
   it("clamps beyond the segment endpoints", () => {
-    // Point is past the top of a horizontal segment.
+    // Point is past the right endpoint of a horizontal segment.
     expect(
-      getDistanceToSegment({ x: 5, y: 20 }, { x1: 0, y1: 0, x2: 10, y2: 0 })
-    ).toBe(20);
+      getDistanceToSegment({ x: 20, y: 0 }, { x1: 0, y1: 0, x2: 10, y2: 0 })
+    ).toBe(10);
+    // Point is past the right endpoint and offset on the cross axis.
+    expect(
+      getDistanceToSegment({ x: 13, y: 4 }, { x1: 0, y1: 0, x2: 10, y2: 0 })
+    ).toBe(5);
   });
 
   it("handles unordered endpoints", () => {

--- a/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
+++ b/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
@@ -1,0 +1,84 @@
+import { runTargetDropAnimation } from "../drop-animation";
+
+jest.mock("../../get-frame", () => ({
+  getFrame: () => document,
+}));
+
+const rect = (top: number): DOMRect =>
+  ({
+    top,
+    bottom: top + 100,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeItem = (id: string, top: number) => {
+  const element = document.createElement("div");
+
+  element.setAttribute("data-puck-component", id);
+  element.getBoundingClientRect = () => rect(top);
+
+  return element;
+};
+
+describe("runTargetDropAnimation", () => {
+  let animationFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    animationFrames = [];
+    document.body.innerHTML = "";
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => ({ finished: Promise.resolve() })),
+    });
+  });
+
+  it("animates a new drawer item to its inferred committed element", () => {
+    const zone = document.createElement("div");
+    const existing = makeItem("existing", 100);
+    const feedback = document.createElement("div");
+    let expectedOrder = ["existing"];
+
+    zone.setAttribute("data-puck-dropzone", "root:slot");
+    zone.append(existing);
+    document.body.append(zone, feedback);
+    feedback.getBoundingClientRect = () => rect(300);
+
+    runTargetDropAnimation({
+      feedbackElement: feedback,
+      targetZone: "root:slot",
+      getExpectedOrder: () => expectedOrder,
+    });
+
+    const inserted = makeItem("inserted", 0);
+    expectedOrder = ["inserted", "existing"];
+    zone.prepend(inserted);
+    animationFrames.forEach((callback) => callback(0));
+
+    const copy = document.body.querySelector<HTMLElement>(
+      '[inert][style*="2147483647"]'
+    );
+
+    expect(copy).not.toBeNull();
+    expect(copy?.animate).toHaveBeenCalledWith(
+      {
+        translate: ["0px 0px 0", "0px -300px 0"],
+        width: ["100px", "100px"],
+        height: ["100px", "100px"],
+      },
+      { duration: 250, easing: "ease", fill: "forwards" }
+    );
+  });
+});

--- a/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
+++ b/packages/core/lib/dnd/__tests__/drop-animation.spec.ts
@@ -1,3 +1,10 @@
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserverMock;
+
 import { runTargetDropAnimation } from "../drop-animation";
 
 jest.mock("../../get-frame", () => ({
@@ -74,7 +81,8 @@ describe("runTargetDropAnimation", () => {
     expect(copy).not.toBeNull();
     expect(copy?.animate).toHaveBeenCalledWith(
       {
-        translate: ["0px 0px 0", "0px -300px 0"],
+        left: ["0px", "0px"],
+        top: ["300px", "0px"],
         width: ["100px", "100px"],
         height: ["100px", "100px"],
       },

--- a/packages/core/lib/dnd/__tests__/flip-commit.spec.ts
+++ b/packages/core/lib/dnd/__tests__/flip-commit.spec.ts
@@ -1,0 +1,89 @@
+import { prepareCommitFlip } from "../flip-commit";
+
+jest.mock("../../get-frame", () => ({
+  getFrame: () => document,
+}));
+
+const rect = (top: number): DOMRect =>
+  ({
+    top,
+    bottom: top + 100,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeItem = (id: string, top: number) => {
+  const element = document.createElement("div");
+
+  element.setAttribute("data-puck-component", id);
+  element.getBoundingClientRect = () => rect(top);
+  element.animate = jest.fn() as typeof element.animate;
+
+  return element;
+};
+
+describe("commit animations", () => {
+  let animationFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    animationFrames = [];
+    document.body.innerHTML = "";
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => ({ finished: Promise.resolve() })),
+    });
+  });
+
+  const flushAnimationFrame = () => {
+    const callbacks = animationFrames;
+    animationFrames = [];
+    callbacks.forEach((callback) => callback(0));
+  };
+
+  it("infers a newly inserted item and animates its displaced siblings", () => {
+    const zone = document.createElement("div");
+    const first = makeItem("first", 0);
+    const second = makeItem("second", 100);
+    let expectedOrder = ["first", "second"];
+
+    zone.setAttribute("data-puck-dropzone", "root:slot");
+    zone.append(first, second);
+    document.body.appendChild(zone);
+
+    const play = prepareCommitFlip({
+      zones: ["root:slot"],
+      targetZone: "root:slot",
+      getExpectedOrder: () => expectedOrder,
+    });
+
+    const inserted = makeItem("inserted", 0);
+    first.getBoundingClientRect = () => rect(100);
+    second.getBoundingClientRect = () => rect(200);
+    expectedOrder = ["inserted", "first", "second"];
+    zone.prepend(inserted);
+
+    play();
+    flushAnimationFrame();
+
+    expect(first.animate).toHaveBeenCalledWith(
+      { translate: ["0px -100px 0", "0px 0px 0"] },
+      { duration: 250, easing: "ease" }
+    );
+    expect(second.animate).toHaveBeenCalledWith(
+      { translate: ["0px -100px 0", "0px 0px 0"] },
+      { duration: 250, easing: "ease" }
+    );
+  });
+});

--- a/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
+++ b/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
@@ -1,0 +1,101 @@
+import { getNearestGapIndex } from "../nearest-gap";
+
+type ItemSpec = { id: string; top: number; height: number };
+
+const rect = (top: number, height: number): DOMRect =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 100,
+    width: 100,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeZone = (items: ItemSpec[]) => {
+  const zone = document.createElement("div");
+
+  items.forEach(({ id, top, height }) => {
+    const el = document.createElement("div");
+
+    el.setAttribute("data-puck-component", id);
+    el.getBoundingClientRect = () => rect(top, height);
+
+    zone.appendChild(el);
+  });
+
+  document.body.appendChild(zone);
+
+  return zone;
+};
+
+describe("getNearestGapIndex", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the index of the gap nearest the pointer", () => {
+    const contentIds = ["a", "b", "c"];
+    const zone = makeZone([
+      { id: "a", top: 0, height: 100 },
+      { id: "b", top: 100, height: 100 },
+      { id: "c", top: 200, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 5 }, contentIds)).toBe(0);
+    expect(getNearestGapIndex(zone, { x: 50, y: 90 }, contentIds)).toBe(1);
+    expect(getNearestGapIndex(zone, { x: 50, y: 110 }, contentIds)).toBe(1);
+    expect(getNearestGapIndex(zone, { x: 50, y: 190 }, contentIds)).toBe(2);
+    expect(getNearestGapIndex(zone, { x: 50, y: 290 }, contentIds)).toBe(3);
+  });
+
+  it("maps rendered items to their content indices in virtualized zones", () => {
+    // 50 items, but only a window (20..23) is rendered in the DOM
+    const contentIds = Array.from({ length: 50 }, (_, i) => `item-${i}`);
+    const zone = makeZone([
+      { id: "item-20", top: 0, height: 100 },
+      { id: "item-21", top: 100, height: 100 },
+      { id: "item-22", top: 200, height: 100 },
+      { id: "item-23", top: 300, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 95 }, contentIds)).toBe(21);
+    expect(getNearestGapIndex(zone, { x: 50, y: 205 }, contentIds)).toBe(22);
+    expect(getNearestGapIndex(zone, { x: 50, y: 390 }, contentIds)).toBe(24);
+    expect(getNearestGapIndex(zone, { x: 50, y: 4 }, contentIds)).toBe(20);
+  });
+
+  it("exposes both edges of a virtualization discontinuity", () => {
+    const contentIds = Array.from({ length: 50 }, (_, i) => `item-${i}`);
+
+    // item-10 is pinned (e.g. selected) far above the rendered window
+    const zone = makeZone([
+      { id: "item-10", top: 0, height: 100 },
+      { id: "item-30", top: 500, height: 100 },
+      { id: "item-31", top: 600, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 105 }, contentIds)).toBe(11);
+    expect(getNearestGapIndex(zone, { x: 50, y: 495 }, contentIds)).toBe(30);
+  });
+
+  it("ignores elements that aren't part of the zone's content", () => {
+    const contentIds = ["a", "b"];
+    const zone = makeZone([
+      { id: "a", top: 0, height: 100 },
+      { id: "spacer", top: 100, height: 50 }, // e.g. virtualizer gap element
+      { id: "b", top: 150, height: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 130 }, contentIds)).toBe(1);
+  });
+
+  it("returns 0 for empty zones", () => {
+    const zone = makeZone([]);
+
+    expect(getNearestGapIndex(zone, { x: 50, y: 50 }, [])).toBe(0);
+  });
+});

--- a/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
+++ b/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
@@ -99,3 +99,92 @@ describe("getNearestGapIndex", () => {
     expect(getNearestGapIndex(zone, { x: 50, y: 50 }, [])).toBe(0);
   });
 });
+
+type HItemSpec = { id: string; left: number; width: number };
+
+const hRect = (left: number, width: number): DOMRect =>
+  ({
+    top: 0,
+    bottom: 100,
+    left,
+    right: left + width,
+    width,
+    height: 100,
+    x: left,
+    y: 0,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeRowZone = (items: HItemSpec[], { rtl }: { rtl?: boolean } = {}) => {
+  const zone = document.createElement("div");
+
+  if (rtl) zone.setAttribute("dir", "rtl");
+
+  items.forEach(({ id, left, width }) => {
+    const el = document.createElement("div");
+
+    el.setAttribute("data-puck-component", id);
+    el.getBoundingClientRect = () => hRect(left, width);
+
+    zone.appendChild(el);
+  });
+
+  document.body.appendChild(zone);
+
+  return zone;
+};
+
+describe("getNearestGapIndex in horizontal flows", () => {
+  let getComputedStyleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getComputedStyleSpy = jest
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({
+        display: "flex",
+        flexDirection: "row",
+        gridTemplateColumns: "none",
+        gridTemplateRows: "none",
+        gridAutoFlow: "row",
+      } as unknown as CSSStyleDeclaration);
+  });
+
+  afterEach(() => {
+    getComputedStyleSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  it("targets the nearest vertical gap along a row (ltr)", () => {
+    const contentIds = ["a", "b", "c"];
+    const zone = makeRowZone([
+      { id: "a", left: 0, width: 100 },
+      { id: "b", left: 100, width: 100 },
+      { id: "c", left: 200, width: 100 },
+    ]);
+
+    expect(getNearestGapIndex(zone, { x: 5, y: 50 }, contentIds)).toBe(0);
+    expect(getNearestGapIndex(zone, { x: 110, y: 50 }, contentIds)).toBe(1);
+    expect(getNearestGapIndex(zone, { x: 295, y: 50 }, contentIds)).toBe(3);
+  });
+
+  it("mirrors before/after edges for rtl rows", () => {
+    // DOM order is a, b, c but rtl lays them right-to-left, so index order
+    // runs from the right edge to the left.
+    const contentIds = ["a", "b", "c"];
+    const zone = makeRowZone(
+      [
+        { id: "a", left: 200, width: 100 },
+        { id: "b", left: 100, width: 100 },
+        { id: "c", left: 0, width: 100 },
+      ],
+      { rtl: true }
+    );
+
+    // Before the first item sits at its right edge (x = 300).
+    expect(getNearestGapIndex(zone, { x: 299, y: 50 }, contentIds)).toBe(0);
+    // After the last item sits at its left edge (x = 0).
+    expect(getNearestGapIndex(zone, { x: 1, y: 50 }, contentIds)).toBe(3);
+    // Between b and c (x = 100).
+    expect(getNearestGapIndex(zone, { x: 110, y: 50 }, contentIds)).toBe(2);
+  });
+});

--- a/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
+++ b/packages/core/lib/dnd/__tests__/nearest-gap.spec.ts
@@ -115,6 +115,44 @@ const hRect = (left: number, width: number): DOMRect =>
     toJSON: () => {},
   } as DOMRect);
 
+type GridItemSpec = {
+  id: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+const gridRect = ({ left, top, width, height }: GridItemSpec): DOMRect =>
+  ({
+    top,
+    bottom: top + height,
+    left,
+    right: left + width,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => {},
+  } as DOMRect);
+
+const makeGridZone = (items: GridItemSpec[]) => {
+  const zone = document.createElement("div");
+
+  items.forEach((item) => {
+    const el = document.createElement("div");
+
+    el.setAttribute("data-puck-component", item.id);
+    el.getBoundingClientRect = () => gridRect(item);
+
+    zone.appendChild(el);
+  });
+
+  document.body.appendChild(zone);
+
+  return zone;
+};
+
 const makeRowZone = (items: HItemSpec[], { rtl }: { rtl?: boolean } = {}) => {
   const zone = document.createElement("div");
 
@@ -167,6 +205,43 @@ describe("getNearestGapIndex in horizontal flows", () => {
     expect(getNearestGapIndex(zone, { x: 295, y: 50 }, contentIds)).toBe(3);
   });
 
+  it("prefers gaps in the pointer's row over nearer gaps in other rows", () => {
+    // Two wrapped rows with misaligned columns: row 1 has two wide items, row
+    // 2 has three narrow ones, so row 1's a|b gap (x 150) sits between row 2's
+    // gaps (x 100 and x 200).
+    const contentIds = ["a", "b", "c", "d", "e"];
+    const zone = makeGridZone([
+      { id: "a", left: 0, top: 0, width: 150, height: 100 },
+      { id: "b", left: 150, top: 0, width: 150, height: 100 },
+      { id: "c", left: 0, top: 100, width: 100, height: 100 },
+      { id: "d", left: 100, top: 100, width: 100, height: 100 },
+      { id: "e", left: 200, top: 100, width: 100, height: 100 },
+    ]);
+
+    // Pointer inside row 2, just under the row boundary. The a|b gap in row 1
+    // is geometrically nearest (~14px vs 40px), but the pointer's row wins:
+    // the gap between c and d.
+    expect(getNearestGapIndex(zone, { x: 140, y: 110 }, contentIds)).toBe(3);
+
+    // Mirrored: pointer inside row 1 targets row 1's a|b gap.
+    expect(getNearestGapIndex(zone, { x: 140, y: 90 }, contentIds)).toBe(1);
+  });
+
+  it("falls back to the nearest gap overall when the pointer is between rows", () => {
+    const contentIds = ["a", "b", "c", "d", "e"];
+    const zone = makeGridZone([
+      { id: "a", left: 0, top: 0, width: 150, height: 100 },
+      { id: "b", left: 150, top: 0, width: 150, height: 100 },
+      { id: "c", left: 0, top: 110, width: 100, height: 100 },
+      { id: "d", left: 100, top: 110, width: 100, height: 100 },
+      { id: "e", left: 200, top: 110, width: 100, height: 100 },
+    ]);
+
+    // Pointer in the 10px strip between the rows sits in no lane, so plain
+    // distance applies: the a|b gap is 5px away.
+    expect(getNearestGapIndex(zone, { x: 150, y: 105 }, contentIds)).toBe(1);
+  });
+
   it("mirrors before/after edges for rtl rows", () => {
     // DOM order is a, b, c but rtl lays them right-to-left, so index order
     // runs from the right edge to the left.
@@ -186,5 +261,68 @@ describe("getNearestGapIndex in horizontal flows", () => {
     expect(getNearestGapIndex(zone, { x: 1, y: 50 }, contentIds)).toBe(3);
     // Between b and c (x = 100).
     expect(getNearestGapIndex(zone, { x: 110, y: 50 }, contentIds)).toBe(2);
+  });
+});
+
+describe("getNearestGapIndex in vertical multi-column flows", () => {
+  let getComputedStyleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getComputedStyleSpy = jest
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({
+        display: "flex",
+        flexDirection: "column",
+        gridTemplateColumns: "none",
+        gridTemplateRows: "none",
+        gridAutoFlow: "row",
+      } as unknown as CSSStyleDeclaration);
+  });
+
+  afterEach(() => {
+    getComputedStyleSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  it("prefers gaps in the pointer's column over nearer gaps in other columns", () => {
+    // Misaligned columns: column 1 has two tall items, column 2 three short
+    // ones, so column 1's a|b gap (y 150) sits between column 2's gaps.
+    const contentIds = ["a", "b", "c", "d", "e"];
+    const zone = makeGridZone([
+      { id: "a", left: 0, top: 0, width: 100, height: 150 },
+      { id: "b", left: 0, top: 150, width: 100, height: 150 },
+      { id: "c", left: 110, top: 0, width: 100, height: 100 },
+      { id: "d", left: 110, top: 100, width: 100, height: 100 },
+      { id: "e", left: 110, top: 200, width: 100, height: 100 },
+    ]);
+
+    // Pointer inside column 2, beside column 1's a|b gap (~16px away): the
+    // pointer's column wins with the gap between c and d (45px).
+    expect(getNearestGapIndex(zone, { x: 115, y: 145 }, contentIds)).toBe(3);
+
+    // Mirrored: pointer inside column 1 targets column 1's a|b gap.
+    expect(getNearestGapIndex(zone, { x: 50, y: 145 }, contentIds)).toBe(1);
+  });
+
+  it("targets gaps along a wrapped column instead of pulling to the column top", () => {
+    // `flex-flow: column wrap` with a set height: three items fill column 1,
+    // the rest wrap into column 2.
+    const contentIds = ["a", "b", "c", "d", "e"];
+    const zone = makeGridZone([
+      { id: "a", left: 0, top: 0, width: 100, height: 100 },
+      { id: "b", left: 0, top: 100, width: 100, height: 100 },
+      { id: "c", left: 0, top: 200, width: 100, height: 100 },
+      { id: "d", left: 110, top: 0, width: 100, height: 100 },
+      { id: "e", left: 110, top: 100, width: 100, height: 100 },
+    ]);
+
+    // Top of column 2: before d.
+    expect(getNearestGapIndex(zone, { x: 160, y: 15 }, contentIds)).toBe(3);
+    // Middle of column 2: between d and e — not the column top.
+    expect(getNearestGapIndex(zone, { x: 160, y: 130 }, contentIds)).toBe(4);
+    // Bottom of column 2: after e.
+    expect(getNearestGapIndex(zone, { x: 160, y: 190 }, contentIds)).toBe(5);
+    // Bottom of column 1: the wrap boundary (same index as before d).
+    expect(getNearestGapIndex(zone, { x: 50, y: 290 }, contentIds)).toBe(3);
   });
 });

--- a/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
+++ b/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
@@ -1,0 +1,46 @@
+import { resolveDndMode, resolveOriginPreviewIndex } from "../resolve-dnd-mode";
+
+describe("resolveDndMode", () => {
+  it("uses fluid mode within a slot for auto behavior", () => {
+    expect(resolveDndMode("auto")).toBe("fluid");
+  });
+
+  it("uses static mode between slots and for new components for auto behavior", () => {
+    expect(resolveDndMode("auto", { isDraggingBetweenSlots: true })).toBe(
+      "static"
+    );
+    expect(resolveDndMode("auto", { isNewComponent: true })).toBe("static");
+  });
+
+  it("always uses fluid mode for fluid behavior", () => {
+    expect(resolveDndMode("fluid")).toBe("fluid");
+    expect(resolveDndMode("fluid", { isDraggingBetweenSlots: true })).toBe(
+      "fluid"
+    );
+    expect(resolveDndMode("fluid", { isNewComponent: true })).toBe("fluid");
+  });
+
+  it("always uses static mode for static behavior", () => {
+    expect(resolveDndMode("static")).toBe("static");
+    expect(resolveDndMode("static", { isDraggingBetweenSlots: true })).toBe(
+      "static"
+    );
+    expect(resolveDndMode("static", { isNewComponent: true })).toBe("static");
+  });
+});
+
+describe("resolveOriginPreviewIndex", () => {
+  it("pins static previews to the initial rendered index", () => {
+    expect(
+      resolveOriginPreviewIndex(0, { index: 2, linePlaceholder: true })
+    ).toBe(0);
+  });
+
+  it("pins fluid previews to their latest rendered index", () => {
+    expect(resolveOriginPreviewIndex(0, { index: 2 })).toBe(2);
+  });
+
+  it("falls back to the initial index without a preview", () => {
+    expect(resolveOriginPreviewIndex(1)).toBe(1);
+  });
+});

--- a/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
+++ b/packages/core/lib/dnd/__tests__/resolve-dnd-mode.spec.ts
@@ -1,4 +1,4 @@
-import { resolveDndMode, resolveOriginPreviewIndex } from "../resolve-dnd-mode";
+import { resolveDndMode } from "../resolve-dnd-mode";
 
 describe("resolveDndMode", () => {
   it("uses fluid mode within a slot for auto behavior", () => {
@@ -26,21 +26,5 @@ describe("resolveDndMode", () => {
       "static"
     );
     expect(resolveDndMode("static", { isNewComponent: true })).toBe("static");
-  });
-});
-
-describe("resolveOriginPreviewIndex", () => {
-  it("pins static previews to the initial rendered index", () => {
-    expect(
-      resolveOriginPreviewIndex(0, { index: 2, linePlaceholder: true })
-    ).toBe(0);
-  });
-
-  it("pins fluid previews to their latest rendered index", () => {
-    expect(resolveOriginPreviewIndex(0, { index: 2 })).toBe(2);
-  });
-
-  it("falls back to the initial index without a preview", () => {
-    expect(resolveOriginPreviewIndex(1)).toBe(1);
   });
 });

--- a/packages/core/lib/dnd/__tests__/resolve-flow.spec.ts
+++ b/packages/core/lib/dnd/__tests__/resolve-flow.spec.ts
@@ -1,0 +1,140 @@
+import { resolveZoneFlow } from "../resolve-flow";
+
+const zoneWith = (
+  style: Partial<CSSStyleDeclaration>,
+  dir?: "ltr" | "rtl"
+) => {
+  const el = document.createElement("div");
+
+  if (dir) el.setAttribute("dir", dir);
+
+  const win = {
+    getComputedStyle: () =>
+      ({
+        display: "block",
+        flexDirection: "row",
+        gridTemplateColumns: "none",
+        gridTemplateRows: "none",
+        gridAutoFlow: "row",
+        ...style,
+      } as CSSStyleDeclaration),
+  } as unknown as Window;
+
+  return { el, win };
+};
+
+describe("resolveZoneFlow", () => {
+  it("treats block containers as a vertical stack", () => {
+    const { el, win } = zoneWith({ display: "block" });
+
+    expect(resolveZoneFlow(el, win)).toEqual({ axis: "y", reversed: false });
+  });
+
+  it("resolves flex rows (incl. inline-flex) to a horizontal axis", () => {
+    expect(
+      resolveZoneFlow(...toArgs({ display: "flex", flexDirection: "row" }))
+    ).toEqual({ axis: "x", reversed: false });
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "inline-flex", flexDirection: "row" })
+      )
+    ).toEqual({ axis: "x", reversed: false });
+  });
+
+  it("reverses rows for rtl and row-reverse (and un-reverses when combined)", () => {
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "flex", flexDirection: "row" }, "rtl")
+      )
+    ).toEqual({ axis: "x", reversed: true });
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "flex", flexDirection: "row-reverse" })
+      )
+    ).toEqual({ axis: "x", reversed: true });
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "flex", flexDirection: "row-reverse" }, "rtl")
+      )
+    ).toEqual({ axis: "x", reversed: false });
+  });
+
+  it("resolves flex columns to a vertical axis", () => {
+    expect(
+      resolveZoneFlow(...toArgs({ display: "flex", flexDirection: "column" }))
+    ).toEqual({ axis: "y", reversed: false });
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "flex", flexDirection: "column-reverse" })
+      )
+    ).toEqual({ axis: "y", reversed: true });
+  });
+
+  it("treats single-column and bare grids as a vertical stack", () => {
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "grid", gridTemplateColumns: "100px" })
+      )
+    ).toEqual({ axis: "y", reversed: false });
+    // A bare `display: grid` serializes its templates as "none" (a single
+    // implicit column that fills row-by-row).
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "grid", gridTemplateColumns: "none" })
+      )
+    ).toEqual({ axis: "y", reversed: false });
+    // Bracketed line-name tokens must not be counted as tracks.
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "grid", gridTemplateColumns: "[start] 1fr [end]" })
+      )
+    ).toEqual({ axis: "y", reversed: false });
+  });
+
+  it("treats a multi-column grid as horizontal (respecting rtl)", () => {
+    expect(
+      resolveZoneFlow(
+        ...toArgs({ display: "grid", gridTemplateColumns: "100px 100px 100px" })
+      )
+    ).toEqual({ axis: "x", reversed: false });
+    expect(
+      resolveZoneFlow(
+        ...toArgs(
+          { display: "grid", gridTemplateColumns: "100px 100px" },
+          "rtl"
+        )
+      )
+    ).toEqual({ axis: "x", reversed: true });
+  });
+
+  it("treats column auto-flow grids as horizontal", () => {
+    // Column auto-flow lays items out across, even without explicit columns.
+    expect(
+      resolveZoneFlow(
+        ...toArgs({
+          display: "grid",
+          gridTemplateColumns: "none",
+          gridAutoFlow: "column",
+        })
+      )
+    ).toEqual({ axis: "x", reversed: false });
+    expect(
+      resolveZoneFlow(
+        ...toArgs({
+          display: "inline-grid",
+          gridTemplateColumns: "1fr 1fr",
+          gridAutoFlow: "row",
+        })
+      )
+    ).toEqual({ axis: "x", reversed: false });
+  });
+});
+
+const toArgs = (
+  style: Partial<CSSStyleDeclaration>,
+  dir?: "ltr" | "rtl"
+): [Element, Window] => {
+  const { el, win } = zoneWith(style, dir);
+
+  return [el, win];
+};

--- a/packages/core/lib/dnd/__tests__/resolve-flow.spec.ts
+++ b/packages/core/lib/dnd/__tests__/resolve-flow.spec.ts
@@ -1,9 +1,6 @@
 import { resolveZoneFlow } from "../resolve-flow";
 
-const zoneWith = (
-  style: Partial<CSSStyleDeclaration>,
-  dir?: "ltr" | "rtl"
-) => {
+const zoneWith = (style: Partial<CSSStyleDeclaration>, dir?: "ltr" | "rtl") => {
   const el = document.createElement("div");
 
   if (dir) el.setAttribute("dir", dir);

--- a/packages/core/lib/dnd/commit-animation.ts
+++ b/packages/core/lib/dnd/commit-animation.ts
@@ -1,0 +1,82 @@
+export const COMMIT_ANIMATION: KeyframeAnimationOptions = {
+  duration: 250,
+  easing: "ease",
+};
+
+const MAX_COMMIT_WAIT_FRAMES = 10;
+
+export const prefersReducedMotion = (doc: Document) =>
+  doc.defaultView?.matchMedia("(prefers-reduced-motion: reduce)").matches ??
+  false;
+
+type WaitForCommitOptions = {
+  zones: string[];
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+  initialExpectedOrder?: string[];
+};
+
+/**
+ * Waits for a dispatched move or insert to render. The committed item must
+ * appear in the target zone's expected order and leave every other zone.
+ * Inserted item ids are inferred by comparing the pre- and post-commit order.
+ */
+export const waitForCommit = (
+  doc: Document,
+  {
+    zones,
+    itemId,
+    targetZone,
+    getExpectedOrder,
+    initialExpectedOrder = [],
+  }: WaitForCommitOptions,
+  callback: (committed: HTMLElement | null) => void
+) => {
+  let attempts = 0;
+
+  const tick = () => {
+    const zoneEl = doc.querySelector(`[data-puck-dropzone="${targetZone}"]`);
+    const expected = getExpectedOrder();
+    const committedItemId =
+      itemId ?? expected.find((id) => !initialExpectedOrder.includes(id));
+    const committed = committedItemId
+      ? zoneEl?.querySelector<HTMLElement>(
+          `:scope > [data-puck-component="${committedItemId}"]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+        ) ?? null
+      : null;
+    const rendered = zoneEl
+      ? Array.from(
+          zoneEl.querySelectorAll(
+            ":scope > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])"
+          )
+        ).map((el) => el.getAttribute("data-puck-component"))
+      : [];
+    const expectedRendered = expected.filter((id) => rendered.includes(id));
+    const orderMatches =
+      rendered.length === expectedRendered.length &&
+      rendered.every((id, index) => id === expectedRendered[index]);
+    const leftOtherZones = zones.every(
+      (zone) =>
+        zone === targetZone ||
+        !committedItemId ||
+        !doc.querySelector(
+          `[data-puck-dropzone="${zone}"] > [data-puck-component="${committedItemId}"]`
+        )
+    );
+
+    if (
+      (!committed || !orderMatches || !leftOtherZones) &&
+      attempts < MAX_COMMIT_WAIT_FRAMES
+    ) {
+      attempts++;
+      requestAnimationFrame(tick);
+
+      return;
+    }
+
+    callback(committed);
+  };
+
+  requestAnimationFrame(tick);
+};

--- a/packages/core/lib/dnd/commit-animation.ts
+++ b/packages/core/lib/dnd/commit-animation.ts
@@ -1,3 +1,5 @@
+import { getComponentSelector, getZoneSelector } from "../dom-selectors";
+
 export const COMMIT_ANIMATION: KeyframeAnimationOptions = {
   duration: 250,
   easing: "ease",
@@ -10,17 +12,25 @@ export const prefersReducedMotion = (doc: Document) =>
   false;
 
 type WaitForCommitOptions = {
+  /** The zones to check for the item. */
   zones: string[];
+  /** The id of the item to wait for. If not provided, the first item that is not in the initial expected order will be used. */
   itemId?: string;
+  /** The zone the item is moved or inserted into. */
   targetZone: string;
+  /** A function that returns the expected order of items in the target zone. */
   getExpectedOrder: () => string[];
+  /** The initial expected order of items in the target zone. Defaults to an empty array. */
   initialExpectedOrder?: string[];
 };
 
 /**
- * Waits for a dispatched move or insert to render. The committed item must
- * appear in the target zone's expected order and leave every other zone.
- * Inserted item ids are inferred by comparing the pre- and post-commit order.
+ * Dispatches a callback when an item has been moved or inserted into a target zone
+ * and rendered in the DOM.
+ *
+ * @param doc The document to query for the target zone and item.
+ * @param options The options for waiting for the commit.
+ * @param callback The callback to invoke when the item has been committed.
  */
 export const waitForCommit = (
   doc: Document,
@@ -33,18 +43,26 @@ export const waitForCommit = (
   }: WaitForCommitOptions,
   callback: (committed: HTMLElement | null) => void
 ) => {
+  const initialIds = new Set(initialExpectedOrder);
+
   let attempts = 0;
 
   const tick = () => {
-    const zoneEl = doc.querySelector(`[data-puck-dropzone="${targetZone}"]`);
+    const zoneEl = doc.querySelector(getZoneSelector(targetZone));
+
     const expected = getExpectedOrder();
+
     const committedItemId =
-      itemId ?? expected.find((id) => !initialExpectedOrder.includes(id));
+      itemId ?? expected.find((id) => !initialIds.has(id));
+
     const committed = committedItemId
       ? zoneEl?.querySelector<HTMLElement>(
-          `:scope > [data-puck-component="${committedItemId}"]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+          `:scope > ${getComponentSelector(
+            committedItemId
+          )}:not([data-dnd-dragging]):not([data-dnd-placeholder])`
         ) ?? null
       : null;
+
     const rendered = zoneEl
       ? Array.from(
           zoneEl.querySelectorAll(
@@ -52,16 +70,21 @@ export const waitForCommit = (
           )
         ).map((el) => el.getAttribute("data-puck-component"))
       : [];
-    const expectedRendered = expected.filter((id) => rendered.includes(id));
+
+    const renderedIds = new Set(rendered);
+
+    const expectedRendered = expected.filter((id) => renderedIds.has(id));
+
     const orderMatches =
       rendered.length === expectedRendered.length &&
       rendered.every((id, index) => id === expectedRendered[index]);
+
     const leftOtherZones = zones.every(
       (zone) =>
         zone === targetZone ||
         !committedItemId ||
         !doc.querySelector(
-          `[data-puck-dropzone="${zone}"] > [data-puck-component="${committedItemId}"]`
+          `${getZoneSelector(zone)} > ${getComponentSelector(committedItemId)}`
         )
     );
 

--- a/packages/core/lib/dnd/drop-animation.ts
+++ b/packages/core/lib/dnd/drop-animation.ts
@@ -1,0 +1,246 @@
+import type { DropAnimationFunction } from "@dnd-kit/dom";
+import { getFrame } from "../get-frame";
+import {
+  COMMIT_ANIMATION,
+  prefersReducedMotion,
+  waitForCommit,
+} from "./commit-animation";
+
+type DropAnimationContext = Parameters<DropAnimationFunction>[0];
+
+type TargetDrop = {
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+};
+
+const parseTranslateValue = (value: string) => {
+  if (!value || value === "none") return null;
+
+  const [x, y = "0px"] = value.split(" ");
+  const parsed = { x: parseFloat(x), y: parseFloat(y) };
+
+  if (isNaN(parsed.x) || isNaN(parsed.y)) return null;
+
+  return parsed;
+};
+
+const getFrameTransform = (element: Element, boundary: Element | null) => {
+  const transform = { x: 0, y: 0, scaleX: 1, scaleY: 1 };
+  let frame = element.ownerDocument.defaultView
+    ?.frameElement as HTMLIFrameElement | null;
+
+  while (frame && frame !== boundary) {
+    const rect = frame.getBoundingClientRect();
+    const scaleX = frame.offsetWidth ? rect.width / frame.offsetWidth : 1;
+    const scaleY = frame.offsetHeight ? rect.height / frame.offsetHeight : 1;
+
+    transform.x += rect.left;
+    transform.y += rect.top;
+    transform.scaleX *= scaleX;
+    transform.scaleY *= scaleY;
+    frame = frame.ownerDocument.defaultView
+      ?.frameElement as HTMLIFrameElement | null;
+  }
+
+  return transform;
+};
+
+const getRectInDocument = (element: HTMLElement, doc: Document) => {
+  const rect = element.getBoundingClientRect();
+
+  if (element.ownerDocument === doc) {
+    return rect;
+  }
+
+  const transform = getFrameTransform(
+    element,
+    doc.defaultView?.frameElement ?? null
+  );
+
+  return {
+    left: rect.left * transform.scaleX + transform.x,
+    top: rect.top * transform.scaleY + transform.y,
+    width: rect.width * transform.scaleX,
+    height: rect.height * transform.scaleY,
+  };
+};
+
+/**
+ * Matches dnd-kit's default behavior when a drag needs to return to its
+ * source placeholder, such as a canceled or invalid drop.
+ */
+export const runFallbackDropAnimation: DropAnimationFunction = ({
+  element,
+  feedbackElement,
+  placeholder,
+  translate,
+}) => {
+  const target = placeholder ?? element;
+  const currentRect = feedbackElement.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const finalPosition = {
+    x: targetRect.left + (targetRect.width - currentRect.width) / 2,
+    y: targetRect.top + (targetRect.height - currentRect.height) / 2,
+  };
+  const win = feedbackElement.ownerDocument.defaultView ?? window;
+  const currentTranslate =
+    parseTranslateValue(
+      win.getComputedStyle(feedbackElement as HTMLElement).translate
+    ) ?? translate;
+  const finalTranslate = {
+    x: currentTranslate.x + finalPosition.x - currentRect.left,
+    y: currentTranslate.y + finalPosition.y - currentRect.top,
+  };
+
+  feedbackElement.setAttribute("data-dnd-dropping", "");
+
+  return feedbackElement
+    .animate(
+      {
+        translate: [
+          `${currentTranslate.x}px ${currentTranslate.y}px 0`,
+          `${finalTranslate.x}px ${finalTranslate.y}px 0`,
+        ],
+      },
+      COMMIT_ANIMATION
+    )
+    .finished.catch(() => undefined)
+    .then(() => {
+      feedbackElement.removeAttribute("data-dnd-dropping");
+    });
+};
+
+/**
+ * Commits a valid drop immediately, then glides a visual copy from the
+ * pointer to the final rendered item in the canvas.
+ */
+export const runTargetDropAnimation = ({
+  feedbackElement,
+  itemId,
+  targetZone,
+  getExpectedOrder,
+}: {
+  feedbackElement: HTMLElement;
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+}) => {
+  const overlayDoc = feedbackElement.ownerDocument;
+  const targetDoc = getFrame() ?? overlayDoc;
+
+  if (prefersReducedMotion(overlayDoc)) return;
+
+  const rect = feedbackElement.getBoundingClientRect();
+  const initialExpectedOrder = getExpectedOrder();
+  const copy = feedbackElement.cloneNode(true) as HTMLElement;
+
+  copy.removeAttribute("id");
+  copy.removeAttribute("popover");
+  copy.removeAttribute("data-puck-component");
+  copy.removeAttribute("data-puck-dnd");
+  copy.removeAttribute("data-dnd-dragging");
+  copy.setAttribute("inert", "true");
+
+  Object.assign(copy.style, {
+    position: "fixed",
+    left: `${rect.left}px`,
+    top: `${rect.top}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    margin: "0",
+    overflow: "hidden",
+    pointerEvents: "none",
+    transform: "none",
+    transition: "none",
+    translate: "none",
+    zIndex: "2147483647",
+  });
+
+  const hideStyle = targetDoc.createElement("style");
+  hideStyle.textContent = `
+    ${
+      itemId
+        ? `[data-puck-component="${itemId}"] { visibility: hidden !important; }`
+        : ""
+    }
+    [data-puck-overlay] { opacity: 0 !important; }
+  `;
+
+  targetDoc.head.appendChild(hideStyle);
+  overlayDoc.body.appendChild(copy);
+
+  const cleanup = () => {
+    copy.remove();
+    hideStyle.remove();
+  };
+
+  waitForCommit(
+    targetDoc,
+    {
+      zones: [targetZone],
+      itemId,
+      targetZone,
+      getExpectedOrder,
+      initialExpectedOrder,
+    },
+    (committed) => {
+      if (!committed) {
+        cleanup();
+
+        return;
+      }
+
+      const committedId = committed.getAttribute("data-puck-component");
+
+      if (!itemId && committedId) {
+        hideStyle.textContent += `
+          [data-puck-component="${committedId}"] { visibility: hidden !important; }
+        `;
+      }
+
+      const final = getRectInDocument(committed, overlayDoc);
+
+      copy
+        .animate(
+          {
+            translate: [
+              "0px 0px 0",
+              `${final.left - rect.left}px ${final.top - rect.top}px 0`,
+            ],
+            width: [`${rect.width}px`, `${final.width}px`],
+            height: [`${rect.height}px`, `${final.height}px`],
+          },
+          { ...COMMIT_ANIMATION, fill: "forwards" }
+        )
+        .finished.catch(() => undefined)
+        .then(cleanup);
+    }
+  );
+};
+
+/**
+ * Sends valid committed drops to their rendered destination and canceled or
+ * invalid drops back to dnd-kit's source placeholder.
+ */
+export const runDropAnimation = (
+  context: DropAnimationContext,
+  target?: TargetDrop
+) => {
+  const operation = context.source.manager?.dragOperation;
+  const aborted =
+    (operation?.canceled ?? false) || operation?.target?.type === "void";
+
+  if (!aborted && target) {
+    runTargetDropAnimation({
+      ...target,
+      feedbackElement: context.feedbackElement as HTMLElement,
+    });
+
+    // Resolve immediately so dnd-kit commits and cleans up while the visual
+    // copy independently glides to the newly rendered component.
+    return;
+  }
+
+  return runFallbackDropAnimation(context);
+};

--- a/packages/core/lib/dnd/drop-animation.ts
+++ b/packages/core/lib/dnd/drop-animation.ts
@@ -5,6 +5,7 @@ import {
   prefersReducedMotion,
   waitForCommit,
 } from "./commit-animation";
+import { getComponentSelector } from "../dom-selectors";
 
 type DropAnimationContext = Parameters<DropAnimationFunction>[0];
 
@@ -76,6 +77,8 @@ export const runFallbackDropAnimation: DropAnimationFunction = ({
   placeholder,
   translate,
 }) => {
+  if (prefersReducedMotion(feedbackElement.ownerDocument)) return;
+
   const target = placeholder ?? element;
   const currentRect = feedbackElement.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
@@ -161,7 +164,7 @@ export const runTargetDropAnimation = ({
   hideStyle.textContent = `
     ${
       itemId
-        ? `[data-puck-component="${itemId}"] { visibility: hidden !important; }`
+        ? `${getComponentSelector(itemId)} { visibility: hidden !important; }`
         : ""
     }
     [data-puck-overlay] { opacity: 0 !important; }
@@ -195,7 +198,7 @@ export const runTargetDropAnimation = ({
 
       if (!itemId && committedId) {
         hideStyle.textContent += `
-          [data-puck-component="${committedId}"] { visibility: hidden !important; }
+          ${getComponentSelector(committedId)} { visibility: hidden !important; }
         `;
       }
 

--- a/packages/core/lib/dnd/drop-animation.ts
+++ b/packages/core/lib/dnd/drop-animation.ts
@@ -1,4 +1,9 @@
 import type { DropAnimationFunction } from "@dnd-kit/dom";
+import {
+  DOMRectangle,
+  getComputedStyles,
+  parseTranslate,
+} from "@dnd-kit/dom/utilities";
 import { getFrame } from "../get-frame";
 import {
   COMMIT_ANIMATION,
@@ -13,17 +18,6 @@ type TargetDrop = {
   itemId?: string;
   targetZone: string;
   getExpectedOrder: () => string[];
-};
-
-const parseTranslateValue = (value: string) => {
-  if (!value || value === "none") return null;
-
-  const [x, y = "0px"] = value.split(" ");
-  const parsed = { x: parseFloat(x), y: parseFloat(y) };
-
-  if (isNaN(parsed.x) || isNaN(parsed.y)) return null;
-
-  return parsed;
 };
 
 const getFrameTransform = (element: Element, boundary: Element | null) => {
@@ -68,8 +62,7 @@ const getRectInDocument = (element: HTMLElement, doc: Document) => {
 };
 
 /**
- * Matches dnd-kit's default behavior when a drag needs to return to its
- * source placeholder, such as a canceled or invalid drop.
+ * Runs the `"fluid"` drop animation.
  */
 export const runFallbackDropAnimation: DropAnimationFunction = ({
   element,
@@ -80,20 +73,21 @@ export const runFallbackDropAnimation: DropAnimationFunction = ({
   if (prefersReducedMotion(feedbackElement.ownerDocument)) return;
 
   const target = placeholder ?? element;
-  const currentRect = feedbackElement.getBoundingClientRect();
-  const targetRect = target.getBoundingClientRect();
-  const finalPosition = {
-    x: targetRect.left + (targetRect.width - currentRect.width) / 2,
-    y: targetRect.top + (targetRect.height - currentRect.height) / 2,
-  };
-  const win = feedbackElement.ownerDocument.defaultView ?? window;
+
+  // Skip the (costly) frame transform when both elements live in the same
+  // document, matching dnd-kit's default.
+  const sameFrame = feedbackElement.ownerDocument === target.ownerDocument;
+  const options = { frameTransform: sameFrame ? null : undefined };
+  const current = new DOMRectangle(feedbackElement, options);
+  const final = new DOMRectangle(target, options);
+
   const currentTranslate =
-    parseTranslateValue(
-      win.getComputedStyle(feedbackElement as HTMLElement).translate
-    ) ?? translate;
+    parseTranslate(getComputedStyles(feedbackElement).translate) ?? translate;
+
+  // Centre-align the feedback onto the target, matching dnd-kit's default.
   const finalTranslate = {
-    x: currentTranslate.x + finalPosition.x - currentRect.left,
-    y: currentTranslate.y + finalPosition.y - currentRect.top,
+    x: currentTranslate.x - (current.center.x - final.center.x),
+    y: currentTranslate.y - (current.center.y - final.center.y),
   };
 
   feedbackElement.setAttribute("data-dnd-dropping", "");
@@ -115,6 +109,8 @@ export const runFallbackDropAnimation: DropAnimationFunction = ({
 };
 
 /**
+ * Runs the `"static"` drop animation.
+ *
  * Commits a valid drop immediately, then glides a visual copy from the
  * pointer to the final rendered item in the canvas.
  */
@@ -206,13 +202,16 @@ export const runTargetDropAnimation = ({
 
       const final = getRectInDocument(committed, overlayDoc);
 
+      // Glide with `left`/`top` rather than a `translate` keyframe. WebKit runs
+      // accelerated properties (translate) on the compositor but width/height
+      // on the main thread, and the post-drop React commit blocks the main
+      // thread, so on Safari the translate races ahead of the width changes and
+      // the still-narrow clone swept sideways before the size caught up.
       copy
         .animate(
           {
-            translate: [
-              "0px 0px 0",
-              `${final.left - rect.left}px ${final.top - rect.top}px 0`,
-            ],
+            left: [`${rect.left}px`, `${final.left}px`],
+            top: [`${rect.top}px`, `${final.top}px`],
             width: [`${rect.width}px`, `${final.width}px`],
             height: [`${rect.height}px`, `${final.height}px`],
           },

--- a/packages/core/lib/dnd/drop-animation.ts
+++ b/packages/core/lib/dnd/drop-animation.ts
@@ -198,7 +198,9 @@ export const runTargetDropAnimation = ({
 
       if (!itemId && committedId) {
         hideStyle.textContent += `
-          ${getComponentSelector(committedId)} { visibility: hidden !important; }
+          ${getComponentSelector(
+            committedId
+          )} { visibility: hidden !important; }
         `;
       }
 

--- a/packages/core/lib/dnd/flip-commit.ts
+++ b/packages/core/lib/dnd/flip-commit.ts
@@ -1,0 +1,82 @@
+import { getFrame } from "../get-frame";
+import {
+  COMMIT_ANIMATION,
+  prefersReducedMotion,
+  waitForCommit,
+} from "./commit-animation";
+
+/**
+ * Captures sibling positions before a static drop commits and returns a
+ * callback that FLIP-animates those siblings once the new layout renders.
+ */
+export const prepareCommitFlip = ({
+  zones,
+  itemId,
+  targetZone,
+  getExpectedOrder,
+}: {
+  zones: string[];
+  itemId?: string;
+  targetZone: string;
+  getExpectedOrder: () => string[];
+}): (() => void) => {
+  const frame = getFrame();
+
+  if (!frame || prefersReducedMotion(frame)) {
+    return () => {};
+  }
+
+  const itemsSelector = Array.from(new Set(zones))
+    .map(
+      (zone) =>
+        `[data-puck-dropzone="${zone}"] > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+    )
+    .join(", ");
+
+  const capture = () => {
+    const items = new Map<string, { el: HTMLElement; rect: DOMRect }>();
+
+    frame.querySelectorAll<HTMLElement>(itemsSelector).forEach((el) => {
+      const id = el.getAttribute("data-puck-component");
+
+      if (id && id !== itemId) {
+        items.set(id, { el, rect: el.getBoundingClientRect() });
+      }
+    });
+
+    return items;
+  };
+
+  const first = capture();
+  const initialExpectedOrder = getExpectedOrder();
+
+  return () => {
+    waitForCommit(
+      frame,
+      {
+        zones,
+        itemId,
+        targetZone,
+        getExpectedOrder,
+        initialExpectedOrder,
+      },
+      () => {
+        capture().forEach(({ el, rect }, id) => {
+          const initial = first.get(id)?.rect;
+
+          if (!initial) return;
+
+          const dx = initial.x - rect.x;
+          const dy = initial.y - rect.y;
+
+          if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+
+          el.animate(
+            { translate: [`${dx}px ${dy}px 0`, "0px 0px 0"] },
+            COMMIT_ANIMATION
+          );
+        });
+      }
+    );
+  };
+};

--- a/packages/core/lib/dnd/flip-commit.ts
+++ b/packages/core/lib/dnd/flip-commit.ts
@@ -4,6 +4,7 @@ import {
   prefersReducedMotion,
   waitForCommit,
 } from "./commit-animation";
+import { getZoneSelector } from "../dom-selectors";
 
 /**
  * Captures sibling positions before a static drop commits and returns a
@@ -29,7 +30,9 @@ export const prepareCommitFlip = ({
   const itemsSelector = Array.from(new Set(zones))
     .map(
       (zone) =>
-        `[data-puck-dropzone="${zone}"] > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
+        `${getZoneSelector(
+          zone
+        )} > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])`
     )
     .join(", ");
 

--- a/packages/core/lib/dnd/frame-pointer.ts
+++ b/packages/core/lib/dnd/frame-pointer.ts
@@ -1,0 +1,31 @@
+type Point = { x: number; y: number };
+
+/**
+ * Maps a position  from top-window coordinates into Puck's preview iframe
+ * coordinate space, accounting for the iframe's scale.
+ *
+ * Only converts when `targetEl` lives inside the iframe; otherwise the position
+ * is already in the correct space and is returned unchanged.
+ *
+ * @param targetEl - Used to check whether the target is inside the preview iframe.
+ * @param position - The position in top-window coordinates.
+ * @returns The position in the iframe's coordinate space, or unchanged when the target is outside the iframe.
+ */
+export const getFramePointer = (targetEl: Element, position: Point): Point => {
+  const frameEl = document.querySelector(
+    "iframe#preview-frame"
+  ) as HTMLIFrameElement | null;
+
+  // If there's no frame or the target element is not inside the frame, return the original position
+  if (!frameEl || targetEl.ownerDocument !== frameEl.contentDocument) {
+    return position;
+  }
+
+  const rect = frameEl.getBoundingClientRect();
+  const scale = rect.width / (frameEl.contentWindow?.innerWidth || 1);
+
+  return {
+    x: (position.x - rect.left) / scale,
+    y: (position.y - rect.top) / scale,
+  };
+};

--- a/packages/core/lib/dnd/frame-pointer.ts
+++ b/packages/core/lib/dnd/frame-pointer.ts
@@ -24,6 +24,10 @@ export const getFramePointer = (targetEl: Element, position: Point): Point => {
   const rect = frameEl.getBoundingClientRect();
   const scale = rect.width / (frameEl.contentWindow?.innerWidth || 1);
 
+  if (!(scale > 0)) {
+    return position;
+  }
+
   return {
     x: (position.x - rect.left) / scale,
     y: (position.y - rect.top) / scale,

--- a/packages/core/lib/dnd/nearest-gap.ts
+++ b/packages/core/lib/dnd/nearest-gap.ts
@@ -1,0 +1,159 @@
+type Point = { x: number; y: number };
+
+type GapCandidate = {
+  index: number;
+  // A line segment describing the gap
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+const distanceToSegment = (point: Point, gap: GapCandidate) => {
+  const x = Math.max(gap.x1, Math.min(gap.x2, point.x));
+  const y = Math.max(gap.y1, Math.min(gap.y2, point.y));
+
+  return Math.hypot(point.x - x, point.y - y);
+};
+
+/**
+ * Maps a drag position from top-window coordinates (as tracked by dnd-kit's
+ * sensors) into the coordinate space of the element's frame, accounting for
+ * the canvas iframe scale.
+ */
+export const getFramePointer = (targetEl: Element, position: Point): Point => {
+  const frameEl = document.querySelector(
+    "iframe#preview-frame"
+  ) as HTMLIFrameElement | null;
+
+  if (!frameEl || targetEl.ownerDocument !== frameEl.contentDocument) {
+    return position;
+  }
+
+  const rect = frameEl.getBoundingClientRect();
+  const scale = rect.width / (frameEl.contentWindow?.innerWidth || 1);
+
+  return {
+    x: (position.x - rect.left) / scale,
+    y: (position.y - rect.top) / scale,
+  };
+};
+
+/**
+ * Returns the insertion index whose gap is nearest to the pointer, using the
+ * same geometry as the line placeholder indicator. This is more predictable
+ * than directional midpoint collisions for cross-zone drags, where items
+ * don't move out of the way and the drag shape's size is unrelated to the
+ * target zone's items.
+ *
+ * Rendered items are mapped to their real content indices via `contentIds`:
+ * virtualized zones only render a window of their content, so DOM positions
+ * can't be used as indices directly.
+ */
+export const getNearestGapIndex = (
+  zoneEl: Element,
+  pointer: Point,
+  contentIds: string[]
+): number | null => {
+  const win = zoneEl.ownerDocument.defaultView;
+
+  if (!win) return null;
+
+  const rendered = Array.from(
+    zoneEl.querySelectorAll(
+      ":scope > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])"
+    )
+  )
+    .map((el) => ({
+      index: contentIds.indexOf(el.getAttribute("data-puck-component") ?? ""),
+      rect: el.getBoundingClientRect(),
+    }))
+    .filter((item) => item.index !== -1)
+    .sort((a, b) => a.index - b.index);
+
+  if (rendered.length === 0) return 0;
+
+  const style = win.getComputedStyle(zoneEl);
+  const horizontalFlow =
+    style.display === "grid" ||
+    (style.display === "flex" && style.flexDirection.startsWith("row"));
+
+  const candidates: GapCandidate[] = [];
+
+  const edgeCandidate = (
+    index: number,
+    rect: DOMRect,
+    side: "before" | "after"
+  ) => {
+    if (horizontalFlow) {
+      const x = side === "before" ? rect.left : rect.right;
+
+      candidates.push({ index, x1: x, x2: x, y1: rect.top, y2: rect.bottom });
+    } else {
+      const y = side === "before" ? rect.top : rect.bottom;
+
+      candidates.push({ index, y1: y, y2: y, x1: rect.left, x2: rect.right });
+    }
+  };
+
+  for (let i = 0; i <= rendered.length; i++) {
+    const prev = rendered[i - 1];
+    const next = rendered[i];
+
+    if (!next) {
+      // After the last rendered item
+      edgeCandidate(prev.index + 1, prev.rect, "after");
+    } else if (!prev) {
+      // Before the first rendered item
+      edgeCandidate(next.index, next.rect, "before");
+    } else if (next.index - prev.index > 1) {
+      // The items between these two are virtualized out: expose both edges
+      // as separate insertion points
+      edgeCandidate(prev.index + 1, prev.rect, "after");
+      edgeCandidate(next.index, next.rect, "before");
+    } else if (horizontalFlow) {
+      const wraps = prev.rect.right > next.rect.left;
+
+      if (wraps) {
+        // Row wraps expose both the end of the previous row and the start
+        // of the next as the same index
+        edgeCandidate(next.index, next.rect, "before");
+        edgeCandidate(next.index, prev.rect, "after");
+      } else {
+        const x = (prev.rect.right + next.rect.left) / 2;
+
+        candidates.push({
+          index: next.index,
+          x1: x,
+          x2: x,
+          y1: next.rect.top,
+          y2: next.rect.bottom,
+        });
+      }
+    } else {
+      const y = (prev.rect.bottom + next.rect.top) / 2;
+
+      candidates.push({
+        index: next.index,
+        y1: y,
+        y2: y,
+        x1: next.rect.left,
+        x2: next.rect.right,
+      });
+    }
+  }
+
+  let nearest: GapCandidate | null = null;
+  let nearestDistance = Infinity;
+
+  for (const candidate of candidates) {
+    const distance = distanceToSegment(pointer, candidate);
+
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearest = candidate;
+    }
+  }
+
+  return nearest?.index ?? null;
+};

--- a/packages/core/lib/dnd/nearest-gap.ts
+++ b/packages/core/lib/dnd/nearest-gap.ts
@@ -1,54 +1,24 @@
+import { getDistanceToSegment } from "../math";
+import { getItemEdgeAccessors, resolveZoneFlow } from "./resolve-flow";
+
 type Point = { x: number; y: number };
 
 type GapCandidate = {
   index: number;
-  // A line segment describing the gap
+  // A line segment describing the gap, ordered so x1 <= x2 and y1 <= y2.
   x1: number;
   y1: number;
   x2: number;
   y2: number;
 };
 
-const distanceToSegment = (point: Point, gap: GapCandidate) => {
-  const x = Math.max(gap.x1, Math.min(gap.x2, point.x));
-  const y = Math.max(gap.y1, Math.min(gap.y2, point.y));
-
-  return Math.hypot(point.x - x, point.y - y);
-};
-
 /**
- * Maps a drag position from top-window coordinates (as tracked by dnd-kit's
- * sensors) into the coordinate space of the element's frame, accounting for
- * the canvas iframe scale.
- */
-export const getFramePointer = (targetEl: Element, position: Point): Point => {
-  const frameEl = document.querySelector(
-    "iframe#preview-frame"
-  ) as HTMLIFrameElement | null;
-
-  if (!frameEl || targetEl.ownerDocument !== frameEl.contentDocument) {
-    return position;
-  }
-
-  const rect = frameEl.getBoundingClientRect();
-  const scale = rect.width / (frameEl.contentWindow?.innerWidth || 1);
-
-  return {
-    x: (position.x - rect.left) / scale,
-    y: (position.y - rect.top) / scale,
-  };
-};
-
-/**
- * Returns the insertion index whose gap is nearest to the pointer, using the
- * same geometry as the line placeholder indicator. This is more predictable
- * than directional midpoint collisions for cross-zone drags, where items
- * don't move out of the way and the drag shape's size is unrelated to the
- * target zone's items.
+ * Returns the insertion index in the content ids whose gap is nearest the pointer in the screen.
  *
- * Rendered items are mapped to their real content indices via `contentIds`:
- * virtualized zones only render a window of their content, so DOM positions
- * can't be used as indices directly.
+ * @param zoneEl The dropzone element in the DOM. This contains the items.
+ * @param pointer The pointer position in viewport coordinates.
+ * @param contentIds The content ids of all items in the zone, in order.
+ * @returns The index of the nearest gap, or null if no gaps exist (i.e., the zone is not on screen).
  */
 export const getNearestGapIndex = (
   zoneEl: Element,
@@ -59,87 +29,85 @@ export const getNearestGapIndex = (
 
   if (!win) return null;
 
+  const indexById = new Map(contentIds.map((id, index) => [id, index]));
+
+  // Get the rendered items in order of their content index, excluding the flying drag element and any placeholder clones.
+  // Rendered items are mapped back to their real content indices via `contentIds`, because
+  // virtualized zones only render a window of their content, so DOM order can't be used as the index directly.
   const rendered = Array.from(
     zoneEl.querySelectorAll(
       ":scope > [data-puck-component]:not([data-dnd-dragging]):not([data-dnd-placeholder])"
     )
   )
     .map((el) => ({
-      index: contentIds.indexOf(el.getAttribute("data-puck-component") ?? ""),
-      rect: el.getBoundingClientRect(),
+      index: indexById.get(el.getAttribute("data-puck-component") ?? "") ?? -1,
+      el,
     }))
     .filter((item) => item.index !== -1)
-    .sort((a, b) => a.index - b.index);
+    .sort((a, b) => a.index - b.index)
+    .map(({ index, el }) => ({ index, rect: el.getBoundingClientRect() }));
 
+  // No rendered items means the first position is the only option, so return 0.
   if (rendered.length === 0) return 0;
 
-  const style = win.getComputedStyle(zoneEl);
-  const horizontalFlow =
-    style.display === "grid" ||
-    (style.display === "flex" && style.flexDirection.startsWith("row"));
+  const zoneFlow = resolveZoneFlow(zoneEl, win);
+
+  const { horizontal, reversed, start, end } = getItemEdgeAccessors(zoneFlow);
+
+  // A gap is a line perpendicular to the main axis at `main`, spanning the
+  // full cross-axis extent of the closest item (neighbor).
+  const getGapAt = (
+    index: number,
+    main: number,
+    cross: DOMRect
+  ): GapCandidate =>
+    horizontal
+      ? { index, x1: main, x2: main, y1: cross.top, y2: cross.bottom }
+      : { index, x1: cross.left, x2: cross.right, y1: main, y2: main };
 
   const candidates: GapCandidate[] = [];
 
-  const edgeCandidate = (
+  const createEdgeCandidate = (
     index: number,
     rect: DOMRect,
     side: "before" | "after"
   ) => {
-    if (horizontalFlow) {
-      const x = side === "before" ? rect.left : rect.right;
+    const main = side === "before" ? start(rect) : end(rect);
 
-      candidates.push({ index, x1: x, x2: x, y1: rect.top, y2: rect.bottom });
-    } else {
-      const y = side === "before" ? rect.top : rect.bottom;
-
-      candidates.push({ index, y1: y, y2: y, x1: rect.left, x2: rect.right });
-    }
+    return getGapAt(index, main, rect);
   };
 
+  // Generate a list of all drop candidates.
   for (let i = 0; i <= rendered.length; i++) {
     const prev = rendered[i - 1];
     const next = rendered[i];
 
     if (!next) {
-      // After the last rendered item
-      edgeCandidate(prev.index + 1, prev.rect, "after");
+      // After the last rendered item. Get the end of the previous item as the drop position.
+      candidates.push(createEdgeCandidate(prev.index + 1, prev.rect, "after"));
     } else if (!prev) {
-      // Before the first rendered item
-      edgeCandidate(next.index, next.rect, "before");
+      // Before the first rendered item. Get the start of the next item as the drop position.
+      candidates.push(createEdgeCandidate(next.index, next.rect, "before"));
     } else if (next.index - prev.index > 1) {
-      // The items between these two are virtualized out: expose both edges
-      // as separate insertion points
-      edgeCandidate(prev.index + 1, prev.rect, "after");
-      edgeCandidate(next.index, next.rect, "before");
-    } else if (horizontalFlow) {
-      const wraps = prev.rect.right > next.rect.left;
-
-      if (wraps) {
-        // Row wraps expose both the end of the previous row and the start
-        // of the next as the same index
-        edgeCandidate(next.index, next.rect, "before");
-        edgeCandidate(next.index, prev.rect, "after");
-      } else {
-        const x = (prev.rect.right + next.rect.left) / 2;
-
-        candidates.push({
-          index: next.index,
-          x1: x,
-          x2: x,
-          y1: next.rect.top,
-          y2: next.rect.bottom,
-        });
-      }
+      // The items between these two are virtualized out: expose both edges as
+      // separate drop positions.
+      candidates.push(createEdgeCandidate(prev.index + 1, prev.rect, "after"));
+      candidates.push(createEdgeCandidate(next.index, next.rect, "before"));
+    } else if (
+      horizontal &&
+      (reversed
+        ? end(prev.rect) < start(next.rect)
+        : end(prev.rect) > start(next.rect))
+    ) {
+      // The row wraps between these items: expose the end of the previous row
+      // and the start of the next as the same drop position (they share the same index).
+      candidates.push(createEdgeCandidate(next.index, next.rect, "before"));
+      candidates.push(createEdgeCandidate(next.index, prev.rect, "after"));
     } else {
-      const y = (prev.rect.bottom + next.rect.top) / 2;
+      // Adjacent items: expose midpoint of the gap between them as the drop position.
+      const mid = (end(prev.rect) + start(next.rect)) / 2;
 
-      candidates.push({
-        index: next.index,
-        y1: y,
-        y2: y,
-        x1: next.rect.left,
-        x2: next.rect.right,
-      });
+      candidates.push(getGapAt(next.index, mid, next.rect));
     }
   }
 
@@ -147,7 +115,7 @@ export const getNearestGapIndex = (
   let nearestDistance = Infinity;
 
   for (const candidate of candidates) {
-    const distance = distanceToSegment(pointer, candidate);
+    const distance = getDistanceToSegment(pointer, candidate);
 
     if (distance < nearestDistance) {
       nearestDistance = distance;

--- a/packages/core/lib/dnd/nearest-gap.ts
+++ b/packages/core/lib/dnd/nearest-gap.ts
@@ -10,10 +10,22 @@ type GapCandidate = {
   y1: number;
   x2: number;
   y2: number;
+  // The cross-axis band of the row/column (row/column) the gap belongs to, taken
+  // from its neighbor items' cross extents (for horizontal -> top/bottom, vertical -> left/right).
+  // Used to prioritize gaps that share the pointer's row/column over geometrically nearer gaps in adjacent lanes.
+  laneStart: number;
+  laneEnd: number;
 };
 
 /**
  * Returns the insertion index in the content ids whose gap is nearest the pointer in the screen.
+ *
+ * Selection follows the zone's resolved flow: gaps in the row (or column, for
+ * vertical flows) under the pointer win over geometrically nearer gaps in
+ * adjacent rows/columns, so dragging along a row targets that row's previous
+ * and next gaps rather than flipping to the row above or below. When the
+ * pointer sits in no lane (between rows, or in zone padding), the nearest gap
+ * overall wins.
  *
  * @param zoneEl The dropzone element in the DOM. This contains the items.
  * @param pointer The pointer position in viewport coordinates.
@@ -55,15 +67,43 @@ export const getNearestGapIndex = (
   const { horizontal, reversed, start, end } = getItemEdgeAccessors(zoneFlow);
 
   // A gap is a line perpendicular to the main axis at `main`, spanning the
-  // full cross-axis extent of the closest item (neighbor).
+  // full cross-axis extent of the closest item (neighbor). Its lane band is
+  // the union of the given neighbors' cross extents, so mixed-size neighbors
+  // both count towards the gap's row/column.
   const getGapAt = (
     index: number,
     main: number,
-    cross: DOMRect
-  ): GapCandidate =>
-    horizontal
-      ? { index, x1: main, x2: main, y1: cross.top, y2: cross.bottom }
-      : { index, x1: cross.left, x2: cross.right, y1: main, y2: main };
+    cross: DOMRect,
+    lane: DOMRect[] = [cross]
+  ): GapCandidate => {
+    let lane1 = Infinity;
+    let lane2 = -Infinity;
+
+    for (const rect of lane) {
+      lane1 = Math.min(lane1, horizontal ? rect.top : rect.left);
+      lane2 = Math.max(lane2, horizontal ? rect.bottom : rect.right);
+    }
+
+    return horizontal
+      ? {
+          index,
+          x1: main,
+          x2: main,
+          y1: cross.top,
+          y2: cross.bottom,
+          laneStart: lane1,
+          laneEnd: lane2,
+        }
+      : {
+          index,
+          x1: cross.left,
+          x2: cross.right,
+          y1: main,
+          y2: main,
+          laneStart: lane1,
+          laneEnd: lane2,
+        };
+  };
 
   const candidates: GapCandidate[] = [];
 
@@ -94,25 +134,33 @@ export const getNearestGapIndex = (
       candidates.push(createEdgeCandidate(prev.index + 1, prev.rect, "after"));
       candidates.push(createEdgeCandidate(next.index, next.rect, "before"));
     } else if (
-      horizontal &&
-      (reversed
+      reversed
         ? end(prev.rect) < start(next.rect)
-        : end(prev.rect) > start(next.rect))
+        : end(prev.rect) > start(next.rect)
     ) {
-      // The row wraps between these items: expose the end of the previous row
-      // and the start of the next as the same drop position (they share the same index).
+      // The flow wraps between these items (row wrap in horizontal zones,
+      // column wrap in vertical ones like `flex-flow: column wrap`): expose the
+      // end of the previous lane and the start of the next as the same drop
+      // position (they share the same index).
       candidates.push(createEdgeCandidate(next.index, next.rect, "before"));
       candidates.push(createEdgeCandidate(next.index, prev.rect, "after"));
     } else {
       // Adjacent items: expose midpoint of the gap between them as the drop position.
       const mid = (end(prev.rect) + start(next.rect)) / 2;
 
-      candidates.push(getGapAt(next.index, mid, next.rect));
+      candidates.push(
+        getGapAt(next.index, mid, next.rect, [prev.rect, next.rect])
+      );
     }
   }
 
+  // The pointer's cross-axis coordinate, used to test lane membership.
+  const cross = horizontal ? pointer.y : pointer.x;
+
   let nearest: GapCandidate | null = null;
   let nearestDistance = Infinity;
+  let nearestInLane: GapCandidate | null = null;
+  let nearestInLaneDistance = Infinity;
 
   for (const candidate of candidates) {
     const distance = getDistanceToSegment(pointer, candidate);
@@ -121,7 +169,16 @@ export const getNearestGapIndex = (
       nearestDistance = distance;
       nearest = candidate;
     }
+
+    if (
+      cross >= candidate.laneStart &&
+      cross <= candidate.laneEnd &&
+      distance < nearestInLaneDistance
+    ) {
+      nearestInLaneDistance = distance;
+      nearestInLane = candidate;
+    }
   }
 
-  return nearest?.index ?? null;
+  return (nearestInLane ?? nearest)?.index ?? null;
 };

--- a/packages/core/lib/dnd/resolve-dnd-mode.ts
+++ b/packages/core/lib/dnd/resolve-dnd-mode.ts
@@ -1,0 +1,33 @@
+import type { DndBehavior } from "../../types";
+
+export type DndMode = Exclude<DndBehavior, "auto">;
+
+type ResolveDndModeOptions = {
+  isDraggingBetweenSlots?: boolean;
+  isNewComponent?: boolean;
+};
+
+export const resolveDndMode = (
+  behavior: DndBehavior,
+  {
+    isDraggingBetweenSlots = false,
+    isNewComponent = false,
+  }: ResolveDndModeOptions = {}
+): DndMode => {
+  if (behavior === "auto") {
+    return isDraggingBetweenSlots || isNewComponent ? "static" : "fluid";
+  }
+
+  return behavior;
+};
+
+export const resolveOriginPreviewIndex = (
+  initialIndex: number,
+  preview?: { index: number; linePlaceholder?: boolean } | null
+) => {
+  if (!preview || preview.linePlaceholder) {
+    return initialIndex;
+  }
+
+  return preview.index;
+};

--- a/packages/core/lib/dnd/resolve-dnd-mode.ts
+++ b/packages/core/lib/dnd/resolve-dnd-mode.ts
@@ -20,14 +20,3 @@ export const resolveDndMode = (
 
   return behavior;
 };
-
-export const resolveOriginPreviewIndex = (
-  initialIndex: number,
-  preview?: { index: number; linePlaceholder?: boolean } | null
-) => {
-  if (!preview || preview.linePlaceholder) {
-    return initialIndex;
-  }
-
-  return preview.index;
-};

--- a/packages/core/lib/dnd/resolve-flow.ts
+++ b/packages/core/lib/dnd/resolve-flow.ts
@@ -1,0 +1,160 @@
+import { getDeepDir } from "../get-deep-dir";
+
+/**
+ * How items are laid out along a drop zone's element main axis:
+ */
+export type ZoneFlow = {
+  /**
+   * The axis along which items are laid out in the zone.
+   * - `"x"` — Horizontal, items sit side by side (insertion carets are a vertical line).
+   * - `"y"` — Vertical, items stack top to bottom (insertion carets are a horizontal line).
+   */
+  axis: "x" | "y";
+  /**
+   * True when index order runs against the western reading direction
+   * along that axis (e.g. rtl rows, `row-reverse`, `column-reverse`), so an
+   * earlier index ("before") sits at the right/bottom edge instead of left/top.
+   */
+  reversed: boolean;
+};
+
+// Counts explicit grid tracks, ignoring bracketed `[line-name]` tokens (which
+// the CSSOM serializes into the computed value). A missing template ("none")
+// means the grid has a single implicit track, so it returns 0.
+const countTracks = (template: string) => {
+  const tracks = template.replace(/\[[^\]]*\]/g, " ").trim();
+
+  return tracks && tracks !== "none" ? tracks.split(/\s+/).length : 0;
+};
+
+/**
+ * Resolves a drop zone's element layout flow from its computed styles.
+ *
+ * Handles:
+ *  - flex (incl. `inline-flex` and `*-reverse`),
+ *  - grid (incl. `inline-grid`,
+ *  - single implicit/explicit columns and column auto-flow),
+ *  - text direction.
+ *
+ * All with RTL support. Block and everything else is treated as a vertical stack in document order.
+ *
+ * @param zoneEl The dropzone element in the DOM. This contains the items with the given flow.
+ * @param win The window object of the zone element.
+ * @param style The computed style of the zone element. If not provided, it will be computed from the `zoneEl` param.
+ * @returns The flow of the drop zone.
+ */
+export const resolveZoneFlow = (
+  zoneEl: Element,
+  win: Window,
+  style: CSSStyleDeclaration = win.getComputedStyle(zoneEl)
+): ZoneFlow => {
+  const display = style.display;
+  const rtl = getDeepDir(zoneEl) === "rtl";
+
+  if (display === "flex" || display === "inline-flex") {
+    const direction = style.flexDirection;
+
+    if (direction.startsWith("row")) {
+      const reverseDirection = direction === "row-reverse";
+
+      // rtl flips a row's visual order; `row-reverse` flips it again.
+      const isReverse = rtl ? !reverseDirection : reverseDirection;
+
+      return { axis: "x", reversed: isReverse };
+    }
+
+    return { axis: "y", reversed: direction === "column-reverse" };
+  }
+
+  if (display === "grid" || display === "inline-grid") {
+    // A grid stacks vertically only when it fills a single (implicit or
+    // explicit) column row-by-row. Multiple columns, or column auto-flow, lay
+    // items out horizontally.
+    const columnFlow = style.gridAutoFlow.startsWith("column");
+    const horizontal = columnFlow || countTracks(style.gridTemplateColumns) > 1;
+
+    return horizontal
+      ? { axis: "x", reversed: rtl }
+      : { axis: "y", reversed: false };
+  }
+
+  // Block and everything else: a vertical stack in document order.
+  return { axis: "y", reversed: false };
+};
+
+/**
+ * The accessors for a drop zone's item edges along its resolved flow.
+ */
+export type ItemEdgeAccessors = {
+  /** True when the zone is horizontal (items sit side by side). */
+  horizontal: boolean;
+  /** True when index order runs against the western reading direction along that axis. */
+  reversed: boolean;
+  /** The viewport direction in which the item index increases (reverse === -1, !reverse === 1). */
+  forward: 1 | -1;
+  /**
+   * Returns the coordinate of an item's leading ("before") edge, for the given drop zone flow.
+   * @param rect The item's bounding client rect.
+   * @returns The coordinate of the leading edge.
+   */
+  start: (rect: DOMRect) => number;
+  /**
+   * Returns the coordinate of an item's trailing ("after") edge, for the given drop zone flow.
+   * @param rect The item's bounding client rect.
+   * @returns The coordinate of the trailing edge.
+   */
+  end: (rect: DOMRect) => number;
+  /**
+   * Returns true when a coordinate sits before another along the given drop zone flow.
+   * @param a The first coordinate.
+   * @param b The second coordinate.
+   * @returns True if `a` is before `b` along the flow direction, false otherwise.
+   */
+  isBefore: (a: number, b: number) => boolean;
+};
+
+/**
+ * Creates the accessors for a drop zone's item edges along its resolved flow.
+ *
+ * @param flow The resolved flow of the drop zone.
+ * @returns The accessors for the drop zone's item edges.
+ */
+export const getItemEdgeAccessors = ({
+  axis,
+  reversed,
+}: ZoneFlow): ItemEdgeAccessors => {
+  const horizontal = axis === "x";
+  // The viewport direction in which the item index increases.
+  const forward = reversed ? -1 : 1;
+
+  // Main-axis coordinate of an item's leading ("before") and trailing
+  // ("after") edges, honoring reversed flows where an earlier index sits at
+  // the right/bottom edge.
+  const leading = (rect: DOMRect) =>
+    horizontal
+      ? reversed
+        ? rect.right
+        : rect.left
+      : reversed
+      ? rect.bottom
+      : rect.top;
+  const trailing = (rect: DOMRect) =>
+    horizontal
+      ? reversed
+        ? rect.left
+        : rect.right
+      : reversed
+      ? rect.top
+      : rect.bottom;
+  // Whether `a` sits before `b` along the flow direction.
+  const isBefore = (a: number, b: number) => (forward > 0 ? a <= b : a >= b);
+
+  return {
+    horizontal,
+    reversed,
+    forward,
+    start: leading,
+    end: trailing,
+    isBefore,
+  };
+};

--- a/packages/core/lib/dom-selectors.ts
+++ b/packages/core/lib/dom-selectors.ts
@@ -1,0 +1,25 @@
+/**
+ * Sanitizes a string to be used as a CSS selector by escaping special characters.
+ * @param value The string to be sanitized.
+ * @returns The sanitized string that can be safely used as a CSS selector.
+ */
+const escapeId = (value: string) =>
+  typeof CSS !== "undefined" && typeof CSS.escape === "function"
+    ? CSS.escape(value)
+    : value;
+
+/**
+ * Gets a CSS selector for a component based on its ID.
+ * @param id The ID of the component.
+ * @returns The CSS selector for the component.
+ */
+export const getComponentSelector = (id: string) =>
+  `[data-puck-component="${escapeId(id)}"]`;
+
+/**
+ * Gets a CSS selector for a drop zone based on its zone compound.
+ * @param zone The zone compound (e.g. "MySlot-123:body").
+ * @returns The CSS selector for the drop zone.
+ */
+export const getZoneSelector = (zone: string) =>
+  `[data-puck-dropzone="${escapeId(zone)}"]`;

--- a/packages/core/lib/get-zone-content-ids.ts
+++ b/packages/core/lib/get-zone-content-ids.ts
@@ -1,0 +1,14 @@
+import type { PrivateAppState } from "../types/Internal";
+
+/**
+ * Reads a zone's content ids from the app-state indexes, defaulting to an empty
+ * array when the zone hasn't been indexed yet.
+ *
+ * @param state - The puck app state to read from with the index.
+ * @param zoneCompound - The compound id of the zone to read content ids for (e.g. "MySlot-123:body").
+ * @returns The content ids of the zone, or an empty array if the zone hasn't been indexed yet.
+ */
+export const getZoneContentIds = (
+  state: PrivateAppState,
+  zoneCompound: string
+): string[] => state.indexes.zones[zoneCompound]?.contentIds ?? [];

--- a/packages/core/lib/math.ts
+++ b/packages/core/lib/math.ts
@@ -1,0 +1,41 @@
+/** Clamp `value` to the inclusive range [min, max]. */
+export const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+type Point = { x: number; y: number };
+type Segment = { x1: number; y1: number; x2: number; y2: number };
+
+/**
+ * Gets the distance from a point to the closest point of a line segment in a 2D plane using pythagoras' theorem.
+ *
+ * @param point The point to measure from.
+ * @param segment The line segment to measure to.
+ * @returns The distance from the point to the closest point on the line segment.
+ *
+ * @example
+ * ```ts
+ * const point = { x: 5, y: 5 };
+ * const segment = { x1: 0, y1: 0, x2: 10, y2: 0 };
+ * // Closest point on the segment is ({ x: 5, y: 0 }).
+ * console.log(getDistanceToSegment(point, segment)); // 5
+ *
+ * const point2 = { x: 20, y: 20 };
+ * const segment2 = { x1: 0, y1: 0, x2: 0, y2: 10 };
+ * // Closest point on the segment is ({ x: 0, y: 10 }).
+ * console.log(getDistanceToSegment(point2, segment2)); // ~ 22.36
+ * ```
+ */
+export const getDistanceToSegment = (point: Point, segment: Segment) => {
+  const x = clamp(
+    point.x,
+    Math.min(segment.x1, segment.x2),
+    Math.max(segment.x1, segment.x2)
+  );
+  const y = clamp(
+    point.y,
+    Math.min(segment.y1, segment.y2),
+    Math.max(segment.y1, segment.y2)
+  );
+
+  return Math.hypot(point.x - x, point.y - y);
+};

--- a/packages/core/lib/overlay-portal/styles.css
+++ b/packages/core/lib/overlay-portal/styles.css
@@ -3,6 +3,12 @@
   pointer-events: auto !important;
 }
 
+/* Disable portals while dragging to avoid mis-targeting them */
+[data-puck-entry][data-puck-dragging] [data-puck-overlay-portal],
+[data-puck-entry][data-puck-dragging] [data-puck-overlay-portal] * {
+  pointer-events: none !important;
+}
+
 /* Render the outline only in edit mode */
 [data-puck-entry][data-puck-preview-mode="edit"]
   [data-puck-overlay-portal]:hover {

--- a/packages/core/styles/tokens.css
+++ b/packages/core/styles/tokens.css
@@ -34,7 +34,7 @@
       transparent
     );
     --puck-color-selection-border: var(--puck-color-azure-08);
-    --puck-color-insertion-indicator: var(--puck-color-azure-06);
+    --puck-color-line-placeholder: var(--puck-color-azure-06);
     --puck-color-highlight: var(--puck-color-rose-07);
     --puck-color-bg-disabled: var(--puck-color-grey-07);
     --puck-color-text-disabled: var(--puck-color-grey-03);

--- a/packages/core/styles/tokens.css
+++ b/packages/core/styles/tokens.css
@@ -116,5 +116,6 @@
     --puck-user-sidebar-left-width: var(--puck-sidebar-width);
     --puck-user-sidebar-right-width: var(--puck-sidebar-width);
     --puck-slot-min-empty-height: 128px;
+    --puck-line-placeholder-width: 2px;
   }
 }

--- a/packages/core/types/API/index.ts
+++ b/packages/core/types/API/index.ts
@@ -22,9 +22,19 @@ export type IframeConfig = {
   syncHostStyles?: boolean;
 };
 
+export type DndBehavior = "auto" | "fluid" | "static";
+
 export type DndConfig = {
   disableAutoScroll?: boolean;
   disableOutlineDrag?: boolean;
+  /**
+   * - `auto` (default): fluid drags within a slot, switching to a static
+   *   line placeholder when dragging between slots or inserting a new item
+   * - `fluid`: always animate sibling items during a drag
+   * - `static`: always show a line placeholder during a drag, only
+   *   animating sibling items on drop
+   */
+  behavior?: DndBehavior;
 };
 
 export type OnAction<UserData extends Data = Data> = (


### PR DESCRIPTION
This PR builds on top of puckeditor/puck#1735 and addresses a few bugs, the PR comments, and re-organizes the architecture while keeping the same behavior. It also rebases from main and resolves the conflicts we had.

\---- Original PR description:

Closes puckeditor/puck#1358, closes puckeditor/puck#1286

## Description

This PR changes the default drag-and-drop behavior when dragging between slots to use a static placeholder with a line preview. When dragging within the same slot, the existing behavior remains.

This is configurable via the `dnd.behavior` API, which can be `auto` (the default, changing based on reparenting), `fluid` (the original) or `static`.

## How to test

* Try dragging items between slots
* Set `?dndBehavior="fluid"` on the demo URL to restore the legacy behavior
* Set `?dndBehavior="static"` on the demo URL to enable static behavior for everything

In code, set the `dnd.behavior` property to change behavior:

```tsx
<Puck dnd={{ behaviour: "static" }} />
```

## Remaining considerations

1. I wasn't totally sure of the parameter name `behavior`, so if you have any suggestions, I'm all ears.

## Summary by CodeRabbit

* **New Features**
  * Added configurable drag-and-drop animation modes: automatic, fluid, and static.
  * Improved drag previews with insertion indicators, ghost previews, and smoother movement across zones.
  * Added polished drop and layout animations, including reduced-motion support.
  * Enhanced dragging across varied layouts, directions, virtualized content, and embedded frames.
* **Documentation**
  * Documented the available drag-and-drop behavior options and animation modes.
* **Tests**
  * Added coverage for drag placement, animations, layout handling, and configuration behavior.