### PR TITLE
Prevent inline text fields from shifting layout on hover

### DIFF
--- a/packages/core/components/InlineTextField/styles.module.css
+++ b/packages/core/components/InlineTextField/styles.module.css
@@ -3,6 +3,10 @@
   display: inline-block;
   white-space: pre-wrap;
   text-decoration: inherit;
+  /* Browsers force `overflow-wrap: break-word` on contenteditable elements,
+     which wraps overflowing text on hover and shifts the layout. Inherit the
+     parent's value so the editable and rendered states stay identical. */
+  overflow-wrap: inherit;
 }
 
 /* Safari fixes for https://bugs.webkit.org/show_bug.cgi?id=112854 */


### PR DESCRIPTION
Closes #1802

## Description

This PR fixes an issue where inline text fields would shift the layout on hover.

The reason this was happening is that browsers default content editable elements to `overflow-wrap: break-word`.

The fix is to inherit whatever the `overflow-wrap` rule is for the content editable `span` parent.

## Changes made

- Added `overflow-wrap: inherit` to the inline text field span.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented editable text from wrapping differently when users hover over inline text fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->