### PR TITLE
fix(core): don't re-enter a fieldTypes override from AutoField

### DIFF
--- a/packages/core/components/AutoField/__tests__/field-type-overrides.spec.tsx
+++ b/packages/core/components/AutoField/__tests__/field-type-overrides.spec.tsx
@@ -1,0 +1,276 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Config, Data, Overrides } from "../../../types";
+
+jest.mock("../../Puck/styles.module.css");
+
+jest.mock("@dnd-kit/react", () => {
+  const original = jest.requireActual("@dnd-kit/react");
+  return {
+    ...original,
+    DragDropProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    useDroppable: () => ({
+      ref: () => undefined,
+      setNodeRef: () => undefined,
+      isOver: false,
+    }),
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => undefined,
+      isDragging: false,
+    }),
+  };
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+const originalConsoleError = console.error;
+jest.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  if (
+    args.some((arg) => String(arg).includes("Could not parse CSS stylesheet"))
+  ) {
+    return;
+  }
+  originalConsoleError(...(args as Parameters<typeof console.error>));
+});
+
+jest.spyOn(console, "warn").mockImplementation(() => {});
+
+import { Puck } from "../../Puck";
+import { AutoField } from "..";
+
+const flush = () => act(async () => {});
+
+type RootProps = { title?: string; subtitle?: string };
+
+const config: Config<{ components: {}; root: RootProps }> = {
+  root: { fields: { title: { type: "text" } } },
+  components: {},
+};
+
+const data: Data<{}, RootProps> = {
+  root: { props: { title: "Hello, world" } },
+  content: [],
+};
+
+const renderPuck = (
+  overrides: Partial<Overrides>,
+  cfg: typeof config = config,
+  d: typeof data = data
+) =>
+  render(
+    <Puck
+      config={cfg}
+      data={d}
+      overrides={overrides}
+      iframe={{ enabled: false }}
+    />
+  );
+
+/**
+ * Puck mounts its fields panel more than once (the sidebar and the mobile
+ * layout render the same fields), so a single field renders a fixed multiple of
+ * times. Measure it rather than hardcoding it, or these tests break the next
+ * time the shell changes.
+ */
+let panels = 0;
+
+beforeAll(async () => {
+  const spy = jest.fn();
+
+  renderPuck({
+    fieldTypes: {
+      text: () => {
+        spy();
+
+        return <strong>Measured</strong>;
+      },
+    },
+  });
+
+  await flush();
+  await waitFor(() => expect(spy).toHaveBeenCalled());
+
+  panels = spy.mock.calls.length;
+
+  cleanup();
+});
+
+describe("fieldTypes overrides that render <AutoField>", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it("renders the built-in field rather than re-entering the override", async () => {
+    const renderSpy = jest.fn();
+
+    renderPuck({
+      fieldTypes: {
+        text: (props) => {
+          renderSpy();
+
+          return (
+            <>
+              <strong>Text Field</strong>
+              <AutoField
+                value={props.value}
+                onChange={props.onChange}
+                field={{ type: "text" }}
+              />
+            </>
+          );
+        },
+      },
+    });
+
+    await flush();
+    await waitFor(() => expect(renderSpy).toHaveBeenCalled());
+
+    // The override wraps its field exactly once. Before this was fixed, the
+    // nested <AutoField> resolved the same override again, and again, until the
+    // stack was exhausted.
+    expect(renderSpy).toHaveBeenCalledTimes(panels);
+    expect(screen.getAllByText("Text Field")).toHaveLength(panels);
+
+    // ...and the field it renders is the built-in one, carrying the value.
+    expect(screen.getAllByDisplayValue("Hello, world")).toHaveLength(panels);
+  });
+
+  it("doesn't re-enter a mutually recursive pair of overrides", async () => {
+    const textSpy = jest.fn();
+    const numberSpy = jest.fn();
+
+    renderPuck({
+      fieldTypes: {
+        text: (props) => {
+          textSpy();
+
+          return (
+            <>
+              <strong>Text Field</strong>
+              <AutoField
+                value={props.value}
+                onChange={props.onChange}
+                field={{ type: "number" }}
+              />
+            </>
+          );
+        },
+        number: (props) => {
+          numberSpy();
+
+          return (
+            <>
+              <strong>Number Field</strong>
+              <AutoField
+                value={props.value}
+                onChange={props.onChange}
+                field={{ type: "text" }}
+              />
+            </>
+          );
+        },
+      },
+    });
+
+    await flush();
+    await waitFor(() => expect(numberSpy).toHaveBeenCalled());
+
+    // text -> number is entered, and the text field nested inside number falls
+    // back to the built-in field instead of starting the cycle again.
+    expect(textSpy).toHaveBeenCalledTimes(panels);
+    expect(numberSpy).toHaveBeenCalledTimes(panels);
+  });
+
+  it("still applies an override to a different field type nested within one", async () => {
+    const numberSpy = jest.fn();
+
+    renderPuck({
+      fieldTypes: {
+        text: (props) => (
+          <>
+            <strong>Text Field</strong>
+            <AutoField
+              value={props.value}
+              onChange={props.onChange}
+              field={{ type: "number" }}
+            />
+          </>
+        ),
+        number: () => {
+          numberSpy();
+
+          return <strong>Number Field</strong>;
+        },
+      },
+    });
+
+    await flush();
+    await waitFor(() => expect(numberSpy).toHaveBeenCalled());
+
+    expect(numberSpy).toHaveBeenCalledTimes(panels);
+  });
+
+  it("leaves the override in place for fields outside its own subtree", async () => {
+    const textSpy = jest.fn();
+
+    renderPuck(
+      {
+        fieldTypes: {
+          text: (props) => {
+            textSpy();
+
+            return (
+              <>
+                <strong>Text Field</strong>
+                <AutoField
+                  value={props.value}
+                  onChange={props.onChange}
+                  field={{ type: "text" }}
+                />
+              </>
+            );
+          },
+        },
+      },
+      {
+        root: {
+          fields: { title: { type: "text" }, subtitle: { type: "text" } },
+        },
+        components: {},
+      },
+      { root: { props: { title: "a", subtitle: "b" } }, content: [] }
+    );
+
+    await flush();
+    await waitFor(() => expect(textSpy).toHaveBeenCalled());
+
+    // Two sibling text fields, each overridden once: the fallback is scoped to
+    // an override's own subtree, not to the field type globally.
+    expect(textSpy).toHaveBeenCalledTimes(panels * 2);
+    expect(screen.getAllByText("Text Field")).toHaveLength(panels * 2);
+  });
+});

