### PR TITLE
Support field transforms within render

### DIFF
--- a/apps/docs/pages/docs/api-reference/components/puck.mdx
+++ b/apps/docs/pages/docs/api-reference/components/puck.mdx
@@ -170,7 +170,7 @@ export function Editor() {
   return (
     <Puck
       fieldTransforms={{
-        text: ({ value }) => <div>{value}</div>, // Wrap all text field values in a div
+        text: ({ value }) => <span>{value}</span>, // Wrap all text field values in a span
       }}
       // ...
     />

--- a/apps/docs/pages/docs/api-reference/components/render.mdx
+++ b/apps/docs/pages/docs/api-reference/components/render.mdx
@@ -80,7 +80,7 @@ export function Example() {
 
 Specify transforms to modify field values before being passed to your components. Implements the [Field Transforms API](/docs/api-reference/field-transforms).
 
-Transforms may return components, unlike [`resolveData`](/docs/api-reference/configuration/component-config#resolvedatadata-params), which must return JSON and writes back to your [`Data`](/docs/api-reference/data-model/data) payload.
+Unlike [`resolveData`](/docs/api-reference/configuration/component-config#resolvedatadata-params), transforms may return components and other unserializable data.
 
 ```tsx {4} copy
 export function Example() {

--- a/apps/docs/pages/docs/api-reference/components/render.mdx
+++ b/apps/docs/pages/docs/api-reference/components/render.mdx
@@ -16,11 +16,12 @@ export function Example() {
 
 ## Props
 
-| Param                   | Example                      | Type                                        | Status   |
-| ----------------------- | ---------------------------- | ------------------------------------------- | -------- |
-| [`config`](#config)     | `config: { components: {} }` | [Config](/docs/api-reference/config)        | Required |
-| [`data`](#data)         | `data: {}`                   | [Data](/docs/api-reference/data-model/data) | Required |
-| [`metadata`](#metadata) | `metadata: {}`               | [Metadata](/docs/api-reference/metadata)    | -        |
+| Param                                 | Example                                  | Type                                                    | Status   |
+| ------------------------------------- | ---------------------------------------- | ------------------------------------------------------- | -------- |
+| [`config`](#config)                   | `config: { components: {} }`             | [Config](/docs/api-reference/config)                    | Required |
+| [`data`](#data)                       | `data: {}`                               | [Data](/docs/api-reference/data-model/data)             | Required |
+| [`fieldTransforms`](#fieldtransforms) | `fieldTransforms: {text: () => <div />}` | [FieldTransforms](/docs/api-reference/field-transforms) | -        |
+| [`metadata`](#metadata)               | `metadata: {}`                           | [Metadata](/docs/api-reference/metadata)                | -        |
 
 ## Required props
 
@@ -68,6 +69,25 @@ export function Example() {
           },
         ],
         root: {},
+      }}
+      // ...
+    />
+  );
+}
+```
+
+### `fieldTransforms`
+
+Specify transforms to modify field values before being passed to your components. Implements the [Field Transforms API](/docs/api-reference/field-transforms).
+
+Transforms may return components, unlike [`resolveData`](/docs/api-reference/configuration/component-config#resolvedatadata-params), which must return JSON and writes back to your [`Data`](/docs/api-reference/data-model/data) payload.
+
+```tsx {4} copy
+export function Example() {
+  return (
+    <Render
+      fieldTransforms={{
+        text: ({ value }) => <div>{value}</div>, // Wrap all text field values in a div
       }}
       // ...
     />

--- a/apps/docs/pages/docs/api-reference/components/render.mdx
+++ b/apps/docs/pages/docs/api-reference/components/render.mdx
@@ -87,7 +87,7 @@ export function Example() {
   return (
     <Render
       fieldTransforms={{
-        text: ({ value }) => <div>{value}</div>, // Wrap all text field values in a div
+        text: ({ value }) => <span>{value}</span>, // Wrap all text field values in a span
       }}
       // ...
     />

--- a/apps/docs/pages/docs/api-reference/field-transforms.mdx
+++ b/apps/docs/pages/docs/api-reference/field-transforms.mdx
@@ -4,7 +4,7 @@ title: FieldTransforms
 
 # FieldTransforms
 
-Transform the data for each [field type](/docs/api-reference/fields) before rendering in the editor.
+Transform the data for each [field type](/docs/api-reference/fields) before rendering. Supported by both [`<Puck>`](/docs/api-reference/components/puck#fieldtransforms) and [`<Render>`](/docs/api-reference/components/render#fieldtransforms).
 
 ```tsx copy
 const fieldTransforms = {
@@ -36,7 +36,7 @@ The component's field definition for this prop.
 
 ### `isReadOnly`
 
-Whether or not this field is currently set to read-only.
+Whether or not this field is currently set to read-only. Always `true` under [`<Render>`](/docs/api-reference/components/render).
 
 ### `propName`
 

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -1,14 +1,8 @@
-import { Callout } from "nextra/components";
-
 # Field Transforms
 
-Puck lets you modify props before rendering in the editor via the [`FieldTransforms` API](/docs/api-reference/field-transforms).
+Puck lets you modify props before rendering via the [`FieldTransforms` API](/docs/api-reference/field-transforms).
 
 Use this API to implement custom rendering behavior for specific field types, which can be used to implement features such as inline text editing.
-
-<Callout type="info">
-  Field transforms only apply to components rendered in `<Puck>` and will not be applied to `<Render>`.
-</Callout>
 
 ## Implementing a transform
 
@@ -21,6 +15,22 @@ const fieldTransforms = {
 
 const Example = () => <Puck fieldTransforms={fieldTransforms} />;
 ```
+
+## Transforming at render time
+
+Transforms can also be provided to [`<Render>`](/docs/api-reference/components/render) to apply them to a finished page.
+
+```tsx
+const fieldTransforms = {
+  text: ({ value }) => <div style={{ color: "blue" }}>{value}</div>, // Make all text fields blue
+};
+
+const Example = () => <Render fieldTransforms={fieldTransforms} />;
+```
+
+Transforms can return components, which makes them a good fit for non-serializable values that should not be baked into your [`Data`](/docs/api-reference/data-model/data) payload.
+
+[`isReadOnly`](/docs/api-reference/field-transforms#isreadonly) is always `true` under `<Render>`. Use it to skip any editing behavior in transforms that you share with `<Puck>`.
 
 ## Making it interactive
 

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -28,7 +28,7 @@ const fieldTransforms = {
 const Example = () => <Render fieldTransforms={fieldTransforms} />;
 ```
 
-Transforms can return components, which makes them a good fit for non-serializable values that should not be baked into your [`Data`](/docs/api-reference/data-model/data) payload.
+Transforms can return components, which makes them a good fit for unserializable values that should not be baked into your [`Data`](/docs/api-reference/data-model/data) payload.
 
 [`isReadOnly`](/docs/api-reference/field-transforms#isreadonly) is always `true` under `<Render>`. Use it to skip any editing behavior in transforms that you share with `<Puck>`.
 

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -18,7 +18,7 @@ const Example = () => <Puck fieldTransforms={fieldTransforms} />;
 
 ## Transforming at render time
 
-Transforms can also be provided to [`<Render>`](/docs/api-reference/components/render) to apply them to a finished page.
+Pass transforms to [`<Render>`](/docs/api-reference/components/render) to apply them to a finished page.
 
 ```tsx
 const fieldTransforms = {

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -589,8 +589,9 @@ const DropZoneRenderItem = ({
   );
 
   const richtextProps = useRichtextProps(
-    fieldTransforms?.richtext ? undefined : Component.fields,
-    props
+    Component.fields,
+    props,
+    fieldTransforms
   );
 
   return (

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -557,16 +557,28 @@ const DropZoneRenderItem = ({
   config,
   item,
   metadata,
+  fieldTransforms,
 }: {
   config: Config;
   item: ComponentData;
   metadata: Metadata;
+  fieldTransforms?: FieldTransforms;
 }) => {
   const Component = config.components[item.type];
 
-  const props = useSlots(config, item, (slotProps) => (
-    <SlotRenderPure {...slotProps} config={config} metadata={metadata} />
-  )) as WithPuckProps<ComponentData["props"]>;
+  const props = useSlots(
+    config,
+    item,
+    (slotProps) => (
+      <SlotRenderPure
+        {...slotProps}
+        config={config}
+        metadata={metadata}
+        fieldTransforms={fieldTransforms}
+      />
+    ),
+    fieldTransforms
+  ) as WithPuckProps<ComponentData["props"]>;
 
   const nextContextValue = useMemo<DropZoneContext>(
     () => ({
@@ -576,7 +588,10 @@ const DropZoneRenderItem = ({
     [props]
   );
 
-  const richtextProps = useRichtextProps(Component.fields, props);
+  const richtextProps = useRichtextProps(
+    fieldTransforms?.richtext ? undefined : Component.fields,
+    props
+  );
 
   return (
     <DropZoneProvider key={props.id} value={nextContextValue}>
@@ -601,7 +616,8 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
   function DropZoneRenderInternal({ className, style, zone, as }, ref) {
     const ctx = useContext(dropZoneContext);
     const { areaId = "root" } = ctx || {};
-    const { config, data, metadata } = useContext(renderContext);
+    const { config, data, metadata, fieldTransforms } =
+      useContext(renderContext);
 
     let zoneCompound = `${areaId}:${zone}`;
     let content = data?.content || [];
@@ -636,6 +652,7 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
                 config={config}
                 item={item}
                 metadata={metadata}
+                fieldTransforms={fieldTransforms}
               />
             );
           }

--- a/packages/core/components/Puck/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/Puck/__tests__/field-transforms.spec.tsx
@@ -1,0 +1,115 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { Config, Data } from "../../../types";
+import "@testing-library/jest-dom";
+
+jest.mock("../styles.module.css");
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+const originalConsoleError = console.error;
+jest.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  if (
+    args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+  ) {
+    return;
+  }
+  originalConsoleError(...(args as Parameters<typeof console.error>));
+});
+jest.spyOn(console, "warn").mockImplementation(() => {});
+
+import { Puck } from "../index";
+
+const flush = () => act(async () => {});
+
+describe("Puck fieldTransforms - edit canvas", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Puck defaults to previewMode "edit", so this renders through EditorPage.
+  // The edit canvas root must run user transforms just like the interactive
+  // <Render> path does, otherwise flipping preview mode changes the root.
+  it("applies a user field transform to root props in edit mode", async () => {
+    const config: Config = {
+      root: {
+        fields: { title: { type: "text" } },
+        render: ({ title }: any) => (
+          <header data-testid="root-render">{title}</header>
+        ),
+      },
+      components: {
+        Text: {
+          fields: { text: { type: "text" } },
+          render: ({ text }: any) => <p>{text}</p>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: { title: "Root Title" } },
+      content: [{ type: "Text", props: { id: "text-1", text: "Body" } }],
+    };
+
+    render(
+      <Puck
+        config={config}
+        data={data}
+        iframe={{ enabled: false }}
+        fieldTransforms={{
+          text: ({ value }: any) => <mark>{value}</mark>,
+        }}
+      />
+    );
+    await flush();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("root-render")).toBeInTheDocument();
+    });
+
+    const rootRender = screen.getByTestId("root-render");
+    // The transform wraps the value in <mark>, so a raw string means the root
+    // was never transformed.
+    expect(rootRender.querySelector("mark")).not.toBeNull();
+    expect(rootRender).toHaveTextContent("Root Title");
+  });
+});

--- a/packages/core/components/Puck/components/Preview/components/edit-page.tsx
+++ b/packages/core/components/Puck/components/Preview/components/edit-page.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { useAppStore } from "../../../../../store";
@@ -10,18 +10,20 @@ import { rootDroppableId } from "../../../../../lib/root-droppable-id";
 import {
   ComponentData,
   DefaultRootRenderProps,
+  FieldTransforms,
   RootData,
 } from "../../../../../types";
 
-import { useRichtextProps } from "../../../../RichTextEditor/lib/use-richtext-props";
 import { DropZoneEditPure, DropZonePure } from "../../../../DropZone";
+import { getInlineTextTransform } from "../../../../../lib/field-transforms/default-transforms/inline-text-transform";
+import { getRichTextTransform } from "../../../../../lib/field-transforms/default-transforms/rich-text-transform";
 
 const slotFieldTransforms = getSlotTransform(DropZoneEditPure);
 
 /**
- * Renders the puck data in the editor where this component is rendered as an editable page.
+ * Renders the puck data as an editable page.
  */
-const EditorPage = memo(() => {
+const EditPage = () => {
   // All the props, slot props are defaulted to null
   const flatRootProps = useAppStore(
     useShallow((s) => s.state.indexes.nodes.root?.flatData.props)
@@ -29,10 +31,25 @@ const EditorPage = memo(() => {
   const config = useAppStore((s) => s.config);
   const metadata = useAppStore((s) => s.metadata);
   const userFieldTransforms = useAppStore((s) => s.fieldTransforms);
+  const plugins = useAppStore((s) => s.plugins);
 
   const combinedFieldTransforms = useMemo(
-    () => ({ ...slotFieldTransforms, ...userFieldTransforms }),
-    [userFieldTransforms]
+    () => ({
+      ...slotFieldTransforms,
+      ...getInlineTextTransform(),
+      ...getRichTextTransform(),
+      ...plugins.reduce<FieldTransforms>((acc, plugin) => {
+        if (!plugin.fieldTransforms) return acc;
+
+        Object.keys(plugin.fieldTransforms).forEach((key) => {
+          acc[key as keyof typeof acc] = plugin.fieldTransforms![key];
+        });
+
+        return acc;
+      }, {}),
+      ...userFieldTransforms,
+    }),
+    [plugins, userFieldTransforms]
   );
 
   // Root as object with slots still defaulted to null
@@ -67,24 +84,14 @@ const EditorPage = memo(() => {
     };
   }, [propsWithSlots, metadata]);
 
-  // Get the richtext props for the root render.
-  const richtextProps = useRichtextProps(
-    config.root?.fields ?? {},
-    renderProps,
-    userFieldTransforms
-  );
-
   return config.root?.render ? (
     config.root?.render({
       ...renderProps,
-      ...richtextProps,
       id: "puck-root",
     })
   ) : (
     <>{renderProps.children}</>
   );
-});
+};
 
-EditorPage.displayName = "EditorPage";
-
-export default EditorPage;
+export default EditPage;

--- a/packages/core/components/Puck/components/Preview/components/editor-page.tsx
+++ b/packages/core/components/Puck/components/Preview/components/editor-page.tsx
@@ -28,6 +28,12 @@ const EditorPage = memo(() => {
   );
   const config = useAppStore((s) => s.config);
   const metadata = useAppStore((s) => s.metadata);
+  const userFieldTransforms = useAppStore((s) => s.fieldTransforms);
+
+  const combinedFieldTransforms = useMemo(
+    () => ({ ...slotFieldTransforms, ...userFieldTransforms }),
+    [userFieldTransforms]
+  );
 
   // Root as object with slots still defaulted to null
   const rootAsComponent = useMemo(() => {
@@ -43,7 +49,7 @@ const EditorPage = memo(() => {
   const propsWithSlots = useFieldTransformsTracked(
     config,
     rootAsComponent,
-    slotFieldTransforms
+    combinedFieldTransforms
   );
 
   // Build the final props to be passed to the user provided root render
@@ -61,10 +67,11 @@ const EditorPage = memo(() => {
     };
   }, [propsWithSlots, metadata]);
 
-  // Get the richtext props for the root render
+  // Get the richtext props for the root render.
   const richtextProps = useRichtextProps(
     config.root?.fields ?? {},
-    renderProps
+    renderProps,
+    userFieldTransforms
   );
 
   return config.root?.render ? (

--- a/packages/core/components/Puck/components/Preview/components/interactive-page.tsx
+++ b/packages/core/components/Puck/components/Preview/components/interactive-page.tsx
@@ -1,0 +1,28 @@
+import { useAppStore } from "../../../../../store";
+
+import { FieldTransforms } from "../../../../../types";
+
+import { Render } from "../../../../Render";
+
+/**
+ * Renders the puck data in the editor where this component is rendered as an interactive page.
+ */
+const InteractivePage = () => {
+  const config = useAppStore((s) => s.config);
+  const metadata = useAppStore((s) => s.metadata);
+  const renderData = useAppStore((s) => s.state.data);
+  const userFieldTransforms = useAppStore((s) => s.fieldTransforms);
+
+  const fieldTransforms = userFieldTransforms as FieldTransforms<typeof config>;
+
+  return (
+    <Render
+      data={renderData}
+      config={config}
+      metadata={metadata}
+      fieldTransforms={fieldTransforms}
+    />
+  );
+};
+
+export default InteractivePage;

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -7,7 +7,7 @@ import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
 import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
 
 import InteractivePage from "./components/interactive-page";
-import EditorPage from "./components/editor-page";
+import EditPage from "./components/edit-page";
 import styles from "./styles.module.css";
 
 const getClassName = getClassNameFactory("PuckPreview", styles);
@@ -95,7 +95,7 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   useBubbleIframeEvents(ref);
   usePreviewModeAttribute(ref);
 
-  const inner = isEditMode ? <EditorPage /> : <InteractivePage />;
+  const inner = isEditMode ? <EditPage /> : <InteractivePage />;
 
   useEffect(() => {
     if (!iframe.enabled) {

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -5,8 +5,8 @@ import { getClassNameFactory } from "../../../../lib";
 import { BubbledPointerEvent } from "../../../../lib/bubble-pointer-event";
 
 import AutoFrame, { autoFrameContext } from "../../../AutoFrame";
-import { Render } from "../../../Render";
 
+import InteractivePage from "./components/interactive-page";
 import EditorPage from "./components/editor-page";
 import styles from "./styles.module.css";
 
@@ -83,14 +83,10 @@ const usePreviewModeAttribute = (ref: RefObject<HTMLIFrameElement | null>) => {
 
 export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   const dispatch = useAppStore((s) => s.dispatch);
-  const config = useAppStore((s) => s.config);
   const setStatus = useAppStore((s) => s.setStatus);
   const iframe = useAppStore((s) => s.iframe);
   const overrides = useAppStore((s) => s.overrides);
-  const metadata = useAppStore((s) => s.metadata);
-  const renderData = useAppStore((s) =>
-    s.state.ui.previewMode === "edit" ? null : s.state.data
-  );
+  const isEditMode = useAppStore((s) => s.state.ui.previewMode === "edit");
 
   const Frame = useMemo(() => overrides.iframe, [overrides]);
 
@@ -99,11 +95,7 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
   useBubbleIframeEvents(ref);
   usePreviewModeAttribute(ref);
 
-  const inner = !renderData ? (
-    <EditorPage />
-  ) : (
-    <Render data={renderData} config={config} metadata={metadata} />
-  );
+  const inner = isEditMode ? <EditorPage /> : <InteractivePage />;
 
   useEffect(() => {
     if (!iframe.enabled) {

--- a/packages/core/components/Render/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/Render/__tests__/field-transforms.spec.tsx
@@ -296,7 +296,10 @@ describe("Render fieldTransforms", () => {
               type: "List",
               props: {
                 id: "list-1",
-                rows: [{ body: "<p>a</p>" }, { body: "<p>b</p>" }],
+                rows: [
+                  { body: "<p>hidden-a</p>" },
+                  { body: "<p>hidden-b</p>" },
+                ],
               },
             },
           ],
@@ -308,6 +311,7 @@ describe("Render fieldTransforms", () => {
     );
 
     expect(html).toContain("rows:2");
-    expect(html).not.toContain("<p>a</p>");
+    expect(html).not.toContain("hidden-a");
+    expect(html).not.toContain("hidden-b");
   });
 });

--- a/packages/core/components/Render/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/Render/__tests__/field-transforms.spec.tsx
@@ -232,7 +232,7 @@ describe("Render fieldTransforms", () => {
   // The transform walker replaces a parent (object/array) field and stops
   // recursing, so the nested richtext leaf could no longer exist. The built-in
   // richtext pass must not still try to descend into the replaced value:
-  // mapDeep would spread a non-object leaf (e.g. string) into unusable data (e.g. `{ 0: "h", 1: "e" }`) 
+  // mapDeep would spread a non-object leaf (e.g. string) into unusable data (e.g. `{ 0: "h", 1: "e" }`)
   // and React crashes.
   it("does not process richtext nested inside an object that a transform replaced", () => {
     const nestedRichtextConfig: Config = {

--- a/packages/core/components/Render/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/Render/__tests__/field-transforms.spec.tsx
@@ -1,0 +1,313 @@
+import { renderToString } from "react-dom/server.node";
+import { Config, Data, DefaultComponents } from "../../../types";
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+import { Render } from "../index";
+
+describe("Render fieldTransforms", () => {
+  const config: Config = {
+    root: {
+      fields: {
+        title: { type: "text" },
+        hero: { type: "slot" },
+      },
+      render: ({ title, hero, children }: any) => {
+        const Hero = hero;
+
+        return (
+          <main>
+            <span>{title}</span>
+            {typeof Hero === "function" ? <Hero /> : null}
+            {children}
+          </main>
+        );
+      },
+    },
+    components: {
+      Section: {
+        fields: { items: { type: "slot" } },
+        render: ({ items }: any) => {
+          const Items = items;
+
+          return (
+            <section>{typeof Items === "function" ? <Items /> : null}</section>
+          );
+        },
+      },
+      Heading: {
+        fields: { title: { type: "text" } },
+        render: ({ title }: any) => <h2>{title}</h2>,
+      },
+    },
+  };
+
+  const data: Data<DefaultComponents, any> = {
+    root: {
+      props: {
+        title: "Root title",
+        hero: [
+          {
+            type: "Heading",
+            props: { id: "in-root-slot", title: "In root slot" },
+          },
+        ],
+      },
+    },
+    content: [
+      {
+        type: "Section",
+        props: {
+          id: "section-1",
+          items: [
+            {
+              type: "Heading",
+              props: { id: "in-nested-slot", title: "In nested slot" },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("leaves props untouched when no fieldTransforms are given", () => {
+    const html = renderToString(<Render config={config} data={data} />);
+
+    expect(html).toContain("<span>Root title</span>");
+    expect(html).toContain("<h2>In root slot</h2>");
+    expect(html).toContain("<h2>In nested slot</h2>");
+    expect(html).not.toContain("<mark>");
+  });
+
+  it("applies a transform to root props and to children at every depth", () => {
+    const html = renderToString(
+      <Render
+        config={config}
+        data={data}
+        fieldTransforms={{
+          text: ({ value }) => <mark>{value}</mark>,
+        }}
+      />
+    );
+
+    expect(html).toContain("<span><mark>Root title</mark></span>");
+    expect(html).toContain("<h2><mark>In root slot</mark></h2>");
+    expect(html).toContain("<h2><mark>In nested slot</mark></h2>");
+  });
+
+  // Render returns from a different branch when the config has no root render,
+  // which is easy to miss when threading transforms down to the dropzones.
+  it("applies a transform when the config has no root render", () => {
+    const configWithoutRootRender: Config = {
+      components: {
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }: any) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={configWithoutRootRender}
+        data={{
+          root: { props: {} },
+          content: [
+            { type: "Heading", props: { id: "h1", title: "Top level" } },
+          ],
+        }}
+        fieldTransforms={{ text: ({ value }) => <mark>{value}</mark> }}
+      />
+    );
+
+    expect(html).toContain("<h2><mark>Top level</mark></h2>");
+  });
+
+  // Regression: useRichtextProps returns a full copy of the props it is given
+  // whenever the component has a richtext field, so feeding it the raw props
+  // discarded every transformed prop on a root that also has a slot field.
+  it("keeps slot and transformed props on a root that also has a richtext field", () => {
+    const richtextRootConfig: Config = {
+      root: {
+        fields: {
+          intro: { type: "richtext" },
+          title: { type: "text" },
+          hero: { type: "slot" },
+        },
+        render: ({ title, hero }: any) => {
+          const Hero = hero;
+
+          return (
+            <main>
+              <span>{title}</span>
+              {typeof Hero === "function" ? (
+                <Hero />
+              ) : (
+                `RAW:${JSON.stringify(hero)}`
+              )}
+            </main>
+          );
+        },
+      },
+      components: {
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }: any) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const richtextRootData: Data<DefaultComponents, any> = {
+      root: {
+        props: {
+          intro: "<p>Intro</p>",
+          title: "Root title",
+          hero: [
+            {
+              type: "Heading",
+              props: { id: "heading-1", title: "In root slot" },
+            },
+          ],
+        },
+      },
+      content: [],
+    };
+
+    const html = renderToString(
+      <Render
+        config={richtextRootConfig}
+        data={richtextRootData}
+        fieldTransforms={{ text: ({ value }) => <mark>{value}</mark> }}
+      />
+    );
+
+    expect(html).not.toContain("RAW:");
+    expect(html).toContain("<h2><mark>In root slot</mark></h2>");
+    expect(html).toContain("<span><mark>Root title</mark></span>");
+  });
+
+  it("honours a user richtext transform instead of the built-in richtext rendering", () => {
+    const richtextConfig: Config = {
+      components: {
+        Article: {
+          fields: { body: { type: "richtext" } },
+          render: ({ body }: any) => <article>{body}</article>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={richtextConfig}
+        data={{
+          root: { props: {} },
+          content: [
+            {
+              type: "Article",
+              props: {
+                id: "article-1",
+                body: "<p>Hello <strong>world</strong></p>",
+              },
+            },
+          ],
+        }}
+        fieldTransforms={{
+          richtext: ({ value }) => <pre>{value}</pre>,
+        }}
+      />
+    );
+
+    expect(html).toContain("<pre>");
+    expect(html).toContain(
+      "&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;"
+    );
+    expect(html).not.toContain('<div class="RichTextEditor">');
+  });
+
+  // The transform walker replaces a parent (object/array) field and stops
+  // recursing, so the nested richtext leaf could no longer exist. The built-in
+  // richtext pass must not still try to descend into the replaced value:
+  // mapDeep would spread a non-object leaf (e.g. string) into unusable data (e.g. `{ 0: "h", 1: "e" }`) 
+  // and React crashes.
+  it("does not process richtext nested inside an object that a transform replaced", () => {
+    const nestedRichtextConfig: Config = {
+      components: {
+        Card: {
+          fields: {
+            meta: {
+              type: "object",
+              objectFields: { body: { type: "richtext" } },
+            },
+          },
+          render: ({ meta }: any) => <div>{meta}</div>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={nestedRichtextConfig}
+        data={{
+          root: { props: {} },
+          content: [
+            {
+              type: "Card",
+              props: { id: "card-1", meta: { body: "<p>hidden</p>" } },
+            },
+          ],
+        }}
+        fieldTransforms={{
+          object: ({ value }) => `meta:${Object.keys(value).length}`,
+        }}
+      />
+    );
+
+    expect(html).toContain("meta:1");
+    expect(html).not.toContain("hidden");
+  });
+
+  it("does not process richtext nested inside an array that a transform replaced", () => {
+    const nestedRichtextConfig: Config = {
+      components: {
+        List: {
+          fields: {
+            rows: {
+              type: "array",
+              arrayFields: { body: { type: "richtext" } },
+            },
+          },
+          render: ({ rows }: any) => <ul>{rows}</ul>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={nestedRichtextConfig}
+        data={{
+          root: { props: {} },
+          content: [
+            {
+              type: "List",
+              props: {
+                id: "list-1",
+                rows: [{ body: "<p>a</p>" }, { body: "<p>b</p>" }],
+              },
+            },
+          ],
+        }}
+        fieldTransforms={{
+          array: ({ value }) => `rows:${value.length}`,
+        }}
+      />
+    );
+
+    expect(html).toContain("rows:2");
+    expect(html).not.toContain("<p>a</p>");
+  });
+});

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -2,7 +2,13 @@
 
 import { rootZone } from "../../lib/root-droppable-id";
 import { useSlots } from "../../lib/use-slots";
-import { Config, Data, Metadata, UserGenerics } from "../../types";
+import {
+  Config,
+  Data,
+  Metadata,
+  UserGenerics,
+  FieldTransforms,
+} from "../../types";
 import {
   DropZonePure,
   DropZoneProvider,
@@ -17,6 +23,7 @@ export const renderContext = React.createContext<{
   config: Config;
   data: Data;
   metadata: Metadata;
+  fieldTransforms?: FieldTransforms;
 }>({
   config: { components: {} },
   data: { root: {}, content: [] },
@@ -30,11 +37,17 @@ export function Render<
   config,
   data,
   metadata = {},
+  fieldTransforms: userFieldTransforms,
 }: {
   config: UserConfig;
   data: Partial<G["UserData"] | Data>;
   metadata?: Metadata;
+  fieldTransforms?: FieldTransforms<UserConfig>;
 }) {
+  // The generic only exists to type the user's transforms against their own
+  // field types. Everything downstream works off the unparameterised type.
+  const fieldTransforms = userFieldTransforms as FieldTransforms | undefined;
+
   const defaultedData = {
     ...data,
     root: data.root || {},
@@ -64,10 +77,21 @@ export function Render<
   const propsWithSlots = useSlots(
     config,
     { type: "root", props: pageProps },
-    (props) => <SlotRender {...props} config={config} metadata={metadata} />
+    (props) => (
+      <SlotRender
+        {...props}
+        config={config}
+        metadata={metadata}
+        fieldTransforms={fieldTransforms}
+      />
+    ),
+    fieldTransforms
   );
 
-  const richtextProps = useRichtextProps(config.root?.fields, pageProps);
+  const richtextProps = useRichtextProps(
+    fieldTransforms?.richtext ? undefined : config.root?.fields,
+    propsWithSlots
+  );
 
   const nextContextValue = useMemo<DropZoneContext>(
     () => ({
@@ -79,7 +103,9 @@ export function Render<
 
   if (config.root?.render) {
     return (
-      <renderContext.Provider value={{ config, data: defaultedData, metadata }}>
+      <renderContext.Provider
+        value={{ config, data: defaultedData, metadata, fieldTransforms }}
+      >
         <DropZoneProvider value={nextContextValue}>
           <config.root.render {...propsWithSlots} {...richtextProps}>
             <DropZoneRenderPure zone={rootZone} />
@@ -90,7 +116,9 @@ export function Render<
   }
 
   return (
-    <renderContext.Provider value={{ config, data: defaultedData, metadata }}>
+    <renderContext.Provider
+      value={{ config, data: defaultedData, metadata, fieldTransforms }}
+    >
       <DropZoneProvider value={nextContextValue}>
         <DropZoneRenderPure zone={rootZone} />
       </DropZoneProvider>

--- a/packages/core/components/Render/index.tsx
+++ b/packages/core/components/Render/index.tsx
@@ -89,8 +89,9 @@ export function Render<
   );
 
   const richtextProps = useRichtextProps(
-    fieldTransforms?.richtext ? undefined : config.root?.fields,
-    propsWithSlots
+    config.root?.fields,
+    propsWithSlots,
+    fieldTransforms
   );
 
   const nextContextValue = useMemo<DropZoneContext>(

--- a/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
+++ b/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
@@ -1,6 +1,8 @@
 import { lazy, Suspense, useMemo } from "react";
 import {
   BaseField,
+  Field,
+  FieldTransforms,
   Fields,
   RichtextField,
   WithPuckProps,
@@ -26,7 +28,8 @@ export function useRichtextProps(
     | undefined,
   props: WithPuckProps<{
     [x: string]: any;
-  }>
+  }>,
+  fieldTransforms?: FieldTransforms
 ) {
   const findAllRichtextKeys = (
     fields:
@@ -40,6 +43,14 @@ export function useRichtextProps(
     const result: RichtextPath[] = [];
 
     for (const [key, field] of Object.entries(fields)) {
+      // A user transform for this field type replaces the whole value.
+      // So we don't need to look for richtext fields inside it.
+      // Users might be transforming richtext fields into something else, or     
+      // it might be a completely different structure (ReactNode, string, number, etc.) and we can't recurse on it.
+      if (fieldTransforms?.[field.type as Field["type"]]) {
+        continue;
+      }
+
       const currentPath = [...path, key];
 
       if (field.type === "richtext") {
@@ -61,7 +72,10 @@ export function useRichtextProps(
     return result;
   };
 
-  const richtextKeys = useMemo(() => findAllRichtextKeys(fields), [fields]);
+  const richtextKeys = useMemo(
+    () => findAllRichtextKeys(fields),
+    [fields, fieldTransforms]
+  );
 
   const richtextProps = useMemo(() => {
     if (!richtextKeys?.length) return {};

--- a/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
+++ b/packages/core/components/RichTextEditor/lib/use-richtext-props.tsx
@@ -45,7 +45,7 @@ export function useRichtextProps(
     for (const [key, field] of Object.entries(fields)) {
       // A user transform for this field type replaces the whole value.
       // So we don't need to look for richtext fields inside it.
-      // Users might be transforming richtext fields into something else, or     
+      // Users might be transforming richtext fields into something else, or
       // it might be a completely different structure (ReactNode, string, number, etc.) and we can't recurse on it.
       if (fieldTransforms?.[field.type as Field["type"]]) {
         continue;

--- a/packages/core/components/ServerRender/__tests__/field-transforms.spec.tsx
+++ b/packages/core/components/ServerRender/__tests__/field-transforms.spec.tsx
@@ -1,0 +1,399 @@
+import { renderToString } from "react-dom/server.node";
+import { Config, Data, DefaultComponents } from "../../../types";
+import { Render } from "../index";
+
+describe("ServerRender fieldTransforms", () => {
+  const config: Config = {
+    root: {
+      fields: {
+        title: { type: "text" },
+        hero: { type: "slot" },
+      },
+      render: ({ title, hero, children }: any) => {
+        const Hero = hero;
+
+        return (
+          <main>
+            <span>{title}</span>
+            {typeof Hero === "function" ? <Hero /> : null}
+            {children}
+          </main>
+        );
+      },
+    },
+    components: {
+      Section: {
+        fields: { items: { type: "slot" } },
+        render: ({ items }: any) => {
+          const Items = items;
+
+          return (
+            <section>{typeof Items === "function" ? <Items /> : null}</section>
+          );
+        },
+      },
+      Heading: {
+        fields: { title: { type: "text" } },
+        render: ({ title }: any) => <h2>{title}</h2>,
+      },
+      Wrapper: {
+        fields: {},
+        render: ({ puck }: any) => (
+          <div>{puck.renderDropZone({ zone: "zone" })}</div>
+        ),
+      },
+    },
+  };
+
+  const data: Data<DefaultComponents, any> = {
+    root: {
+      props: {
+        title: "Root title",
+        hero: [
+          {
+            type: "Heading",
+            props: { id: "in-root-slot", title: "In root slot" },
+          },
+        ],
+      },
+    },
+    content: [
+      {
+        type: "Section",
+        props: {
+          id: "section-1",
+          items: [
+            {
+              type: "Heading",
+              props: { id: "in-nested-slot", title: "In nested slot" },
+            },
+          ],
+        },
+      },
+      { type: "Wrapper", props: { id: "wrapper-1" } },
+    ],
+    zones: {
+      "wrapper-1:zone": [
+        { type: "Heading", props: { id: "in-zone", title: "In zone" } },
+      ],
+    },
+  };
+
+  it("leaves props untouched when no fieldTransforms are given", () => {
+    const html = renderToString(<Render config={config} data={data} />);
+
+    expect(html).toContain("<span>Root title</span>");
+    expect(html).toContain("<h2>In root slot</h2>");
+    expect(html).toContain("<h2>In nested slot</h2>");
+    expect(html).toContain("<h2>In zone</h2>");
+    expect(html).not.toContain("<mark>");
+  });
+
+  it("applies a transform to root props, zone children and slot children at every depth", () => {
+    const html = renderToString(
+      <Render
+        config={config}
+        data={data}
+        fieldTransforms={{
+          text: ({ value }) => <mark>{value}</mark>,
+        }}
+      />
+    );
+
+    // Root props
+    expect(html).toContain("<span><mark>Root title</mark></span>");
+    // Slot child of root
+    expect(html).toContain("<h2><mark>In root slot</mark></h2>");
+    // Slot child of a component in root content
+    expect(html).toContain("<h2><mark>In nested slot</mark></h2>");
+    // Child rendered through puck.renderDropZone
+    expect(html).toContain("<h2><mark>In zone</mark></h2>");
+  });
+
+  it("passes field metadata to the transform", () => {
+    const seen: { propName: string; type: string; componentId: string }[] = [];
+
+    renderToString(
+      <Render
+        config={config}
+        data={data}
+        fieldTransforms={{
+          text: ({ value, propName, field, componentId }) => {
+            seen.push({ propName, type: field.type, componentId });
+            return value;
+          },
+        }}
+      />
+    );
+
+    expect(seen).toContainEqual({
+      propName: "title",
+      type: "text",
+      componentId: "puck-root",
+    });
+    expect(seen).toContainEqual({
+      propName: "title",
+      type: "text",
+      componentId: "in-zone",
+    });
+  });
+
+  it("applies transforms to fields nested in object and array fields", () => {
+    const nestedConfig: Config = {
+      components: {
+        Card: {
+          fields: {
+            meta: {
+              type: "object",
+              objectFields: { label: { type: "text" } },
+            },
+            rows: {
+              type: "array",
+              arrayFields: { caption: { type: "text" } },
+            },
+          },
+          render: ({ meta, rows }: any) => (
+            <div>
+              <em>{meta?.label}</em>
+              {rows?.map((row: any, i: number) => (
+                <p key={i}>{row.caption}</p>
+              ))}
+            </div>
+          ),
+        },
+      },
+    };
+
+    const nestedData: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Card",
+          props: {
+            id: "card-1",
+            meta: { label: "Object label" },
+            rows: [{ caption: "Row one" }, { caption: "Row two" }],
+          },
+        },
+      ],
+    };
+
+    const propPaths: string[] = [];
+
+    const html = renderToString(
+      <Render
+        config={nestedConfig}
+        data={nestedData}
+        fieldTransforms={{
+          text: ({ value, propPath }) => {
+            propPaths.push(propPath);
+            return <mark>{value}</mark>;
+          },
+        }}
+      />
+    );
+
+    expect(propPaths).toEqual([
+      "meta.label",
+      "rows[0].caption",
+      "rows[1].caption",
+    ]);
+    expect(html).toContain("<em><mark>Object label</mark></em>");
+    expect(html).toContain("<p><mark>Row one</mark></p>");
+    expect(html).toContain("<p><mark>Row two</mark></p>");
+  });
+
+  it("reports isReadOnly, since nothing is editable in Render", () => {
+    const seen: boolean[] = [];
+
+    renderToString(
+      <Render
+        config={config}
+        data={data}
+        fieldTransforms={{
+          text: ({ value, isReadOnly }) => {
+            seen.push(isReadOnly);
+            return value;
+          },
+        }}
+      />
+    );
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every(Boolean)).toBe(true);
+  });
+
+  it("honours a user richtext transform instead of the built-in richtext rendering", () => {
+    const richtextConfig: Config = {
+      components: {
+        Article: {
+          fields: { body: { type: "richtext" } },
+          render: ({ body }: any) => <article>{body}</article>,
+        },
+      },
+    };
+
+    const richtextData: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Article",
+          props: {
+            id: "article-1",
+            body: "<p>Hello <strong>world</strong></p>",
+          },
+        },
+      ],
+    };
+
+    const html = renderToString(
+      <Render
+        config={richtextConfig}
+        data={richtextData}
+        fieldTransforms={{
+          richtext: ({ value }) => <pre>{value}</pre>,
+        }}
+      />
+    );
+
+    expect(html).toContain("<pre>");
+    expect(html).toContain(
+      "&lt;p&gt;Hello &lt;strong&gt;world&lt;/strong&gt;&lt;/p&gt;"
+    );
+    expect(html).not.toContain('<div class="RichTextEditor">');
+  });
+
+  it("lets a user transform override the built-in slot transform", () => {
+    const slotConfig: Config = {
+      root: {
+        fields: { hero: { type: "slot" } },
+        render: ({ hero }: any) => <main>{hero}</main>,
+      },
+      components: {
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }: any) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={slotConfig}
+        data={data}
+        fieldTransforms={{
+          slot: ({ value }) => `slot has ${value.length} item(s)`,
+        }}
+      />
+    );
+
+    expect(html).toContain("slot has 1 item(s)");
+    expect(html).not.toContain("<h2>In root slot</h2>");
+  });
+
+  // The transform walker replaces a parent (object/array) field and stops
+  // recursing, so the nested richtext leaf no longer exists. The built-in
+  // richtext pass must not still try to descend into the replaced value or it
+  // spreads a non-object leaf into corrupt props and React crashes.
+  it("does not process richtext nested inside a field that a transform replaced", () => {
+    const nestedRichtextConfig: Config = {
+      components: {
+        Card: {
+          fields: {
+            meta: {
+              type: "object",
+              objectFields: { body: { type: "richtext" } },
+            },
+          },
+          render: ({ meta }: any) => <div>{meta}</div>,
+        },
+      },
+    };
+
+    const html = renderToString(
+      <Render
+        config={nestedRichtextConfig}
+        data={{
+          root: { props: {} },
+          content: [
+            {
+              type: "Card",
+              props: { id: "card-1", meta: { body: "<p>hidden</p>" } },
+            },
+          ],
+        }}
+        fieldTransforms={{
+          object: ({ value }) => `meta:${Object.keys(value).length}`,
+        }}
+      />
+    );
+
+    expect(html).toContain("meta:1");
+    expect(html).not.toContain("hidden");
+  });
+});
+
+describe("ServerRender root prop resolution", () => {
+  // Regression: useRichtextProps returns a full copy of the props it is given
+  // whenever the component has a richtext field, so feeding it the raw props
+  // discarded every transformed prop on root.
+  it("keeps slot and transformed props on a root that also has a richtext field", () => {
+    const config: Config = {
+      root: {
+        fields: {
+          intro: { type: "richtext" },
+          title: { type: "text" },
+          hero: { type: "slot" },
+        },
+        render: ({ title, hero }: any) => {
+          const Hero = hero;
+
+          return (
+            <main>
+              <span>{title}</span>
+              {typeof Hero === "function" ? (
+                <Hero />
+              ) : (
+                `RAW:${JSON.stringify(hero)}`
+              )}
+            </main>
+          );
+        },
+      },
+      components: {
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }: any) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const data: Data<DefaultComponents, any> = {
+      root: {
+        props: {
+          intro: "<p>Intro</p>",
+          title: "Root title",
+          hero: [
+            {
+              type: "Heading",
+              props: { id: "heading-1", title: "In root slot" },
+            },
+          ],
+        },
+      },
+      content: [],
+    };
+
+    const html = renderToString(
+      <Render
+        config={config}
+        data={data}
+        fieldTransforms={{ text: ({ value }) => <mark>{value}</mark> }}
+      />
+    );
+
+    expect(html).not.toContain("RAW:");
+    expect(html).toContain("<h2><mark>In root slot</mark></h2>");
+    expect(html).toContain("<span><mark>Root title</mark></span>");
+  });
+});

--- a/packages/core/components/ServerRender/index.tsx
+++ b/packages/core/components/ServerRender/index.tsx
@@ -5,7 +5,13 @@ import {
   rootZone,
 } from "../../lib/root-droppable-id";
 import { setupZone } from "../../lib/data/setup-zone";
-import { Config, Data, Metadata, UserGenerics } from "../../types";
+import {
+  Config,
+  Data,
+  Metadata,
+  UserGenerics,
+  FieldTransforms,
+} from "../../types";
 import { useSlots } from "../../lib/use-slots";
 import { SlotRenderPure } from "../SlotRender/server";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
@@ -17,6 +23,7 @@ type DropZoneRenderProps = {
   areaId?: string;
   style?: CSSProperties;
   metadata?: Metadata;
+  fieldTransforms?: FieldTransforms;
 };
 
 type DropZoneRenderItemProps = {
@@ -24,6 +31,7 @@ type DropZoneRenderItemProps = {
   data: Data;
   config: Config;
   metadata: Metadata;
+  fieldTransforms?: FieldTransforms;
 };
 
 function DropZoneRenderItem({
@@ -31,6 +39,7 @@ function DropZoneRenderItem({
   data,
   config,
   metadata,
+  fieldTransforms,
 }: DropZoneRenderItemProps) {
   const Component = config.components[item.type];
 
@@ -44,6 +53,7 @@ function DropZoneRenderItem({
           areaId={item.props.id}
           config={config}
           metadata={metadata}
+          fieldTransforms={fieldTransforms}
         />
       ),
       metadata,
@@ -53,10 +63,24 @@ function DropZoneRenderItem({
   };
 
   const renderItem = { ...item, props };
-  const propsWithSlots = useSlots(config, renderItem, (slotProps) => (
-    <SlotRenderPure {...slotProps} config={config} metadata={metadata} />
-  ));
-  const richtextProps = useRichtextProps(Component?.fields, propsWithSlots);
+  const propsWithSlots = useSlots(
+    config,
+    renderItem,
+    (slotProps) => (
+      <SlotRenderPure
+        {...slotProps}
+        config={config}
+        metadata={metadata}
+        fieldTransforms={fieldTransforms}
+      />
+    ),
+    fieldTransforms
+  );
+
+  const richtextProps = useRichtextProps(
+    fieldTransforms?.richtext ? undefined : Component?.fields,
+    propsWithSlots
+  );
 
   if (!Component) {
     return null;
@@ -71,6 +95,7 @@ export function DropZoneRender({
   areaId = "root",
   config,
   metadata = {},
+  fieldTransforms,
 }: DropZoneRenderProps) {
   let zoneCompound = rootDroppableId;
   let content = data?.content || [];
@@ -94,6 +119,7 @@ export function DropZoneRender({
             data={data}
             config={config}
             metadata={metadata}
+            fieldTransforms={fieldTransforms}
           />
         );
       })}
@@ -108,11 +134,17 @@ export function Render<
   config,
   data,
   metadata = {},
+  fieldTransforms: userFieldTransforms,
 }: {
   config: UserConfig;
   data: G["UserData"];
   metadata?: Metadata;
+  fieldTransforms?: FieldTransforms<UserConfig>;
 }) {
+  // The generic only exists to type the user's transforms against their own
+  // field types. Everything downstream works off the unparameterised type.
+  const fieldTransforms = userFieldTransforms as FieldTransforms | undefined;
+
   // DEPRECATED
   const rootProps = "props" in data.root ? data.root.props : data.root;
 
@@ -127,6 +159,7 @@ export function Render<
           data={data}
           config={config}
           metadata={metadata}
+          fieldTransforms={fieldTransforms}
         />
       ),
       isEditing: false,
@@ -138,11 +171,24 @@ export function Render<
     id: "puck-root",
   };
 
-  const propsWithSlots = useSlots(config, { type: "root", props }, (props) => (
-    <SlotRenderPure {...props} config={config} metadata={metadata} />
-  ));
+  const propsWithSlots = useSlots(
+    config,
+    { type: "root", props },
+    (props) => (
+      <SlotRenderPure
+        {...props}
+        config={config}
+        metadata={metadata}
+        fieldTransforms={fieldTransforms}
+      />
+    ),
+    fieldTransforms
+  );
 
-  const richtextProps = useRichtextProps(config.root?.fields, props);
+  const richtextProps = useRichtextProps(
+    fieldTransforms?.richtext ? undefined : config.root?.fields,
+    propsWithSlots
+  );
 
   if (config.root?.render) {
     return (
@@ -152,6 +198,7 @@ export function Render<
           data={data}
           zone={rootZone}
           metadata={metadata}
+          fieldTransforms={fieldTransforms}
         />
       </config.root.render>
     );
@@ -163,6 +210,7 @@ export function Render<
       data={data}
       zone={rootZone}
       metadata={metadata}
+      fieldTransforms={fieldTransforms}
     />
   );
 }

--- a/packages/core/components/ServerRender/index.tsx
+++ b/packages/core/components/ServerRender/index.tsx
@@ -78,8 +78,9 @@ function DropZoneRenderItem({
   );
 
   const richtextProps = useRichtextProps(
-    fieldTransforms?.richtext ? undefined : Component?.fields,
-    propsWithSlots
+    Component?.fields,
+    propsWithSlots,
+    fieldTransforms
   );
 
   if (!Component) {
@@ -186,8 +187,9 @@ export function Render<
   );
 
   const richtextProps = useRichtextProps(
-    fieldTransforms?.richtext ? undefined : config.root?.fields,
-    propsWithSlots
+    config.root?.fields,
+    propsWithSlots,
+    fieldTransforms
   );
 
   if (config.root?.render) {

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -50,8 +50,9 @@ const Item = ({
   ) as WithPuckProps<ComponentData["props"]>;
 
   const richtextProps = useRichtextProps(
-    fieldTransforms?.richtext ? undefined : Component.fields,
-    props
+    Component.fields,
+    props,
+    fieldTransforms
   );
 
   return (

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -6,6 +6,7 @@ import {
   Content,
   Metadata,
   WithPuckProps,
+  FieldTransforms,
 } from "../../types";
 import { useSlots } from "../../lib/use-slots";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
@@ -14,6 +15,7 @@ type SlotRenderProps = DropZoneProps & {
   content: Content;
   config: Config;
   metadata: Metadata;
+  fieldTransforms?: FieldTransforms;
 };
 
 export const SlotRenderPure = (props: SlotRenderProps) => (
@@ -24,19 +26,33 @@ const Item = ({
   config,
   item,
   metadata,
+  fieldTransforms,
 }: {
   config: Config;
   item: ComponentData;
   metadata: Metadata;
+  fieldTransforms?: FieldTransforms;
 }) => {
   const Component = config.components[item.type];
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const props = useSlots(config, item, (slotProps) => (
-    <SlotRenderPure {...slotProps} config={config} metadata={metadata} />
-  )) as WithPuckProps<ComponentData["props"]>;
+  const props = useSlots(
+    config,
+    item,
+    (slotProps) => (
+      <SlotRenderPure
+        {...slotProps}
+        config={config}
+        metadata={metadata}
+        fieldTransforms={fieldTransforms}
+      />
+    ),
+    fieldTransforms
+  ) as WithPuckProps<ComponentData["props"]>;
 
-  const richtextProps = useRichtextProps(Component.fields, props);
+  const richtextProps = useRichtextProps(
+    fieldTransforms?.richtext ? undefined : Component.fields,
+    props
+  );
 
   return (
     <Component.render
@@ -57,7 +73,7 @@ const Item = ({
  */
 export const SlotRender = forwardRef<HTMLDivElement, SlotRenderProps>(
   function SlotRenderInternal(
-    { className, style, content, config, metadata, as },
+    { className, style, content, config, metadata, as, fieldTransforms },
     ref
   ) {
     const El = as ?? "div";
@@ -75,6 +91,7 @@ export const SlotRender = forwardRef<HTMLDivElement, SlotRenderProps>(
               config={config}
               item={item}
               metadata={metadata}
+              fieldTransforms={fieldTransforms}
             />
           );
         })}

--- a/packages/core/lib/data/resolve-and-replace-data.ts
+++ b/packages/core/lib/data/resolve-and-replace-data.ts
@@ -4,6 +4,7 @@ import { ComponentData, ResolveDataTrigger, UiState } from "../../types";
 import { getSelectorForId } from "../get-selector-for-id";
 
 import { toComponent } from "./to-component";
+import { toRoot } from "./to-root";
 
 /**
  * Resolves the data of a component and replaces it in the appStore state.
@@ -26,6 +27,19 @@ export async function resolveAndReplaceData(
     trigger
   );
   if (!resolvedResult.didChange && !writeThrough) return;
+
+  const isRoot =
+    resolvedResult.node.type === "root" ||
+    resolvedResult.node.props.id === "root";
+
+  if (isRoot) {
+    getState().dispatch({
+      type: "replaceRoot",
+      root: toRoot(resolvedResult.node),
+      ui,
+    });
+    return;
+  }
 
   const itemSelector = getSelectorForId(
     getState().state,

--- a/packages/core/lib/get-selector-for-id.ts
+++ b/packages/core/lib/get-selector-for-id.ts
@@ -5,6 +5,12 @@ export const getSelectorForId = (state: PrivateAppState, id: string) => {
 
   if (!node) return;
 
+  const isRoot = node.data.type === "root" || id === "root";
+
+  if (isRoot) {
+    return;
+  }
+
   const zoneCompound = `${node.parentId}:${node.zone}`;
 
   const index = state.indexes.zones[zoneCompound].contentIds.indexOf(id);

--- a/packages/core/lib/use-slots.tsx
+++ b/packages/core/lib/use-slots.tsx
@@ -7,7 +7,7 @@ import { FieldTransforms } from "../types/API/FieldTransforms";
 
 /**
  * Converts the item slot props to ReactNodes, applies any transforms to them, and returns them.
- * 
+ *
  * @param config The Puck config used to build the item
  * @param item The component or root data to resolve props for
  * @param renderSlot A function that converts slot component data to a ReactNode.

--- a/packages/core/lib/use-slots.tsx
+++ b/packages/core/lib/use-slots.tsx
@@ -3,25 +3,31 @@ import { ComponentData, Config, Content, RootData } from "../types";
 import { DropZoneProps } from "../components/DropZone/types";
 import { useFieldTransforms } from "./field-transforms/use-field-transforms";
 import { getSlotTransform } from "./field-transforms/default-transforms/slot-transform";
+import { FieldTransforms } from "../types/API/FieldTransforms";
 
+/**
+ * Converts the item slot props to ReactNodes, applies any transforms to them, and returns them.
+ * 
+ * @param config The Puck config used to build the item
+ * @param item The component or root data to resolve props for
+ * @param renderSlot A function that converts slot component data to a ReactNode.
+ * @param fieldTransforms Field transforms to apply while rendering the final page props.
+ * @returns The props for the item, with slot props converted to ReactNodes and any field transforms applied.
+ */
 export function useSlots<
   T extends ComponentData | RootData,
   UserConfig extends Config
 >(
   config: UserConfig,
   item: T,
-  renderSlotEdit: (dzProps: DropZoneProps & { content: Content }) => ReactNode,
-  renderSlotRender: (
-    dzProps: DropZoneProps & { content: Content }
-  ) => ReactNode = renderSlotEdit,
-  readOnly?: T["readOnly"],
-  forceReadOnly?: boolean
+  renderSlot: (dzProps: DropZoneProps & { content: Content }) => ReactNode,
+  fieldTransforms?: FieldTransforms
 ): T["props"] {
   return useFieldTransforms(
     config,
     item as ComponentData,
-    getSlotTransform(renderSlotEdit, renderSlotRender),
-    readOnly,
-    forceReadOnly
+    { ...getSlotTransform(renderSlot), ...fieldTransforms },
+    undefined,
+    true
   );
 }


### PR DESCRIPTION
Closes #1780, Closes #1794

## Description

This PR adds support for the [`fieldTransforms` API](https://puckeditor.com/docs/api-reference/field-transforms) to the `Render` component. Field transforms were previously only available inside `Puck`; now the same API can be applied at render time, after a page has been created.

This makes it possible to transform stored field values into components or computed values on every render, without polluting the saved data. Unlike `resolveData`, transforms can return React components (not just JSON) and re-run whenever the transforms or data change.

Transforms run through the existing `useSlots` walk (the same one that resolves slots), so props are transformed in a single pass at every depth: root props, component props, and slot children. Both render paths are supported: the client `Render` (which shares state through context) and the RSC `Render` from the `rsc` bundle (which prop-drills, so nothing pulls the page to the client). 

Inside the editor, the interactive preview and the edit canvas run the same transforms, so the preview stays consistent with production output.

## Changes made

- `Render` and the RSC `Render` (`ServerRender`) accept an optional `fieldTransforms` prop and thread it through `useSlots`, `SlotRender`, and the dropzones, so it applies to root props, component props, and slot children at every depth.
  - `useSlots` now merges the built-in slot transform with the caller's transforms (`{ ...slotTransform, ...fieldTransforms }`), so user transforms compose with slots and can override them. 
    - It also forces `isReadOnly`, since nothing is editable under `Render`. 
    - This hook used to be used for edit mode root slots, but it doesn't use it any longer. So I'm defaulting this hook to be the `render` path for transforming slots.
- The render rich text hook (`useRichtextProps`) is now transform-aware: it skips any field whose type has a user transform. Without this, the richtext pass would descend into a value a transform had already replaced, produce corrupt props, and crash React.
- Fixed a pre-existing bug where a root with both a richtext field and a slot field dropped its resolved slot props, because the richtext pass was fed the raw props instead of the slot-resolved ones.
- Split the editor preview into an interactive path (`Render` with transforms) and an edit path.
- Fixed a pre-existing bug where field transforms were not applied to root fields.

## How to test

- Render a page with a `text` transform that converts every text value into a component with red text, and confirm it renders as that component instead of a raw string:

```tsx
import { Render } from "@puckeditor/core";

export function Page() {
  return (
    <Render
      config={config}
      data={data}
      fieldTransforms={{
        text: ({ value }) => <div style={{ color: "red" }}>{ value }</div>,
      }}
    />
  );
}
```

- Import `Render` from the `rsc` bundle and render it inside a Next.js Server Component with the same `fieldTransforms`; confirm the transforms run on the server and nothing is pulled to the client.
- In the editor, pass `fieldTransforms` to `Puck` and toggle between edit and interactive preview; confirm root and component props render identically in both modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Field transforms now apply consistently during editing and rendered output.
  - Added optional `fieldTransforms` support to `Render`, including nested content, slots, drop zones, and rich-text fields.
  - Transforms can replace values with rendered components and receive read-only context.

- **Bug Fixes**
  - Prevented rich-text processing from overriding values replaced by field transforms.

- **Documentation**
  - Updated API and extension guides with configuration details, examples, and `Render` read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->