### PR TITLE
Don't trigger hotkeys from stuck modifier keys after switching windows

### DIFF
--- a/packages/core/lib/__tests__/use-hotkey.spec.tsx
+++ b/packages/core/lib/__tests__/use-hotkey.spec.tsx
@@ -1,0 +1,119 @@
+import { renderHook } from "@testing-library/react";
+import { monitorHotkeys, useHotkey, useHotkeyStore } from "../use-hotkey";
+
+type Modifiers = {
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+};
+
+const keydown = (code: string, modifiers: Modifiers = {}) =>
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      code,
+      bubbles: true,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      ...modifiers,
+    })
+  );
+
+describe("monitorHotkeys", () => {
+  let cleanup: () => void;
+
+  beforeAll(() => {
+    cleanup = monitorHotkeys(document);
+  });
+
+  afterAll(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    // The store is a module singleton, so wipe held keys and registered
+    // triggers between tests for a clean slate. `useHotkey`'s effect never
+    // removes its trigger, so this is the only reliable reset for `triggers`.
+    useHotkeyStore.setState({ held: {}, triggers: {} });
+  });
+
+  it("reports modifier state on jsdom KeyboardEvents", () => {
+    // Guards the tests below: they are meaningless if jsdom drops these fields.
+    const event = new KeyboardEvent("keydown", {
+      code: "MetaLeft",
+      metaKey: true,
+    });
+
+    expect(event.code).toBe("MetaLeft");
+    expect(event.metaKey).toBe(true);
+    expect(event.getModifierState("AltGraph")).toBe(false);
+  });
+
+  it("triggers a meta combo when both keys are held", () => {
+    const cb = jest.fn();
+    renderHook(() => useHotkey({ meta: true, i: true }, cb));
+
+    keydown("MetaLeft", { metaKey: true });
+    keydown("KeyI", { metaKey: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers a ctrl combo when both keys are held (Windows)", () => {
+    const cb = jest.fn();
+    renderHook(() => useHotkey({ ctrl: true, i: true }, cb));
+
+    keydown("ControlLeft", { ctrlKey: true });
+    keydown("KeyI", { ctrlKey: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire a meta combo when 'i' is pressed alone after meta was left stuck", () => {
+    const cb = jest.fn();
+    renderHook(() => useHotkey({ meta: true, i: true }, cb));
+
+    // Meta is pressed, then the user switches windows so its keyup is never
+    // seen and meta stays "held" in the store.
+    keydown("MetaLeft", { metaKey: true });
+
+    // Back in the editor the user types 'i' on its own. The event reports
+    // metaKey: false, so the combo must not fire.
+    keydown("KeyI", { metaKey: false });
+
+    expect(cb).not.toHaveBeenCalled();
+
+    // Prove the trigger is still live so the assertion above is meaningful: a
+    // genuine meta+i must still fire the same callback.
+    keydown("MetaLeft", { metaKey: true });
+    keydown("KeyI", { metaKey: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire a ctrl combo when 'i' is pressed alone after ctrl was left stuck", () => {
+    const cb = jest.fn();
+    renderHook(() => useHotkey({ ctrl: true, i: true }, cb));
+
+    keydown("ControlLeft", { ctrlKey: true });
+    keydown("KeyI", { ctrlKey: false });
+
+    expect(cb).not.toHaveBeenCalled();
+
+    keydown("ControlLeft", { ctrlKey: true });
+    keydown("KeyI", { ctrlKey: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a meta combo when the modifier is genuinely still held after returning to the window", () => {
+    const cb = jest.fn();
+    renderHook(() => useHotkey({ meta: true, i: true }, cb));
+
+    // The meta keydown was missed (pressed while another window had focus), but
+    // 'i' arrives with metaKey: true, so reconciliation restores meta and fires.
+    keydown("KeyI", { metaKey: true });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -80,7 +80,7 @@ const keyCodeMap: KeyCodeMap = {
   AltRight: "altRight",
 };
 
-const useHotkeyStore = create<{
+export const useHotkeyStore = create<{
   held: KeyMap;
   hold: (key: string) => void;
   release: (key: string) => void;
@@ -98,6 +98,32 @@ const useHotkeyStore = create<{
   }))
 );
 
+/**
+ * Syncs the tracked modifier state (ctrl/meta/shift) to match the real state reported by the event.
+ *
+ * Every KeyboardEvent carries the ground-truth for ctrl/meta/shift, so reconciling
+ * here self-heals a modifier left "stuck" when its keyup was missed, e.g. because it
+ * was released while another window had focus after an alt-tab or window switch.
+ *
+ * @param e - The KeyboardEvent to sync the state with.
+ */
+const syncModifierState = (e: KeyboardEvent) => {
+  const { hold, release } = useHotkeyStore.getState();
+  const modifiers: [KeyStrict, boolean][] = [
+    ["ctrl", e.ctrlKey],
+    ["meta", e.metaKey],
+    ["shift", e.shiftKey],
+  ];
+
+  modifiers.forEach(([modifier, isPressed]) => {
+    if (isPressed) {
+      hold(modifier);
+    } else {
+      release(modifier);
+    }
+  });
+};
+
 export const monitorHotkeys = (doc: Document) => {
   const onKeyDown = (e: KeyboardEvent) => {
     // If altGraphKey (Alt Right) is pressed, register altRight instead of mapping ControlRight to ctrl
@@ -109,6 +135,10 @@ export const monitorHotkeys = (doc: Document) => {
     const key = keyCodeMap[e.code];
 
     if (key) {
+      // Sync the state modifier keys with the event before evaluating triggers, so a
+      // modifier left "stuck" from a missed keyup/blur can't fire a combo on its own.
+      syncModifierState(e);
+
       useHotkeyStore.getState().hold(key);
 
       const { held, triggers } = useHotkeyStore.getState();


### PR DESCRIPTION
## Description

This PR fixes an issue where switching windows with `cmd` + `tab` from an inline rich text editor left the `cmd` key "stuck".

The real reason this happens is that the inline rich text editor stops propagation of blur events when the [`relatedEvent`](https://github.com/puckeditor/puck/blob/main/packages/core/components/RichTextEditor/components/EditorInner.tsx#L72) is falsy, which also happens when you tab out of the window.

That said, I don't think hardcoding every possible situation in which a window can be left is the way to go here. It can become hard to keep track of, and users might also do similar things from their own components, where we don't have a way to identify that.

So instead, I'm syncing the state with the source-of-truth modifiers (`ctrl`, `cmd`, `shift`) that come directly from the `keydown` event. This captures all of those cases, since `keydown` is the event that triggers the hold to begin with. If a consumer is stopping it, then it would also be stopped for the modifier `keydown`, never triggering this issue. In cases where any of the other release events are intercepted, this would still be able to identify the correct keys since they are modifiers (don't trigger anything on their own).

## Changes made

- Added a small `syncModifierState` utility that checks for key modifiers in the `keydown` event. If any of the modifiers are being pressed, or are no longer being pressed, it holds or releases the corresponding modifier in the state.

## How to test

- Navigate to the demo.
- Add a hero.
- Select the description in the canvas to edit it.
- While it is selected, alt-tab out of the browser.
- Go back to the browser.
- Type a string containing `z`, `i`, or a combination of `shift` with `z` or `i`.
- Observe that the editor does not trigger the hotkeys and behaves as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling by correcting modifier-key states during keyboard events.
  * Reduced missed key-release states, helping shortcuts trigger more reliably.

* **New Features**
  * Exposed hotkey state for broader application use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->