### PR TITLE
Forward additional props to slot `as` component

### DIFF
--- a/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
+++ b/apps/docs/pages/docs/api-reference/configuration/component-config.mdx
@@ -4,6 +4,7 @@ title: ComponentConfig
 
 import { ConfigPreview, PuckPreview } from "@/docs/components/Preview";
 import { Drawer } from "@/puck";
+import { Callout } from "nextra/components";
 
 # ComponentConfig
 
@@ -109,6 +110,10 @@ const config = {
 ```
 
 ##### `puck.renderDropZone`
+
+<Callout>
+`puck.renderDropZone` and the [`<DropZone>` component](/docs/api-reference/components/drop-zone) are deprecated in favor of the [`slot` field](/docs/api-reference/fields/slot), and will be removed in a future release. For migration notes, see [these docs](/docs/guides/migrations/dropzones-to-slots).
+</Callout>
 
 A render method that creates a [`<DropZone>`](/docs/api-reference/components/drop-zone) for creating nested components. Use this method instead of the `<DropZone>` when implementing React server components.
 

--- a/apps/docs/pages/docs/api-reference/fields/slot.mdx
+++ b/apps/docs/pages/docs/api-reference/fields/slot.mdx
@@ -231,6 +231,31 @@ const config = {
 };
 ```
 
+Any additional props are forwarded to the element or component provided via `as`.
+
+```tsx copy {5}
+const config = {
+  components: {
+    Example: {
+      render: ({ content: Content }) => {
+        return <Content as="details" open />;
+      },
+    },
+  },
+};
+```
+
+The following props are **not** forwarded to the `as` element, because Puck either consumes them internally or they are incompatible with slots:
+
+| Prop                      | Reason                              |
+| ------------------------- | ----------------------------------- |
+| `zone`                    | Identifies the drop zone internally |
+| `content`                 | Injected by Puck internally         |
+| `config`                  | Injected by Puck internally         |
+| `metadata`                | Injected by Puck internally         |
+| `dangerouslySetInnerHTML` | Isn't compatible with Puck slots    |
+| `children`                | Isn't compatible with Puck slots    |
+
 ### `className`
 
 Provide a className to the rendered element. The default styles will still be applied.

--- a/packages/core/bundle/core.ts
+++ b/packages/core/bundle/core.ts
@@ -12,7 +12,12 @@ export { AutoField, FieldLabel } from "../components/AutoField";
 export * from "../components/Button";
 export { Drawer } from "../components/Drawer";
 
-export { DropZone } from "../components/DropZone";
+export {
+  /**
+   * @deprecated Use {@link https://puckeditor.com/docs/api-reference/fields/slot Slots} instead.
+   */
+  DropZone,
+} from "../components/DropZone";
 export * from "../components/IconButton";
 export { Puck } from "../components/Puck";
 export * from "../components/Render";

--- a/packages/core/components/DropZone/index.tsx
+++ b/packages/core/components/DropZone/index.tsx
@@ -1,5 +1,7 @@
 import {
   CSSProperties,
+  ElementType,
+  ReactElement,
   Ref,
   forwardRef,
   memo,
@@ -22,6 +24,7 @@ import {
 } from "./context";
 import { useAppStore, useAppStoreApi } from "../../store";
 import { DropZoneProps } from "./types";
+import { getDropZoneProps } from "../../lib/props/shared/get-drop-zone-props";
 import {
   ComponentData,
   Config,
@@ -93,9 +96,9 @@ const InsertPreview = ({
   return <DrawerItemInner name={label}>{override}</DrawerItemInner>;
 };
 
-export const DropZoneEditPure = (props: DropZoneProps) => (
-  <DropZoneEdit {...props} />
-);
+export const DropZoneEditPure = <ComponentType extends ElementType = "div">(
+  props: DropZoneProps<ComponentType>
+) => <DropZoneEdit {...(props as DropZoneProps)} />;
 
 const DropZoneChild = ({
   zoneCompound,
@@ -302,19 +305,20 @@ const DropZoneChild = ({
 const DropZoneChildMemo = memo(DropZoneChild);
 
 export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
-  function DropZoneEditInternal(
-    {
-      zone,
-      allow,
-      disallow,
-      style,
-      className,
-      minEmptyHeight: userMinEmptyHeight = "128px",
-      collisionAxis,
-      as,
-    },
-    userRef
-  ) {
+  function DropZoneEditInternal(allProps, userRef) {
+    const {
+      props: {
+        zone,
+        allow,
+        disallow,
+        style,
+        className,
+        minEmptyHeight: userMinEmptyHeight = "128px",
+        collisionAxis,
+        as,
+      },
+      forwardableProps,
+    } = getDropZoneProps(allProps);
     const ctx = useContext(dropZoneContext);
     const appStoreApi = useAppStoreApi();
 
@@ -490,6 +494,7 @@ export const DropZoneEdit = forwardRef<HTMLDivElement, DropZoneProps>(
 
     return (
       <El
+        {...forwardableProps}
         className={`${getClassName({
           isRootZone,
           hoveringOverArea,
@@ -593,12 +598,16 @@ const DropZoneRenderItem = ({
   );
 };
 
-export const DropZoneRenderPure = (props: DropZoneProps) => (
-  <DropZoneRender {...props} />
-);
+export const DropZoneRenderPure = <ComponentType extends ElementType = "div">(
+  props: DropZoneProps<ComponentType>
+) => <DropZoneRender {...(props as DropZoneProps)} />;
 
 const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
-  function DropZoneRenderInternal({ className, style, zone, as }, ref) {
+  function DropZoneRenderInternal(allProps, ref) {
+    const {
+      props: { className, style, zone, as },
+      forwardableProps,
+    } = getDropZoneProps(allProps);
     const ctx = useContext(dropZoneContext);
     const { areaId = "root" } = ctx || {};
     const { config, data, metadata } = useContext(renderContext);
@@ -626,7 +635,7 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
       content = setupZone(data, zoneCompound).zones[zoneCompound];
     }
     return (
-      <El className={className} style={style} ref={ref}>
+      <El {...forwardableProps} className={className} style={style} ref={ref}>
         {content.map((item) => {
           const Component = config.components[item.type];
           if (Component) {
@@ -647,9 +656,11 @@ const DropZoneRender = forwardRef<HTMLDivElement, DropZoneProps>(
   }
 );
 
-export const DropZonePure = (props: DropZoneProps) => <DropZone {...props} />;
+export const DropZonePure = <ComponentType extends ElementType = "div">(
+  props: DropZoneProps<ComponentType>
+) => <DropZone {...props} />;
 
-export const DropZone = forwardRef<HTMLDivElement, DropZoneProps>(
+const DropZoneImpl = forwardRef<HTMLDivElement, DropZoneProps>(
   function DropZone(props: DropZoneProps, ref) {
     const ctx = useContext(dropZoneContext);
 
@@ -668,3 +679,14 @@ export const DropZone = forwardRef<HTMLDivElement, DropZoneProps>(
     );
   }
 );
+
+// Public DropZone component.
+// Cast so `as` infers `ComponentType` and any forwarded props are
+// typed against it (mirroring slots).
+//
+// We need a cast because `forwardRef` doesn't support generic parameters.
+export const DropZone = DropZoneImpl as <
+  ComponentType extends ElementType = "div"
+>(
+  props: DropZoneProps<ComponentType> & { ref?: Ref<HTMLDivElement> }
+) => ReactElement | null;

--- a/packages/core/components/DropZone/types.ts
+++ b/packages/core/components/DropZone/types.ts
@@ -1,14 +1,81 @@
-import { CSSProperties, ElementType, Ref } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ElementType,
+  Ref,
+} from "react";
 import { DragAxis } from "../../types";
 
-export type DropZoneProps = {
-  zone: string;
+/**
+ * Props consumed by Puck internally that are shared between DropZones and slots.
+ */
+export type DropZoneSharedProps<ComponentType extends ElementType = "div"> = {
   allow?: string[];
   disallow?: string[];
   style?: CSSProperties;
   minEmptyHeight?: CSSProperties["minHeight"] | number;
   className?: string;
   collisionAxis?: DragAxis;
-  as?: ElementType;
   ref?: Ref<any>;
+  as?: ComponentType;
 };
+
+/**
+ * All props consumed by Puck for a DropZone component. `zone` lives here only.
+ *
+ * On slots `zone` is injected internally, so slots use {@link SlotProps} instead.
+ */
+export type DropZoneOwnProps<ComponentType extends ElementType = "div"> =
+  DropZoneSharedProps<ComponentType> & {
+    zone: string;
+  };
+
+/**
+ * Unsupported additional props that are never forwarded to `as`.
+ *
+ * Omitted from the public types AND stripped at runtime.
+ */
+export type NonForwardableProps = {
+  // Both removed because slot content is always rendered as children
+  children?: unknown;
+  dangerouslySetInnerHTML?: unknown;
+};
+
+/**
+ * Keys internally consumed by Puck and never forwarded to `as`.
+ */
+export type ConsumedPropKey =
+  | keyof DropZoneOwnProps
+  | "as"
+  | "content"
+  | "config"
+  | "metadata";
+
+/**
+ * Additional props forwarded to the element or component provided via `as`,
+ * typed against it.
+ *
+ * Puck-internal/unsupported props are stripped so they don't leak onto the DOM.
+ */
+type ForwardedProps<ComponentType extends ElementType> = Omit<
+  ComponentPropsWithoutRef<ComponentType>,
+  ConsumedPropKey | keyof NonForwardableProps
+>;
+
+/**
+ * Props for a `DropZone` component.
+ *
+ * Any additional props not consumed by Puck are forwarded to the element or
+ * component provided via `as` (defaulting to a `div`), typed against it.
+ */
+export type DropZoneProps<ComponentType extends ElementType = "div"> =
+  DropZoneOwnProps<ComponentType> & ForwardedProps<ComponentType>;
+
+/**
+ * Props for a `slot` render component.
+ *
+ * Any additional props not consumed by Puck are forwarded to the element or
+ * component provided via `as` (defaulting to a `div`), typed against it.
+ */
+export type SlotProps<ComponentType extends ElementType = "div"> =
+  DropZoneSharedProps<ComponentType> & ForwardedProps<ComponentType>;

--- a/packages/core/components/ServerRender/__tests__/index.spec.tsx
+++ b/packages/core/components/ServerRender/__tests__/index.spec.tsx
@@ -102,4 +102,116 @@ describe("ServerRender", () => {
     expect(html).toContain("<h2>Nested heading</h2>");
     expect(html).not.toContain("&lt;p&gt;Hello");
   });
+
+  it("forwards additional props to the element provided via `as`", () => {
+    const config: Config = {
+      components: {
+        Section: {
+          fields: {
+            content: { type: "slot" },
+          },
+          render: ({ content: Content }) => (
+            <Content as="section" id="my-slot" data-custom="foo" />
+          ),
+        },
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Section",
+          props: {
+            id: "section-1",
+            content: [
+              { type: "Heading", props: { id: "heading-1", title: "Hello" } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const html = renderToString(<Render config={config} data={data} />);
+
+    expect(html).toContain("<section");
+    expect(html).toContain('id="my-slot"');
+    expect(html).toContain('data-custom="foo"');
+    expect(html).toContain("<h2>Hello</h2>");
+    // Puck-internal props should not leak onto the element
+    expect(html).not.toContain('zone="');
+  });
+
+  it("strips `children` and `dangerouslySetInnerHTML` before forwarding to `as`", () => {
+    const configWithDangerousSetHTML: Config = {
+      components: {
+        Section: {
+          fields: {
+            content: { type: "slot" },
+          },
+          render: ({ content: Content }) => (
+            <Content
+              as="section"
+              dangerouslySetInnerHTML={{ __html: "<em>injected</em>" }}
+            />
+          ),
+        },
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const configWithChildren: Config = {
+      components: {
+        Section: {
+          fields: {
+            content: { type: "slot" },
+          },
+          render: ({ content: Content }) => (
+            <Content as="section">Rogue child</Content>
+          ),
+        },
+        Heading: {
+          fields: { title: { type: "text" } },
+          render: ({ title }) => <h2>{title}</h2>,
+        },
+      },
+    };
+
+    const data: Data = {
+      root: { props: {} },
+      content: [
+        {
+          type: "Section",
+          props: {
+            id: "section-1",
+            content: [
+              { type: "Heading", props: { id: "heading-1", title: "Hello" } },
+            ],
+          },
+        },
+      ],
+    };
+
+    // Without the runtime strip this throws: React refuses to render an
+    // element with both children and dangerouslySetInnerHTML
+    const htmlWithDangerousSetHTML = renderToString(
+      <Render config={configWithDangerousSetHTML} data={data} />
+    );
+    const htmlWithChildren = renderToString(
+      <Render config={configWithChildren} data={data} />
+    );
+
+    expect(htmlWithDangerousSetHTML).toContain("<h2>Hello</h2>");
+    expect(htmlWithDangerousSetHTML).not.toContain("injected");
+
+    expect(htmlWithChildren).toContain("<h2>Hello</h2>");
+    expect(htmlWithChildren).not.toContain("Rogue child");
+  });
 });

--- a/packages/core/components/SlotRender/server.tsx
+++ b/packages/core/components/SlotRender/server.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../types";
 import { useSlots } from "../../lib/use-slots";
 import { useRichtextProps } from "../RichTextEditor/lib/use-richtext-props";
+import { getDropZoneProps } from "../../lib/props/shared/get-drop-zone-props";
 
 type SlotRenderProps = DropZoneProps & {
   content: Content;
@@ -56,14 +57,16 @@ const Item = ({
  * Replacement for DropZoneRender
  */
 export const SlotRender = forwardRef<HTMLDivElement, SlotRenderProps>(
-  function SlotRenderInternal(
-    { className, style, content, config, metadata, as },
-    ref
-  ) {
+  function SlotRenderInternal(allProps, ref) {
+    const {
+      props: { className, style, content, config, metadata, as },
+      forwardableProps,
+    } = getDropZoneProps(allProps);
+
     const El = as ?? "div";
 
     return (
-      <El className={className} style={style} ref={ref}>
+      <El {...forwardableProps} className={className} style={style} ref={ref}>
         {content.map((item) => {
           if (!config.components[item.type]) {
             return null;

--- a/packages/core/lib/props/shared/__tests__/get-drop-zone-props.spec.ts
+++ b/packages/core/lib/props/shared/__tests__/get-drop-zone-props.spec.ts
@@ -1,0 +1,88 @@
+import { getDropZoneProps } from "../get-drop-zone-props";
+
+describe("getDropZoneProps", () => {
+  const style = { color: "red" };
+  const onClick = () => {};
+  const children = "rogue";
+  const dangerouslySetInnerHTML = { __html: "<em>injected</em>" };
+
+  const allProps = {
+    zone: "my-zone",
+    allow: ["Heading"],
+    className: "my-class",
+    style,
+    as: "button",
+    id: "my-id",
+    onClick,
+    "data-custom": "foo",
+    children,
+    dangerouslySetInnerHTML,
+  };
+
+  it("splits props into consumed, forwardable and non-forwardable groups", () => {
+    const { props, forwardableProps, nonForwardableProps } =
+      getDropZoneProps(allProps);
+
+    expect(props).toEqual({
+      zone: "my-zone",
+      allow: ["Heading"],
+      className: "my-class",
+      style,
+      as: "button",
+    });
+    expect(forwardableProps).toEqual({
+      id: "my-id",
+      onClick,
+      "data-custom": "foo",
+    });
+    expect(nonForwardableProps).toEqual({ children, dangerouslySetInnerHTML });
+  });
+
+  it("moves values by reference without cloning", () => {
+    const { props, forwardableProps, nonForwardableProps } =
+      getDropZoneProps(allProps);
+
+    expect(props.style).toBe(style);
+    expect(props.allow).toBe(allProps.allow);
+    expect(forwardableProps.onClick).toBe(onClick);
+    expect(nonForwardableProps.dangerouslySetInnerHTML).toBe(
+      dangerouslySetInnerHTML
+    );
+  });
+
+  it("assigns every key to exactly one group", () => {
+    const { props, forwardableProps, nonForwardableProps } =
+      getDropZoneProps(allProps);
+
+    const regrouped = [
+      ...Object.keys(props),
+      ...Object.keys(forwardableProps),
+      ...Object.keys(nonForwardableProps),
+    ].sort();
+
+    expect(regrouped).toEqual(Object.keys(allProps).sort());
+  });
+
+  it("uses null-prototype groups so an own `__proto__` key can't pollute prototypes", () => {
+    // JSON.parse produces an *own* enumerable `__proto__` key (object literals don't)
+    const malicious = JSON.parse(
+      '{ "zone": "z", "__proto__": { "polluted": true } }'
+    );
+
+    const { props, forwardableProps, nonForwardableProps } =
+      getDropZoneProps(malicious);
+
+    // Groups have no prototype, so `group["__proto__"] = ...` stores data
+    // instead of swapping the group's prototype.
+    expect(Object.getPrototypeOf(props)).toBeNull();
+    expect(Object.getPrototypeOf(forwardableProps)).toBeNull();
+    expect(Object.getPrototypeOf(nonForwardableProps)).toBeNull();
+
+    // No ordinary object was polluted in the process.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+    // Recognised keys are still grouped correctly. `props` is typed as `{}` here
+    // because JSON.parse widens the input to `any`, so read it as a record.
+    expect((props as Record<string, unknown>).zone).toBe("z");
+  });
+});

--- a/packages/core/lib/props/shared/get-drop-zone-props.ts
+++ b/packages/core/lib/props/shared/get-drop-zone-props.ts
@@ -1,0 +1,91 @@
+import type {
+  ConsumedPropKey,
+  NonForwardableProps,
+} from "../../../components/DropZone/types";
+
+type NonForwardableKey = keyof NonForwardableProps;
+
+type DropZonePropGroups<Props> = {
+  /** Props consumed by Puck internally. */
+  props: Pick<Props, Extract<keyof Props, ConsumedPropKey>>;
+  /** Props that should be forwarded to the element or component provided via `as`. */
+  forwardableProps: Omit<Props, ConsumedPropKey | NonForwardableKey>;
+  /** Props that shouldn't be forwarded to the component provided via `as` (e.g., `children` and `dangerouslySetInnerHTML`). */
+  nonForwardableProps: Pick<Props, Extract<keyof Props, NonForwardableKey>>;
+};
+
+// Key maps with all the consumed and non-forwardable keys -----------------------------------------------
+
+// Note to future maintainers: When adding new keys to the DropZone props, add them to the appropriate map below.
+//
+// `Record<Key, true>` makes these compile errors if a key
+// is added to (or removed from) the source types without updating them here, keeping
+// the runtime in sync with the type public interface.
+
+const CONSUMED_PROP_KEYS: Record<ConsumedPropKey, true> = {
+  zone: true,
+  allow: true,
+  disallow: true,
+  style: true,
+  minEmptyHeight: true,
+  className: true,
+  collisionAxis: true,
+  ref: true,
+  as: true,
+  content: true,
+  config: true,
+  metadata: true,
+};
+
+const NON_FORWARDABLE_PROP_KEYS: Record<NonForwardableKey, true> = {
+  children: true,
+  dangerouslySetInnerHTML: true,
+};
+
+const CONSUMED_KEY_SET: ReadonlySet<string> = new Set(
+  Object.keys(CONSUMED_PROP_KEYS)
+);
+const NON_FORWARDABLE_KEY_SET: ReadonlySet<string> = new Set(
+  Object.keys(NON_FORWARDABLE_PROP_KEYS)
+);
+
+/**
+ * Groups the props received from a user dropzone or slot render function into the groups Puck cares about.
+ *
+ * Central formatting point that should be shared by any component rendering DropZones/slots.
+ *
+ * `allProps` are grouped by reference in a single pass, never cloned or merged, so
+ * downstream identity (and memoization) is unaffected.
+ *
+ * @param allProps The component's full incoming props, as received from the user dropzone or slot render function.
+ * @returns An object containing the three prop groups: {@link DropZonePropGroups.props props}, {@link DropZonePropGroups.forwardableProps forwardableProps}, and {@link DropZonePropGroups.nonForwardableProps nonForwardableProps}.
+ */
+export const getDropZoneProps = <Props extends Record<string, any>>(
+  allProps: Props
+): DropZonePropGroups<Props> => {
+  // Null-prototype so an own `__proto__` key is stored as data instead of
+  // mutating the target's prototype (prototype pollution / lost key).
+  const props: Record<string, unknown> = Object.create(null);
+  const forwardableProps: Record<string, unknown> = Object.create(null);
+  const nonForwardableProps: Record<string, unknown> = Object.create(null);
+
+  for (const key of Object.keys(allProps)) {
+    if (NON_FORWARDABLE_KEY_SET.has(key)) {
+      console.warn(
+        "The following prop is not supported by Puck DropZones or slots and will not be forwarded to the `as` element:",
+        key
+      );
+      nonForwardableProps[key] = allProps[key];
+    } else if (CONSUMED_KEY_SET.has(key)) {
+      props[key] = allProps[key];
+    } else {
+      forwardableProps[key] = allProps[key];
+    }
+  }
+
+  return {
+    props,
+    forwardableProps,
+    nonForwardableProps,
+  } as DropZonePropGroups<Props>;
+};

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -1,12 +1,13 @@
-import type { JSX, ReactNode } from "react";
-import { BaseField, Field, Fields } from "./Fields";
-import { ComponentData, ComponentMetadata, RootData } from "./Data";
+import type { JSX, ReactNode, ElementType } from "react";
 
+import { SlotProps } from "../components/DropZone/types";
+
+import { ComponentData, ComponentMetadata, RootData } from "./Data";
+import { BaseField, Field, Fields } from "./Fields";
 import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";
 import { AppState } from "./AppState";
 import { DefaultComponentProps, WithDefaultRootFieldProps } from "./Props";
 import { Permissions } from "./API";
-import { DropZoneProps } from "../components/DropZone/types";
 import {
   AssertHasValue,
   FieldsExtension,
@@ -14,7 +15,9 @@ import {
   WithDeepSlots,
 } from "./Internal";
 
-export type SlotComponent = (props?: Omit<DropZoneProps, "zone">) => ReactNode;
+export type SlotComponent = <ComponentType extends ElementType = "div">(
+  props?: SlotProps<ComponentType>
+) => ReactNode;
 
 export type PuckComponent<Props> = (
   props: WithId<

--- a/packages/core/types/Props.tsx
+++ b/packages/core/types/Props.tsx
@@ -1,9 +1,15 @@
+import { ElementType } from "react";
 import { DropZoneProps } from "../components/DropZone/types";
 import { Metadata } from "./Data";
 import { WithChildren, WithPuckProps } from "./Utils";
 
 export type PuckContext = {
-  renderDropZone: (props: DropZoneProps) => React.ReactNode;
+  /**
+   * @deprecated Use {@link https://puckeditor.com/docs/api-reference/fields/slot Slots} instead.
+   */
+  renderDropZone: <ComponentType extends ElementType = "div">(
+    props: DropZoneProps<ComponentType>
+  ) => React.ReactNode;
   metadata: Metadata;
   isEditing: boolean;
   dragRef: ((element: Element | null) => void) | null;


### PR DESCRIPTION
Closes puckeditor/puck#1441

## Description

Slots (and `Dropzone`/`puck.renderDropZone`) accept an `as` prop to render a custom element or component, but previously there was no way to pass props to the component. This forwards additional props not used by puck onto the as element/component, so you can pass e.g. library specific props:

```
render: ({ SlotComponent, height }) => (
  <SlotComponent as={Box} sx={{ height: (theme) => theme.units * height }} />
);
```

## Changes made

* Slot render components, `<DropZone>`, and `puck.renderDropZone` now forward any additional props to the element or component provided via `as` (defaulting to a `div`).
* The forwarded props are fully typed: `SlotComponent`, `renderDropZone`, and `<DropZone>` are generic over `as`, so `as="button"` only accepts button attributes, a custom component only accepts its own props, and unknown props are compile errors.
  * The `SlotProps` type was refactored from `Omit<DropZoneProps<T>, "zone">` to `DropZoneSharedProps` and `DropZoneOwnProps`.
    * This was done because using `Omit` erases the generic inference (`T`), collapsing `as` to the default `div` and letting any prop through.
  * The public `DropZone` component stays a div-typed `forwardRef` internally and is exported publicly with a cast type, since `forwardRef` can't use generics.
* Added `getDropZoneProps` (`lib/props/shared`) as the single formatting point that splits incoming public props into `props` (consumed by Puck), `forwardableProps` (spread onto `as`), and `nonForwardableProps` (dropped with a warning).
  * The benefit of doing this is that we avoid future props leakage bugs by forcing future devs to check this list and update it if needed.
  * This should be used anywhere `DropZoneProps` are read.
    * `DropZoneEdit`, `DropZoneRender`, and `SlotRender`, the three components where props reach the DOM, all use it instead of hand-rolled destructured lists.
  * Props are grouped by reference in a single pass, never cloned or merged, so downstream identity and memoization are unaffected.
  * The key maps are `Record<Key, true>` objects tied to the `ConsumedPropKey` and `NonForwardableProps` types, so adding a prop to the types without updating the runtime check (or vice versa) is a compile error.
  * Component-specific consumed props (`SlotRender`'s `config` and `metadata`) are passed as `extraConsumedKeys` so they're never forwarded to the underlying `as` component.
* Marked the `DropZone` export and `puck.renderDropZone` as `@deprecated` in favor of slots. Since that's what the docs clarify and what we want people to use.
* Added tests.
* Documented the forwarding behavior in the slot docs, including the table of props that are never forwarded and why.

## How to test

Add extra props alongside `as` in a slot render function and confirm they reach the element and that internal props don't leak:

```tsx
render: ({ content: Content }) => (
  <Content as="details" open data-custom="foo" />
);
```

## Summary by CodeRabbit

* **New Features**
  * Slot and drop zone props can now be forwarded to custom elements or components specified through `as`.
  * Added typed, component-specific props for slots and drop zones.
  * Internal props, `children`, and unsafe HTML content are excluded from forwarding.
* **Documentation**
  * Expanded Slot documentation with forwarding behavior and examples.
  * Marked the legacy DropZone and `renderDropZone` APIs as deprecated in favor of Slots.
  * Added migration guidance for replacing `renderDropZone` with Slots.