### PR TITLE
Allow for`fieldType` overrides to hide field

### DIFF
--- a/apps/docs/pages/docs/api-reference/overrides/field-types.mdx
+++ b/apps/docs/pages/docs/api-reference/overrides/field-types.mdx
@@ -4,7 +4,7 @@ title: fieldTypes
 
 # fieldTypes
 
-Override each [field type](/docs/api-reference/fields).
+Override or hide each [field type](/docs/api-reference/fields).
 
 ```tsx copy
 const overrides = {
@@ -21,6 +21,20 @@ const overrides = {
 ```
 
 You can specify a custom render method for each known [field type](/docs/api-reference/fields), or introduce completely new ones.
+
+## Hiding field types
+
+Set a field type to `null` to hide every field of that type from the fields sidebar.
+
+```tsx copy
+const overrides = {
+  fieldTypes: {
+    text: null,
+  },
+};
+```
+
+[Plugins](/docs/api-reference/plugins) can override this behavior, showing hidden field types if necessary.
 
 ## Render Props
 

--- a/packages/core/components/AutoField/fields/ArrayField/index.tsx
+++ b/packages/core/components/AutoField/fields/ArrayField/index.tsx
@@ -28,6 +28,7 @@ import { walkField } from "../../../../lib/data/map-fields";
 import { populateIds } from "../../../../lib/data/populate-ids";
 import { defaultSlots } from "../../../../lib/data/default-slots";
 import { getDeep } from "../../../../lib/data/get-deep";
+import { isFieldVisible } from "../../../../lib/fields/is-field-visible";
 import { SubField } from "../../subfield";
 import { setDeep } from "../../../../lib/data/set-deep";
 import { useMessage } from "../../../../lib/use-message";
@@ -95,12 +96,13 @@ const ArrayFieldItemInternal = ({
   name?: string;
   localName?: string;
 }) => {
-  // NB this will prevent array fields from being used outside of Puck
+  // NB AppStore usage will prevent array fields from being used outside of Puck
+  const fieldTypeOverrides = useAppStore((s) => s.overrides.fieldTypes);
+
   const isExpanded = useAppStore((s) => {
     return s.state.ui.arrayState[arrayId]?.openId === id;
   });
 
-  // NB this will prevent array fields from being used outside of Puck
   const canEdit = useAppStore(
     (s) => s.permissions.getPermissions({ item: s.selectedItem }).edit
   );
@@ -110,10 +112,10 @@ const ArrayFieldItemInternal = ({
       return false;
     }
 
-    return Object.values(field.arrayFields).some(
-      (subField) => subField.type !== "slot" && subField.visible !== false
+    return Object.values(field.arrayFields).some((subField) =>
+      isFieldVisible(fieldTypeOverrides, subField)
     );
-  }, [field.arrayFields]);
+  }, [field.arrayFields, fieldTypeOverrides]);
 
   return (
     <Sortable id={id} index={dragIndex} disabled={readOnly}>

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -191,17 +191,18 @@ function AutoFieldInternal<
 
   const fieldKey = field.type === "custom" ? field.key : undefined;
 
-  let FieldComponent: React.ComponentType<any> = useMemo(() => {
-    // if there's an override provided for custom fields, fallback to standard behavior
-    if (field.type === "custom" && !render[field.type]) {
-      if (!field.render) {
-        return null;
+  let FieldComponent: React.ComponentType<any> | null | undefined =
+    useMemo(() => {
+      // if there's an override provided for custom fields, fallback to standard behavior
+      if (field.type === "custom" && !render[field.type]) {
+        if (!field.render) {
+          return null;
+        }
+        return field.render;
+      } else if (field.type !== "slot") {
+        return render[field.type];
       }
-      return field.render as any;
-    } else if (field.type !== "slot") {
-      return render[field.type] as (props: FieldProps) => ReactElement;
-    }
-  }, [field.type, fieldKey, render]);
+    }, [field.type, fieldKey, render]);
 
   const { visible = true } = props.field;
 

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -25,6 +25,7 @@ import { useSafeId } from "../../lib/use-safe-id";
 import { NestedFieldContext } from "./context";
 import { useShallow } from "zustand/react/shallow";
 import { setDeep } from "../../lib/data/set-deep";
+import { isFieldVisible } from "../../lib/fields/is-field-visible";
 import type {
   FieldLabelPropsInternal,
   FieldPropsInternalOptional,
@@ -204,13 +205,7 @@ function AutoFieldInternal<
       }
     }, [field.type, fieldKey, render]);
 
