### PR TITLE
fix: hide sidebar resize handle when sidebar is not visible

### DIFF
--- a/packages/core/components/Puck/components/Sidebar/index.tsx
+++ b/packages/core/components/Puck/components/Sidebar/index.tsx
@@ -30,14 +30,16 @@ export const Sidebar: React.FC<SidebarProps> = ({
       >
         {children}
       </div>
-      <div className={`${getClassName("resizeHandle")}`}>
-        <ResizeHandle
-          position={position}
-          sidebarRef={sidebarRef}
-          onResize={onResize}
-          onResizeEnd={onResizeEnd}
-        />
-      </div>
+      {isVisible && (
+        <div className={`${getClassName("resizeHandle")}`}>
+          <ResizeHandle
+            position={position}
+            sidebarRef={sidebarRef}
+            onResize={onResize}
+            onResizeEnd={onResizeEnd}
+          />
+        </div>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description

The `Sidebar` component always showed its resize handle, even when `isVisible` was false. CSS hid the sidebar itself, but not the handle next to it. So if a sidebar was turned off (e.g. `ui.rightSideBarVisible: false`), the resize handle still showed up on screen with a `col-resize` cursor, even though there was nothing to resize. Dragging it still ran the resize code on a sidebar you couldn't see.

## Changes made

- The resize handle now only renders when `isVisible` is true, same as the sidebar itself.

## How to test

- Render `<Puck>` with either `ui.rightSideBarVisible: false` or `ui.leftSideBarVisible: false`. Look at that edge of the canvas. 

Before: a resize handle is still there and clickable. 


https://github.com/user-attachments/assets/bd168734-1801-4566-bf9f-2ce740a02a0a



After: no handle shows.



https://github.com/user-attachments/assets/701101f7-9d41-4477-b3d0-cf91257757b0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The sidebar resize handle is now hidden when the sidebar is not visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->