--- a/packages/core/components/AutoField/context.tsx
+++ b/packages/core/components/AutoField/context.tsx
@@ -1,4 +1,13 @@
 import { createContext, PropsWithChildren, useContext, useMemo } from "react";
+import type { ActiveFieldTypeOverrides } from "../../lib/overrides/field-types";
+
+/**
+ * The field types whose `fieldTypes` override is rendering above this point in
+ * the tree, so a public `<AutoField>` inside an override can fall back to the
+ * built-in field instead of re-entering it.
+ */
+export const ActiveFieldTypeOverridesContext =
+  createContext<ActiveFieldTypeOverrides>({});
 
 type NestedFieldContext = {
   localName?: string;

--- a/packages/core/components/AutoField/index.tsx
+++ b/packages/core/components/AutoField/index.tsx
@@ -22,10 +22,11 @@ import {
 import { ObjectField } from "./fields/ObjectField";
 import { useAppStore } from "../../store";
 import { useSafeId } from "../../lib/use-safe-id";
-import { NestedFieldContext } from "./context";
+import { ActiveFieldTypeOverridesContext, NestedFieldContext } from "./context";
 import { useShallow } from "zustand/react/shallow";
 import { setDeep } from "../../lib/data/set-deep";
 import { isFieldVisible } from "../../lib/fields/is-field-visible";
+import { isFieldTypeOverrideActive } from "../../lib/overrides/field-types";
 import type {
   FieldLabelPropsInternal,
   FieldPropsInternalOptional,
@@ -65,15 +66,20 @@ const defaultFields = {
 function AutoFieldInternal<
   ValueType = any,
   FieldType extends FieldNoLabel<ValueType> = FieldNoLabel<ValueType>
->(
-  props: FieldPropsInternalOptional<ValueType, FieldType> & {
-    Label?: React.FC<FieldLabelPropsInternal>;
-  }
-) {
+>({
+  // Stripped from the props handed to field components: this is Puck's own
+  // bookkeeping, not part of the public field API.
+  bypassFieldTypeOverride = false,
+  ...props
+}: FieldPropsInternalOptional<ValueType, FieldType> & {
+  Label?: React.FC<FieldLabelPropsInternal>;
+  bypassFieldTypeOverride?: boolean;
+}) {
   const dispatch = useAppStore((s) => s.dispatch);
   const overrides = useAppStore((s) => s.overrides);
   const readOnly = useAppStore(useShallow((s) => s.selectedItem?.readOnly));
   const nestedFieldContext = useContext(NestedFieldContext);
+  const activeFieldTypeOverrides = useContext(ActiveFieldTypeOverridesContext);
 
   const { id, Label = FieldLabelInternal } = props;
 
@@ -101,10 +107,15 @@ function AutoFieldInternal<
     [overrides]
   );
 
+  // Whether this field is actually rendered by a `fieldTypes` override. False
+  // when the override is being bypassed to avoid re-entering itself, in which
+  // case this behaves exactly like a field with no override at all.
+  const rendersOverride =
+    !!overrides.fieldTypes?.[field.type] && !bypassFieldTypeOverride;
+
   // Custom fields and overridden field types are handed their value directly,
   // out of the field store. Built-in fields read it themselves.
-  const readsValueFromStore =
-    field.type === "custom" || !!overrides.fieldTypes?.[field.type];
+  const readsValueFromStore = field.type === "custom" || rendersOverride;
 
   const fieldPath = props.name ?? resolvedId;
 
@@ -192,18 +203,35 @@ function AutoFieldInternal<
 
   const fieldKey = field.type === "custom" ? field.key : undefined;
 
+  // Mark this field type as overridden for everything the override renders, so a
+  // public `<AutoField>` of the same type inside it doesn't resolve the override
+  // again. Unchanged by reference when nothing is being overridden here, so
+  // fields that aren't overridden pay nothing for this.
+  const childActiveFieldTypeOverrides = useMemo(
+    () =>
+      rendersOverride
+        ? { ...activeFieldTypeOverrides, [field.type]: true }
+        : activeFieldTypeOverrides,
+    [rendersOverride, activeFieldTypeOverrides, field.type]
+  );
+
   let FieldComponent: React.ComponentType<any> | null | undefined =
     useMemo(() => {
       // if there's an override provided for custom fields, fallback to standard behavior
-      if (field.type === "custom" && !render[field.type]) {
+      if (
+        field.type === "custom" &&
+        (!render[field.type] || bypassFieldTypeOverride)
+      ) {
         if (!field.render) {
           return null;
         }
         return field.render;
       } else if (field.type !== "slot") {
-        return render[field.type];
+        return bypassFieldTypeOverride
+          ? defaultFields[field.type as keyof typeof defaultFields]
+          : render[field.type];
       }
-    }, [field.type, fieldKey, render]);
+    }, [field.type, fieldKey, render, bypassFieldTypeOverride]);
 
   if (!isFieldVisible(overrides.fieldTypes, field)) {
     return null;
@@ -220,21 +248,25 @@ function AutoFieldInternal<
         localName: nestedFieldContext.localName ?? mergedProps.name,
       }}
     >
-      <div
-        className={getClassNameWrapper()}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onClick={(e) => {
-          // Prevent propagation of any click events to parent field.
-          // For example, a field within an array may bubble an event
-          // and fail to stop propagation.
-          e.stopPropagation();
-        }}
+      <ActiveFieldTypeOverridesContext.Provider
+        value={childActiveFieldTypeOverrides}
       >
-        <FieldComponent {...mergedProps}>
-          <Children {...(mergedProps as any)} />
-        </FieldComponent>
-      </div>
+        <div
+          className={getClassNameWrapper()}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onClick={(e) => {
+            // Prevent propagation of any click events to parent field.
+            // For example, a field within an array may bubble an event
+            // and fail to stop propagation.
+            e.stopPropagation();
+          }}
+        >
+          <FieldComponent {...mergedProps}>
+            <Children {...(mergedProps as any)} />
+          </FieldComponent>
+        </div>
+      </ActiveFieldTypeOverridesContext.Provider>
     </NestedFieldContext.Provider>
   );
 }
@@ -256,7 +288,14 @@ export function AutoFieldPrivate<
 function AutoFieldPublicInternal<
   ValueType = any,
   FieldType extends FieldNoLabel<ValueType> = FieldNoLabel<ValueType>
->({ value, ...props }: FieldProps<FieldType, ValueType> & { value: any }) {
+>({
+  value,
+  bypassFieldTypeOverride,
+  ...props
+}: FieldProps<FieldType, ValueType> & {
+  value: any;
+  bypassFieldTypeOverride?: boolean;
+}) {
   const DefaultLabel = useMemo(() => {
     const DefaultLabel = (labelProps: any) => (
       <div
@@ -292,6 +331,7 @@ function AutoFieldPublicInternal<
       {...props}
       onChange={onChange}
       Label={DefaultLabel}
+      bypassFieldTypeOverride={bypassFieldTypeOverride}
     />
   );
 }
@@ -301,14 +341,30 @@ export function AutoField<
   FieldType extends FieldNoLabel<ValueType> = FieldNoLabel<ValueType>
 >(props: FieldProps<FieldType, ValueType> & { value: any }) {
   const id = useSafeId();
+  const activeFieldTypeOverrides = useContext(ActiveFieldTypeOverridesContext);
 
   if (props.field.type === "slot") {
     return null;
   }
 
+  // A `fieldTypes` override that renders an `<AutoField>` for its own field type
+  // would resolve that same override again and recurse until the stack is
+  // exhausted. Inside an override's own subtree, render the built-in field for
+  // that type instead. Only this public entry point can re-enter an override —
+  // the default node an override receives as `children`, and every field Puck
+  // nests itself, go through `AutoFieldPrivate`.
+  const bypassFieldTypeOverride = isFieldTypeOverrideActive(
+    activeFieldTypeOverrides,
+    props.field.type
+  );
+
   return (
     <fieldContextStore.Provider value={{ [id]: props.value }}>
-      <AutoFieldPublicInternal<ValueType, FieldType> {...props} id={id} />
+      <AutoFieldPublicInternal<ValueType, FieldType>
+        {...props}
+        id={id}
+        bypassFieldTypeOverride={bypassFieldTypeOverride}
+      />
     </fieldContextStore.Provider>
   );
 }

--- a/packages/core/lib/overrides/__tests__/field-types.spec.ts
+++ b/packages/core/lib/overrides/__tests__/field-types.spec.ts
@@ -1,4 +1,4 @@
-import { isFieldTypeHidden } from "../field-types";
+import { isFieldTypeHidden, isFieldTypeOverrideActive } from "../field-types";
 
 describe("isFieldTypeHidden", () => {
   it("returns true when the matching override is null", () => {
@@ -17,5 +17,30 @@ describe("isFieldTypeHidden", () => {
 
   it("returns false when the field type is missing", () => {
     expect(isFieldTypeHidden({ text: null })).toBe(false);
+  });
+});
+
+describe("isFieldTypeOverrideActive", () => {
+  it("returns true when the field type's override is rendering above", () => {
+    expect(isFieldTypeOverrideActive({ text: true }, "text")).toBe(true);
+  });
+
+  it("returns false for a field type whose override isn't rendering above", () => {
+    expect(isFieldTypeOverrideActive({ text: true }, "number")).toBe(false);
+  });
+
+  it("returns true for mutually recursive overrides", () => {
+    expect(
+      isFieldTypeOverrideActive({ text: true, number: true }, "text")
+    ).toBe(true);
+  });
+
+  it("returns false when nothing is rendering above", () => {
+    expect(isFieldTypeOverrideActive(undefined, "text")).toBe(false);
+    expect(isFieldTypeOverrideActive({}, "text")).toBe(false);
+  });
+
+  it("returns false when the field type is missing", () => {
+    expect(isFieldTypeOverrideActive({ text: true })).toBe(false);
   });
 });

--- a/packages/core/lib/overrides/__tests__/field-types.spec.ts
+++ b/packages/core/lib/overrides/__tests__/field-types.spec.ts
@@ -43,4 +43,12 @@ describe("isFieldTypeOverrideActive", () => {
   it("returns false when the field type is missing", () => {
     expect(isFieldTypeOverrideActive({ text: true })).toBe(false);
   });
+
+  it("returns false for a field type inherited from Object.prototype", () => {
+    expect(isFieldTypeOverrideActive({ text: true }, "toString")).toBe(false);
+    expect(isFieldTypeOverrideActive({ text: true }, "constructor")).toBe(
+      false
+    );
+    expect(isFieldTypeOverrideActive({}, "hasOwnProperty")).toBe(false);
+  });
 });

--- a/packages/core/lib/overrides/field-types.ts
+++ b/packages/core/lib/overrides/field-types.ts
@@ -13,3 +13,28 @@ export const isFieldTypeHidden = (
 ) => {
   return fieldType ? overrides?.[fieldType] === null : false;
 };
+
+/**
+ * The field types whose `fieldTypes` override is already rendering higher up the
+ * tree.
+ */
+export type ActiveFieldTypeOverrides = Readonly<Record<string, boolean>>;
+
+/**
+ * Checks if a field type's override is already rendering higher up the tree.
+ *
+ * An override that renders an `<AutoField>` for its own field type resolves the
+ * same override again, which renders another `<AutoField>`, and so on until the
+ * stack is exhausted. Puck's own nested fields go through `AutoFieldPrivate`, so
+ * only the public `<AutoField>` can re-enter an override this way.
+ *
+ * @param activeFieldTypeOverrides The field types whose override is rendering above.
+ * @param fieldType The field type to check.
+ * @returns True if rendering the override again would re-enter it, false otherwise.
+ */
+export const isFieldTypeOverrideActive = (
+  activeFieldTypeOverrides?: ActiveFieldTypeOverrides,
+  fieldType?: string
+) => {
+  return fieldType ? !!activeFieldTypeOverrides?.[fieldType] : false;
+};

--- a/packages/core/lib/overrides/field-types.ts
+++ b/packages/core/lib/overrides/field-types.ts
@@ -28,6 +28,10 @@ export type ActiveFieldTypeOverrides = Readonly<Record<string, boolean>>;
  * stack is exhausted. Puck's own nested fields go through `AutoFieldPrivate`, so
  * only the public `<AutoField>` can re-enter an override this way.
  *
+ * Compared against `true` rather than coerced, so a field type that names an
+ * `Object.prototype` member — `toString`, `constructor` — reads as inactive
+ * rather than picking up the inherited value.
+ *
  * @param activeFieldTypeOverrides The field types whose override is rendering above.
  * @param fieldType The field type to check.
  * @returns True if rendering the override again would re-enter it, false otherwise.
@@ -36,5 +40,5 @@ export const isFieldTypeOverrideActive = (
   activeFieldTypeOverrides?: ActiveFieldTypeOverrides,
   fieldType?: string
 ) => {
-  return fieldType ? !!activeFieldTypeOverrides?.[fieldType] : false;
+  return fieldType ? activeFieldTypeOverrides?.[fieldType] === true : false;
 };


### PR DESCRIPTION
Fixes #1057.

## The mechanism

`AutoFieldInternal` resolves a field's component out of `overrides.fieldTypes`. So when a `text` override renders an `<AutoField field={{ type: "text" }} />`, that `AutoField` resolves `fieldTypes.text` again — the same override — which renders another `<AutoField>`, and so on. Nothing terminates it.

This isn't only the shape in the issue: any two overrides that reach each other (`text` renders a `number` field, `number` renders a `text` field) form the same cycle.

## The fix

A context records which field types have an override rendering above the current point in the tree. The public `<AutoField>` reads it, and for a field type that is already in it, renders the built-in field for that type instead of the override.

The bookkeeping is deliberately narrow:

- **Only the public `<AutoField>` consults it.** The default node an override receives as `children`, and every field Puck nests itself, go through `AutoFieldPrivate`, which is untouched. An override that renders `children` still gets nested overrides applied to whatever that default node renders — including another field of its own type, which is not a cycle.
- **The fallback is scoped to an override's own subtree**, not to the field type globally, so a second `text` field elsewhere in the sidebar is still overridden. There's a test for this.
- **A set, not a flag**, so `text -> number -> text` terminates too.
- The context value is unchanged by reference when the field isn't overridden, so fields with no override don't pay for it.

`readsValueFromStore` follows the same distinction: when the override is bypassed the field behaves exactly like one with no override at all, and reads its own value.

## How it was checked

`packages/core/components/AutoField/__tests__/field-type-overrides.spec.tsx` renders `<Puck>` with the issue's own override and asserts the override is entered once per field and that the field it wraps is the built-in one, carrying its value. Three more cases cover the mutually recursive pair, an override nested inside a *different* override (which must still apply), and two sibling fields of the overridden type.

**The negative control is worth stating plainly: against `main` this spec does not fail, it kills the worker** — `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory` after ~67s, which is the "page freezes" in the issue reproduced in jsdom. It fails safely with the fix in place; I mention it so the OOM isn't a surprise if anyone reverts the source file to check.

The panel count the assertions use is measured in `beforeAll` rather than hardcoded, since Puck mounts its fields panel more than once and that's a shell detail these tests shouldn't pin.

Also unit tests for the new pure helper alongside the existing `isFieldTypeHidden` ones.

    yarn jest        55 suites, 299 tests, 19 snapshots — all pass
    yarn lint        0 errors (4 pre-existing warnings, none in changed files)
    tsc --noEmit     7 errors, identical to `main` — none in changed files
    prettier         clean

## Note

The documented way to reuse the default field inside an override is `children`, and that remains the better path. But `<AutoField>` is documented for building fields, an override is a natural place to reach for it, and the current failure mode is a frozen tab with no error — so falling back seemed better than, say, throwing.

Happy to reshape any of this if you'd rather solve it a different way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented custom field-type overrides from recursively rendering themselves.
  * Added safeguards for mutually recursive overrides while preserving valid nested overrides.
  * Ensured overrides continue to apply correctly to separate fields outside the current override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*