### PR TITLE
Expose inline text field component

### DIFF
--- a/apps/docs/pages/docs/api-reference/components.mdx
+++ b/apps/docs/pages/docs/api-reference/components.mdx
@@ -26,6 +26,7 @@ Puck provides several components to support different integration approaches.
 - [\<Drawer\>](components/drawer) - A reference list of items that can be dragged into a droppable area, normally [`<Puck.Preview>`](components/puck-preview).
 - [\<Drawer.Item\>](components/drawer-item) - An item that can be dragged from a [`<Drawer>`](components/drawer).
 - [\<FieldLabel\>](components/field-label) - Render a styled `label` when creating [`custom` fields](/docs/api-reference/fields/custom).
+- [\<InlineTextField\>](components/inline-text-field) - Render an inline-editable text element from a [field transform](/docs/api-reference/field-transforms).
 - [\<RichTextMenu\>](components/rich-text-menu) - A menu containing a series of controls for the rich text field.
 - [\<RichTextMenu.Control\>](components/rich-text-menu-control) - A control for custom behavior within the RichTextMenu component.
 - [\<RichTextMenu.Group\>](components/rich-text-menu-group) - A group of controls for use within the RichTextMenu component.

--- a/apps/docs/pages/docs/api-reference/components/_meta.js
+++ b/apps/docs/pages/docs/api-reference/components/_meta.js
@@ -9,6 +9,7 @@ const menu = {
   "drawer-item": {},
   "drop-zone": {},
   "field-label": {},
+  "inline-text-field": {},
   puck: {},
   "puck-components": {},
   "puck-fields": {},

--- a/apps/docs/pages/docs/api-reference/components/inline-text-field.mdx
+++ b/apps/docs/pages/docs/api-reference/components/inline-text-field.mdx
@@ -1,0 +1,129 @@
+---
+title: <InlineTextField>
+---
+
+import { PuckPreview } from "@/docs/components/Preview";
+import { Puck, InlineTextField } from "@/puck";
+import { Callout } from "nextra/components";
+
+# \<InlineTextField\>
+
+Render inline-editable text from a [field transform](/docs/api-reference/field-transforms).
+
+This is the same component that powers the [`contentEditable`](/docs/api-reference/fields/text#contenteditable) option internally. Use it to create new [inline-editable fields](/docs/extending-puck/ui-overrides#introducing-new-field-types).
+
+<PuckPreview
+  label="Example"
+  config={{
+    components: {
+      Example: {
+        fields: {
+          heading: { type: "heading" },
+        },
+        render: ({ heading }) => <h2>{heading}</h2>,
+      },
+    },
+  }}
+  data={{
+    content: [
+      {
+        type: "Example",
+        props: {
+          id: "example",
+          heading: "Edit me inline",
+        },
+      },
+    ],
+    root: { props: {} },
+  }}
+  overrides={{
+    fieldTypes: {
+      heading: {
+        render: () => <div />,
+      },
+    },
+  }}
+  fieldTransforms={{
+    heading: ({ value, componentId, propPath, isReadOnly, field }) => (
+      <InlineTextField
+        value={value}
+        componentId={componentId}
+        propPath={propPath}
+        isReadOnly={isReadOnly}
+      />
+    ),
+  }}
+  permissions={{ drag: false, delete: false, duplicate: false }}
+/>
+
+```tsx {1,5-10} showLineNumbers copy
+import { InlineTextField, Puck } from "@puckeditor/core";
+
+const fieldTransforms = {
+  heading: ({ value, componentId, propPath, isReadOnly }) => (
+    <InlineTextField
+      value={value}
+      componentId={componentId}
+      propPath={propPath}
+      isReadOnly={isReadOnly}
+    />
+  ),
+};
+```
+
+All required props below are available in [field transforms](/docs/api-reference/field-transforms).
+
+## Props
+
+| Param                         | Example                       | Type                        | Status   |
+| ----------------------------- | ----------------------------- | --------------------------- | -------- |
+| [`componentId`](#componentid) | `"Example-1"`                 | String                      | Required |
+| [`propPath`](#proppath)       | `"heading.text"`              | String                      | Required |
+| [`value`](#value)             | `"Hello, world"`              | String \| null \| undefined | Required |
+| [`isReadOnly`](#isreadonly)   | `false`                       | Boolean                     | Required |
+| [`opts`](#opts)               | `{ disableLineBreaks: true }` | Object                      | -        |
+
+## Required props
+
+### `componentId`
+
+The id of the component containing the prop being edited.
+
+### `propPath`
+
+The path of the prop to write changes to, within the component's props object.
+
+Append keys to the transform's [`propPath`](/docs/api-reference/field-transforms#proppath) to target a nested property within the field value (for example `${propPath}.text`).
+
+### `value`
+
+The current field value.
+
+### `isReadOnly`
+
+Whether the field is currently read-only. When `true`, edits are prevented.
+
+## Optional props
+
+### `opts`
+
+Additional options for the field.
+
+#### `opts.disableLineBreaks`
+
+Prevent the user from adding line breaks when pressing `Enter`. Defaults to `false`.
+
+```tsx /opts={{ disableLineBreaks: true }}/ copy
+<InlineTextField
+  value={value}
+  componentId={componentId}
+  propPath={propPath}
+  isReadOnly={isReadOnly}
+  opts={{ disableLineBreaks: true }}
+/>
+```
+
+## Further reading
+
+- [Field Transforms API reference](/docs/api-reference/field-transforms)
+- [Field Transforms guide](/docs/extending-puck/field-transforms)

--- a/packages/core/bundle/core.ts
+++ b/packages/core/bundle/core.ts
@@ -14,6 +14,7 @@ export { Drawer } from "../components/Drawer";
 
 export { DropZone } from "../components/DropZone";
 export * from "../components/IconButton";
+export { InlineTextField } from "../components/InlineTextField";
 export { Puck } from "../components/Puck";
 export * from "../components/Render";
 export { RichTextMenu } from "../components/RichTextMenu/inner";


### PR DESCRIPTION
Closes puckeditor/puck#1252

## Description

This PR exposes the inline text field component to allow users to create new inline editable fields using field transforms.

## Changes made

* Added new docs for the component
* Exposed the component from the core bundle

## Summary by CodeRabbit

* **New Features**
  * Added the `InlineTextField` component to the public component library.
  * Supports inline text editing through field transforms, with configurable line-break behavior.
* **Documentation**
  * Added comprehensive `InlineTextField` documentation, including an interactive example, props, usage guidance, and related resources.
  * Added the component to the API reference navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `InlineTextField` to the public component library.
  * Supports inline editing through field transforms, with configurable line-break behavior.

* **Documentation**
  * Added comprehensive usage documentation, interactive examples, prop details, and related links.
  * Added `InlineTextField` to the component reference and navigation menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->