-  const { visible = true } = props.field;
-
-  if (!visible) {
-    return null;
-  }
-
-  if (field.type === "slot") {
+  if (!isFieldVisible(overrides.fieldTypes, field)) {
     return null;
   }
 

--- a/packages/core/components/Puck/components/Fields/index.tsx
+++ b/packages/core/components/Puck/components/Fields/index.tsx
@@ -1,4 +1,5 @@
 import { Loader } from "../../../Loader";
+import { isFieldVisible } from "../../../../lib/fields/is-field-visible";
 import { rootDroppableId } from "../../../../lib/root-droppable-id";
 import { ItemSelector } from "../../../../lib/data/get-item";
 import { getSelectorForId } from "../../../../lib/get-selector-for-id";
@@ -94,7 +95,10 @@ const createOnChange =
   };
 
 const FieldsChildInner = ({ fieldName }: { fieldName: string }) => {
+  const fieldTypeOverrides = useAppStore((s) => s.overrides.fieldTypes);
+
   const field = useAppStore((s) => s.fields.fields[fieldName]);
+
   const isReadOnly = useAppStore(
     (s) =>
       ((s.selectedItem
@@ -126,8 +130,6 @@ const FieldsChildInner = ({ fieldName }: { fieldName: string }) => {
     fieldName,
   ]);
 
-  const { visible = true } = field ?? {};
-
   const fieldStore = useContext(fieldContextStore.ctx);
 
   useEffect(() => {
@@ -143,9 +145,7 @@ const FieldsChildInner = ({ fieldName }: { fieldName: string }) => {
     );
   }, [appStore, fieldStore]);
 
-  if (!field || !id || !visible) return null;
-
-  if (field.type === "slot") return null;
+  if (!id || !isFieldVisible(fieldTypeOverrides, field)) return null;
 
   return (
     <div key={id} className={getClassName("field")}>

--- a/packages/core/lib/__tests__/load-overrides.spec.tsx
+++ b/packages/core/lib/__tests__/load-overrides.spec.tsx
@@ -14,6 +14,11 @@ describe("load-overrides", () => {
         },
         {
           overrides: {
+            header: undefined, // Ignored
+          },
+        },
+        {
+          overrides: {
             header: ({ children }) => `${children} | 3` as any,
           },
         },
@@ -38,6 +43,11 @@ describe("load-overrides", () => {
         },
         {
           overrides: {
+            fieldTypes: { text: undefined }, // Ignored
+          },
+        },
+        {
+          overrides: {
             fieldTypes: { text: ({ children }) => `${children} | 3` as any },
           },
         },
@@ -49,9 +59,113 @@ describe("load-overrides", () => {
     );
   });
 
+  it("should hide field type overrides when the last plugin sets it to null", () => {
+    const loaded = loadOverrides({
+      overrides: {
+        fieldTypes: { text: ({ children }) => `${children} | 1` as any },
+      },
+      plugins: [
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 2` as any },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: null },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 3` as any },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: null },
+          },
+        },
+      ],
+    });
+
+    expect(loaded.fieldTypes!.text).toBeNull();
+  });
+
+  it("should show field types overrides when the last plugin sets it to a value regardless of previous nulls", () => {
+    const loaded = loadOverrides({
+      overrides: {
+        fieldTypes: { text: ({ children }) => `${children} | 1` as any },
+      },
+      plugins: [
+        {
+          overrides: {
+            fieldTypes: { text: null },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 2` as any },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: null },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 3` as any },
+          },
+        },
+      ],
+    });
+
+    expect(loaded.fieldTypes!.text!({ children: "0" } as any)).toBe(
+      "0 | 1 | 2 | 3"
+    );
+  });
+
+  it("shouldn't collide field type overrides", () => {
+    const loaded = loadOverrides({
+      overrides: {
+        fieldTypes: {
+          text: ({ children }) => `Text: ${children} | 1` as any,
+          number: ({ children }) => `Number: ${children} | 1` as any,
+        },
+      },
+      plugins: [
+        {
+          overrides: {
+            fieldTypes: { text: ({ children }) => `${children} | 2` as any },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { text: null },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { number: null },
+          },
+        },
+        {
+          overrides: {
+            fieldTypes: { number: ({ children }) => `${children} | 2` as any },
+          },
+        },
+      ],
+    });
+
+    expect(loaded.fieldTypes!.text).toBeNull();
+    expect(loaded.fieldTypes!.number!({ children: "0" } as any)).toBe(
+      "Number: 0 | 1 | 2"
+    );
+  });
+
   it("should avoid mutating the provided overrides", () => {
     const overrides = {};
-    const loaded = loadOverrides({
+    loadOverrides({
       overrides,
       plugins: [
         {

--- a/packages/core/lib/fields/__tests__/is-field-visible.spec.ts
+++ b/packages/core/lib/fields/__tests__/is-field-visible.spec.ts
@@ -1,0 +1,25 @@
+import { isFieldVisible } from "../is-field-visible";
+
+describe("isFieldVisible", () => {
+  it("returns false when the field is missing", () => {
+    expect(isFieldVisible()).toBe(false);
+  });
+
+  it("returns false for slot fields", () => {
+    expect(isFieldVisible(undefined, { type: "slot" })).toBe(false);
+  });
+
+  it("returns false when the field type override is null", () => {
+    expect(
+      isFieldVisible({ text: null }, { type: "text", visible: true })
+    ).toBe(false);
+  });
+
+  it("respects the field `visible` property", () => {
+    expect(isFieldVisible(undefined, { type: "text" })).toBe(true);
+    expect(isFieldVisible({ text: undefined }, { type: "text" })).toBe(true);
+    expect(isFieldVisible(undefined, { type: "text", visible: false })).toBe(
+      false
+    );
+  });
+});

--- a/packages/core/lib/fields/is-field-visible.ts
+++ b/packages/core/lib/fields/is-field-visible.ts
@@ -1,0 +1,23 @@
+import { Field, Overrides } from "../../types";
+
+import { isFieldTypeHidden } from "../overrides/field-types";
+
+/**
+ * Checks if a field is visible based on its type, overrides, and visibility property.
+ *
+ * @param fieldTypeOverrides The field type overrides as received from `Puck`.
+ * @param field The field object to check.
+ * @returns `true` if the field is visible, `false` otherwise.
+ */
+export const isFieldVisible = (
+  fieldTypeOverrides?: Overrides["fieldTypes"],
+  field?: Field
+): field is Field => {
+  if (!field) return false;
+
+  if (field.type === "slot") return false;
+
+  if (isFieldTypeHidden(fieldTypeOverrides, field.type)) return false;
+
+  return field.visible ?? true;
+};

--- a/packages/core/lib/load-overrides.ts
+++ b/packages/core/lib/load-overrides.ts
@@ -1,4 +1,39 @@
+import { FunctionComponent } from "react";
 import { Overrides, Plugin } from "../types";
+import { isFieldTypeHidden } from "./overrides/field-types";
+
+/**
+ * Curries the current plugin's override with the previous plugin's override
+ * (renders the previous plugin's override as children of the current plugin's override).
+ *
+ * @param override The current plugin's override function
+ * @param previousPluginOverride The previous plugin's override function (with any previous plugin's overrides already composed)
+ * @returns A new override that composes the two overrides together
+ */
+const curryPluginOverrides = (
+  override?: FunctionComponent<any> | null,
+  previousPluginOverride?: FunctionComponent<any> | null
+) => {
+  const Comp = (props: any) => {
+    // Render the previous plugin if it exists
+    const children = previousPluginOverride
+      ? previousPluginOverride(props)
+      : props.children;
+
+    // Render this plugin's override if it exists, passing the previous plugin's override as children
+    if (override) {
+      return override({
+        ...props,
+        children,
+      });
+    }
+
+    // Otherwise just return the previous plugins override (or the original children if there were no previous plugins)
+    return children;
+  };
+
+  return Comp;
+};
 
 export const loadOverrides = ({
   overrides,
@@ -7,7 +42,15 @@ export const loadOverrides = ({
   overrides?: Partial<Overrides>;
   plugins?: Plugin[];
 }) => {
-  const collected: Partial<Overrides> = { ...overrides };
+  const collected: Partial<Overrides> = {
+    ...overrides,
+  };
+
+  if (overrides?.fieldTypes) collected.fieldTypes = { ...overrides.fieldTypes };
+
+  const prevFieldTypesOverride: NonNullable<Overrides["fieldTypes"]> = {
+    ...overrides?.fieldTypes,
+  };
 
   plugins?.forEach((plugin) => {
     if (!plugin.overrides) return;
@@ -18,19 +61,28 @@ export const loadOverrides = ({
       if (!plugin.overrides?.[overridesType]) return;
 
       if (overridesType === "fieldTypes") {
-        const fieldTypes = plugin.overrides!.fieldTypes!;
-        Object.keys(fieldTypes).forEach((fieldType) => {
+        const currPluginFieldTypes = plugin.overrides!.fieldTypes!;
+
+        Object.keys(currPluginFieldTypes).forEach((fieldType) => {
           collected.fieldTypes = collected.fieldTypes || {};
 
-          const childNode = collected.fieldTypes[fieldType];
+          // This plugin overrides is hiding this field type,
+          // hide it regardless of any previous plugin's override.
+          if (isFieldTypeHidden(currPluginFieldTypes, fieldType)) {
+            collected.fieldTypes[fieldType] = null;
+            return;
+          }
 
-          const Comp = (props: any) =>
-            fieldTypes[fieldType]!({
-              ...props,
-              children: childNode ? childNode(props) : props.children,
-            });
+          const prevNonNullPluginFieldType = prevFieldTypesOverride[fieldType];
+          const currPluginFieldType = currPluginFieldTypes[fieldType];
+
+          const Comp = curryPluginOverrides(
+            currPluginFieldType,
+            prevNonNullPluginFieldType
+          );
 
           collected.fieldTypes[fieldType] = Comp;
+          prevFieldTypesOverride[fieldType] = Comp;
         });
 
         return;
@@ -38,11 +90,10 @@ export const loadOverrides = ({
 
       const childNode = collected[overridesType];
 
-      const Comp = (props: any) =>
-        plugin.overrides![overridesType]!({
-          ...props,
-          children: childNode ? childNode(props) : props.children,
-        });
+      const Comp = curryPluginOverrides(
+        plugin.overrides[overridesType],
+        childNode
+      );
 
       collected[overridesType] = Comp;
     });

--- a/packages/core/lib/overrides/__tests__/field-types.spec.ts
+++ b/packages/core/lib/overrides/__tests__/field-types.spec.ts
@@ -1,0 +1,21 @@
+import { isFieldTypeHidden } from "../field-types";
+
+describe("isFieldTypeHidden", () => {
+  it("returns true when the matching override is null", () => {
+    expect(isFieldTypeHidden({ text: null }, "text")).toBe(true);
+  });
+
+  it("returns false when the matching override is a component", () => {
+    expect(isFieldTypeHidden({ text: () => null }, "text")).toBe(false);
+  });
+
+  it("returns false when the override doesn't set the field type as null", () => {
+    expect(isFieldTypeHidden(undefined, "text")).toBe(false);
+    expect(isFieldTypeHidden({}, "text")).toBe(false);
+    expect(isFieldTypeHidden({ text: undefined }, "text")).toBe(false);
+  });
+
+  it("returns false when the field type is missing", () => {
+    expect(isFieldTypeHidden({ text: null })).toBe(false);
+  });
+});

--- a/packages/core/lib/overrides/field-types.ts
+++ b/packages/core/lib/overrides/field-types.ts
@@ -1,0 +1,15 @@
+import { Overrides } from "../../types";
+
+/**
+ * Checks if a field type has been hidden via overrides.
+ *
+ * @param overrides The overrides object containing field type overrides.
+ * @param fieldType The field type to check.
+ * @returns True if the field type is hidden, false otherwise.
+ */
+export const isFieldTypeHidden = (
+  overrides?: Overrides["fieldTypes"],
+  fieldType?: string
+) => {
+  return fieldType ? overrides?.[fieldType] === null : false;
+};

--- a/packages/core/types/API/Overrides.ts
+++ b/packages/core/types/API/Overrides.ts
@@ -66,14 +66,16 @@ export type FieldRenderFunctions<
   UserConfig extends Config = Config,
   G extends UserGenerics<UserConfig> = UserGenerics<UserConfig>,
   UserField extends { type: string } = Field | G["UserField"]
-> = Omit<
-  {
-    [Type in UserField["type"]]: React.FunctionComponent<
-      FieldProps<ExtractField<UserField, Type>, any> & {
-        children: ReactNode;
-        name: string;
-      }
-    >;
-  },
-  "custom"
->;
+> = {
+  /**
+   * The React component used to render this field type.
+   *
+   * Set to `null` to not render anything for the field type.
+   */
+  [Type in UserField["type"]]: React.FunctionComponent<
+    FieldProps<ExtractField<UserField, Type>, any> & {
+      children: ReactNode;
+      name: string;
+    }
+  > | null;
+};


### PR DESCRIPTION

## Description

This PR allows hiding all instances of a field type from the editor using `fieldType` overrides:

```tsx
<Puck overrides={{ fieldTypes: { text: null } }} />
```

## Changes made

- A new utility was introduced to verify whether a field should be visible in a single place. It checks the field type, the `visible` param, and the field definition, and uses the utility below.
- A new utility was introduced to verify whether a field type override hides a field. It checks for a `null` definition in the override.
- Updated `loadOverrides` to allow plugins to override other plugins hidden fields.
- Fixed a type bug that didn't accept `custom` fields in overrides.
- Refactored `autofield` to remove unnecessary type casts.

## How to test

1. Render `Puck` with a config containing some components that use `text` fields at the top level, within an array, and within an object:

```tsx
<Puck
  config={{
    components: {
      TestComponent: {
        fields: {
          title: { type: "text" },
          objectTitle: {
            type: "object",
            objectFields: {
              nestedTitle: { type: "text" },
              someOtherField: { type: "number" },
            },
          },
          arrayTitle: {
            type: "array",
            arrayFields: {
              nestedTitle: { type: "text" },
            },
            defaultItemProps: { nestedTitle: "Test" },
          },
        },
        defaultProps: {
          title: "Text",
          objectTitle: {
            nestedTitle: "Nested text",
            someOtherField: 12,
          },
          arrayTitle: [{ nestedTitle: "Nested text" }],
        },
        render: () => <p>Test</p>,
      },
    },
  }}
/>
```

2. Set the `overrides.fieldTypes.text` override to `null`:

```tsx
<Puck overrides={{ fieldTypes: { text: null } }} />
```

3. Run the app.
4. Navigate to the editor.
5. Add the component that uses the text fields to the canvas.
6. Observe that the right sidebar does not show the text fields.
7. Try to click on an array item.
8. Observe that the array item does not expand.

https://github.com/user-attachments/assets/8a618aaf-d131-4e30-babc-e351085a4c98



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Field types can be hidden from the fields sidebar by setting their override to `null`.
  * Visibility rules now apply consistently across standard and array fields.
  * Field-type overrides can remove or restore previously configured overrides.

* **Documentation**
  * Added guidance and examples for hiding field types.

* **Bug Fixes**
  * Improved handling of hidden, missing, and custom field types while preserving fallback rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->