### PR TITLE
Clarify that field transforms that use components need to be rendered instead of passed

### DIFF
--- a/apps/docs/pages/docs/api-reference/field-transforms.mdx
+++ b/apps/docs/pages/docs/api-reference/field-transforms.mdx
@@ -7,8 +7,10 @@ title: FieldTransforms
 Transform the data for each [field type](/docs/api-reference/fields) before rendering in the editor.
 
 ```tsx copy
+const UppercaseText = ({ value }) => <p>{value.toUpperCase()}</p>;
+
 const fieldTransforms = {
-  text: ({ value }) => <p>{value}</p>,
+  text: (props) => <UppercaseText {...props} />,
   // ...
 };
 ```

--- a/apps/docs/pages/docs/extending-puck/field-transforms.mdx
+++ b/apps/docs/pages/docs/extending-puck/field-transforms.mdx
@@ -16,7 +16,7 @@ Specify a transforms object for the fields you want to modify before rendering:
 
 ```tsx
 const fieldTransforms = {
-  text: ({ value }) => <div>Value: {value}</div>, // Wrap all text field props in divs
+  text: ({ value }) => value.toUpperCase(), // Transform text fields to uppercase
 };
 
 const Example = () => <Puck fieldTransforms={fieldTransforms} />;
@@ -48,11 +48,13 @@ const EditableText = ({ value }) => {
 };
 
 const fieldTransforms = {
-  text: EditableText,
+  text: (props) => <EditableText {...props} />,
 };
 
 const Example = () => <Puck fieldTransforms={fieldTransforms} />;
 ```
+
+Because Puck calls transforms as functions, render components that use hooks from the transform instead of passing them directly.
 
 ## Define new fields
 

--- a/apps/docs/pages/docs/extending-puck/plugins.mdx
+++ b/apps/docs/pages/docs/extending-puck/plugins.mdx
@@ -127,10 +127,22 @@ This may result in some incompatible plugin combinations. To improve your chance
 
 Both the field transforms and overrides let you introduce [entirely new field types](/docs/extending-puck/ui-overrides#introducing-new-field-types). Plugins can combine this functionality to bundle up new field behavior in a convenient package.
 
-This example uses [Overlay Portals](overlay-portals) to create an interactive rich text field that can modified directly in the editor preview.
+This example uses [Overlay Portals](overlay-portals) to create an interactive rich text field that can be modified directly in the editor preview.
 
-```tsx showLineNumbers copy {6-8, 12-20}
+```tsx showLineNumbers copy {4-14, 23-25}
+import { useCallback } from "react";
 import { registerOverlayPortal } from "@puckeditor/core";
+
+const InlineRichText = ({ value }) => {
+  const handleInput = useCallback(() => {}, []); // Implement your input behavior
+
+  return (
+    // Wrap the value in a span, create an overlay portal, and make it editable
+    <span ref={registerOverlayPortal} contentEditable onInput={handleInput}>
+      {value}
+    </span>
+  );
+};
 
 const plugin = {
   overrides: {
@@ -140,16 +152,8 @@ const plugin = {
     },
   },
   fieldTransforms: {
-    // Wrap the value in a span, create an overlay portal, and make it editable
-    richText: ({ value }) => {
-      const handleInput = useCallback(() => {}, []); // Implement your input behavior
-
-      return (
-        <span ref={registerOverlayPortal} contentEditable onInput={handleInput}>
-          {value}
-        </span>
-      );
-    },
+    // Make the richText field editable inline
+    richText: (props) => <InlineRichText {...props} />,
   },
 };
 ```


### PR DESCRIPTION
Closes #1251

## Description

This PR addresses parts of the docs that were mistakenly encouraging users to follow anti-patterns in field transforms.

The docs were telling people to pass component references directly to transforms instead of rendering the component from the transform. This is an anti-pattern because transforms are called internally as plain functions within `useMemo`. For plain values, that's fine, but for components, that's not correct because it merges the render context (state tracking, hook usage, DOM access, etc.) of the user-defined components with the internal Puck ones. Basically, React doesn't "see" two components. It just sees the component code as a function call within our internal rendering flow.

That's wrong for a number of different reasons, performance being one of them, but it also makes React throw when components passed directly to transforms use hooks, since those hooks get bubbled up to the parent and can't be used within `useMemo`.

Since we can't know whether the user will return a value or a component, and therefore can't know whether we need to call the transform as JSX or as a plain function, I decided to fix the docs to clarify how to render components instead of providing an additional API that would just wrap what React already handles.

This is not an issue with things like component config or override render functions because we always call those as JSX, since we know they will always be components.

## Changes made

- Documented that transforms are called as functions, so when using components, users should render the component instead of passing it directly.
- Fixed the snippet that originally surfaced this problem to use the correct pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated field transform examples to demonstrate uppercase text transformations.
  * Clarified that transforms are invoked as functions, including guidance for interactive components using hooks.
  * Improved rich text plugin examples by simplifying inline editing implementation and correcting explanatory text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->