### PR TITLE
fix(core): re-mirror a host style that is removed and re-added

### DIFF
--- a/packages/core/components/AutoFrame/__tests__/copy-host-styles.spec.tsx
+++ b/packages/core/components/AutoFrame/__tests__/copy-host-styles.spec.tsx
@@ -103,4 +103,42 @@ describe("CopyHostStyles", () => {
     hostStyle = null;
     await flush();
   });
+
+  it("keeps the mirror until the last of several identical styles is removed", async () => {
+    render(
+      <autoFrameContext.Provider
+        value={{ document: mirrorDoc, window: window as Window }}
+      >
+        <CopyHostStyles>{null}</CopyHostStyles>
+      </autoFrameContext.Provider>
+    );
+    await flush();
+
+    const first = await addHostStyle();
+    const second = document.createElement("style");
+    second.innerHTML = CSS;
+    document.head.appendChild(second);
+    await flush();
+
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+
+    // Removing the FIRST of the two must not take the shared mirror away from
+    // the second, which is still in the host document. Both nodes are dedupe
+    // partners, so only one of them ever owned an `elements` entry.
+    first.remove();
+    await flush();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+
+    // ...and the mirror goes when the last owner does, leaving nothing stale
+    // behind for the re-add path above to trip over.
+    second.remove();
+    hostStyle = null;
+    await flush();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(0);
+
+    // The hash must have been retired with it: an identical style added now is
+    // mirrored rather than skipped as a duplicate.
+    await addHostStyle();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+  });
 });

--- a/packages/core/components/AutoFrame/__tests__/copy-host-styles.spec.tsx
+++ b/packages/core/components/AutoFrame/__tests__/copy-host-styles.spec.tsx
@@ -1,0 +1,106 @@
+import { render, act } from "@testing-library/react";
+import { CopyHostStyles, autoFrameContext } from "../index";
+
+/**
+ * Regression cover for #1732: a host <style> that is removed and then re-added
+ * identically must be mirrored into the frame again.
+ *
+ * `hashes` is keyed by the mirror's outerHTML (which carries
+ * data-puck-style-mirror). removeEl used to key its delete by the *original*
+ * node, so the real entry survived the removal and the re-added style looked
+ * like a duplicate. It also left the elements entry in place, so a re-add took
+ * addEl's "already mirrored" branch and wrote to a detached node.
+ *
+ * The mirror document here stands in for the iframe's document; CopyHostStyles
+ * takes it from autoFrameContext, and `win.parent.document` in jsdom is the
+ * host document the test mutates.
+ */
+
+const CSS = ".from-host { color: red; }";
+
+// defer() in the component is setTimeout(fn, 0); the observer itself delivers
+// on a microtask. Flush both.
+const flush = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+const mirroredCss = (doc: Document) =>
+  Array.from(doc.head.querySelectorAll("style"))
+    .map((el) => el.innerHTML)
+    .filter((css) => css.includes("from-host"));
+
+describe("CopyHostStyles", () => {
+  let mirrorDoc: Document;
+  let hostStyle: HTMLStyleElement | null;
+
+  beforeEach(() => {
+    mirrorDoc = document.implementation.createHTMLDocument("frame");
+    hostStyle = null;
+  });
+
+  afterEach(() => {
+    hostStyle?.remove();
+  });
+
+  const addHostStyle = async () => {
+    const style = document.createElement("style");
+    style.innerHTML = CSS;
+    document.head.appendChild(style);
+    hostStyle = style;
+    await flush();
+    return style;
+  };
+
+  it("re-mirrors an identical style element after it is removed and re-added", async () => {
+    render(
+      <autoFrameContext.Provider
+        value={{ document: mirrorDoc, window: window as Window }}
+      >
+        <CopyHostStyles>{null}</CopyHostStyles>
+      </autoFrameContext.Provider>
+    );
+    await flush();
+
+    const first = await addHostStyle();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+
+    first.remove();
+    hostStyle = null;
+    await flush();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(0);
+
+    // Byte-identical to the one just removed — this is the ag-grid
+    // unmount/remount case from the report, and what used to be dropped.
+    await addHostStyle();
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+  });
+
+  it("still dedupes a second, concurrently present identical style", async () => {
+    render(
+      <autoFrameContext.Provider
+        value={{ document: mirrorDoc, window: window as Window }}
+      >
+        <CopyHostStyles>{null}</CopyHostStyles>
+      </autoFrameContext.Provider>
+    );
+    await flush();
+
+    const first = await addHostStyle();
+    const second = document.createElement("style");
+    second.innerHTML = CSS;
+    document.head.appendChild(second);
+    await flush();
+
+    // The dedupe this fix must not break: two live identical nodes still
+    // produce one mirror.
+    expect(mirroredCss(mirrorDoc)).toHaveLength(1);
+
+    first.remove();
+    second.remove();
+    hostStyle = null;
+    await flush();
+  });
+});

--- a/packages/core/components/AutoFrame/index.tsx
+++ b/packages/core/components/AutoFrame/index.tsx
@@ -77,7 +77,9 @@ const syncAttributes = (sourceElement: Element, targetElement: Element) => {
 
 const defer = (fn: () => void) => setTimeout(fn, 0);
 
-const CopyHostStyles = ({
+// Exported for tests, like shouldMirrorStyleElement above it. Not re-exported
+// from the package root.
+export const CopyHostStyles = ({
   children,
   debug = false,
   onStylesLoaded = () => null,
@@ -97,7 +99,14 @@ const CopyHostStyles = ({
       return () => {};
     }
 
-    let elements: { original: HTMLElement; mirror: HTMLElement }[] = [];
+    // `mirrorHash` is the key this entry put into `hashes`, stored rather than
+    // recomputed: it is derived from the mirror, which `addEl` can mutate after
+    // insertion, so recomputing it later can produce a key that was never set.
+    let elements: {
+      original: HTMLElement;
+      mirror: HTMLElement;
+      mirrorHash: string;
+    }[] = [];
     const hashes: Record<string, boolean> = {};
 
     const removeAllMirrors = () => {
@@ -199,7 +208,7 @@ const CopyHostStyles = ({
       hashes[elHash] = true;
 
       doc.head.append(mirror as HTMLElement);
-      elements.push({ original: el, mirror: mirror });
+      elements.push({ original: el, mirror: mirror, mirrorHash: elHash });
 
       if (debug) console.log(`Added style node ${el.outerHTML}`);
     };
@@ -215,10 +224,18 @@ const CopyHostStyles = ({
         return;
       }
 
-      const elHash = hash(el.outerHTML);
+      const { mirror, mirrorHash } = elements[index];
 
-      elements[index]?.mirror?.remove();
-      delete hashes[elHash];
+      mirror.remove();
+      // Keyed by the mirror, matching addEl and the initial bulk sync. Hashing
+      // `el` here keyed by the original, which carries no
+      // data-puck-style-mirror attribute, so the delete missed and the real
+      // entry survived — an identical style re-added later then looked like a
+      // duplicate and was never mirrored back into the iframe.
+      delete hashes[mirrorHash];
+      // Without this the entry outlives its mirror, so a re-add takes addEl's
+      // "already mirrored" branch and updates a node no longer in the document.
+      elements.splice(index, 1);
 
       if (debug) console.log(`Removed style node ${el.outerHTML}`);
     };
@@ -301,7 +318,11 @@ const CopyHostStyles = ({
 
         if (!mirror) return;
 
-        elements.push({ original: styleNode, mirror });
+        elements.push({
+          original: styleNode,
+          mirror,
+          mirrorHash: hash(mirror.outerHTML),
+        });
 
         return mirror;
       })
@@ -357,10 +378,9 @@ const CopyHostStyles = ({
 
       observer.observe(parentDocument.head, { childList: true, subtree: true });
 
-      filtered.forEach((el) => {
-        const elHash = hash(el.outerHTML);
-
-        hashes[elHash] = true;
+      // Same keys the entries were pushed with, so removeEl can delete them.
+      elements.forEach(({ mirrorHash }) => {
+        hashes[mirrorHash] = true;
       });
     });
 

--- a/packages/core/components/AutoFrame/index.tsx
+++ b/packages/core/components/AutoFrame/index.tsx
@@ -199,8 +199,24 @@ export const CopyHostStyles = ({
       if (hashes[elHash]) {
         if (debug)
           console.log(
-            `iframe already contains element that is being mirrored. Skipping...`
+            `iframe already contains element that is being mirrored. Sharing...`
           );
+
+        // A second host style whose mirror would be byte-identical to one
+        // already in the frame. Don't append a duplicate — but do record this
+        // original against the existing mirror, so that removing the *first*
+        // style does not take the mirror away from this one.
+        const shared = elements.find(
+          (elementMap) => elementMap.mirrorHash === elHash
+        );
+
+        if (shared) {
+          elements.push({
+            original: el,
+            mirror: shared.mirror,
+            mirrorHash: elHash,
+          });
+        }
 
         return;
       }
@@ -226,16 +242,31 @@ export const CopyHostStyles = ({
 
       const { mirror, mirrorHash } = elements[index];
 
-      mirror.remove();
+      // Drop this original's claim first, so the two checks below see only the
+      // claims that survive it. Without this the entry outlives its mirror, and
+      // a re-add takes addEl's "already mirrored" branch and updates a node no
+      // longer in the document.
+      elements.splice(index, 1);
+
+      // One mirror can be shared by several identical host styles (addEl), and
+      // the initial bulk sync can produce several *distinct* mirrors that hash
+      // alike. So the node and the hash are retired independently: the node
+      // once nothing still points at it, the hash once no mirror in the frame
+      // carries that content.
+      if (!elements.some((elementMap) => elementMap.mirror === mirror)) {
+        mirror.remove();
+      }
+
       // Keyed by the mirror, matching addEl and the initial bulk sync. Hashing
       // `el` here keyed by the original, which carries no
       // data-puck-style-mirror attribute, so the delete missed and the real
       // entry survived — an identical style re-added later then looked like a
       // duplicate and was never mirrored back into the iframe.
-      delete hashes[mirrorHash];
-      // Without this the entry outlives its mirror, so a re-add takes addEl's
-      // "already mirrored" branch and updates a node no longer in the document.
-      elements.splice(index, 1);
+      if (
+        !elements.some((elementMap) => elementMap.mirrorHash === mirrorHash)
+      ) {
+        delete hashes[mirrorHash];
+      }
 
       if (debug) console.log(`Removed style node ${el.outerHTML}`);
     };


### PR DESCRIPTION
## What was wrong

`CopyHostStyles` keys its `hashes` dedupe map by the **mirror**'s `outerHTML` — the mirror carries `data-puck-style-mirror="true"`, the original does not. `addEl` and the initial bulk sync both key that way; `removeEl` computed its delete key from the **original** node, so the key never matched and the real entry survived the removal. `removeEl` also never spliced the entry out of `elements`, so a later re-add took `addEl`'s "already mirrored" branch and wrote to a mirror that had already been detached from the frame document.

Either path alone loses the style permanently. An identical `<style>` removed and then re-added on the host is never mirrored back into the frame — the ag-grid unmount/remount case in #1732. 0.22.0 reworked this to key by the mirror and two of the three sites were updated.

## What changed

`packages/core/components/AutoFrame/index.tsx`:

- `elements` entries now carry the `mirrorHash` they inserted into `hashes`, stored at insertion instead of recomputed later.
- `removeEl` deletes that stored key, and splices the entry.
- The initial bulk sync populates `hashes` from the same stored values, so all three sites share one definition of the key.
- `CopyHostStyles` is exported for the test, alongside the existing `shouldMirrorStyleElement` export used the same way. It is not re-exported from the package root.

**Deviation from the fix proposed in the issue** (which I verified does address the reported symptom): recomputing the key in `removeEl` from `elements[index].mirror.outerHTML` still leaves the general defect, because `addEl`'s update branch mutates a mirror after insertion (`elements[index].mirror.innerText = el.innerText`) and any later recompute can then produce a key that was never in `hashes`. Storing the key at insertion removes the whole class rather than this one instance. Same effect at the call site, and the `elements.splice` the issue proposes is included.

No wire, CLI or public-API change. No visual or behavioural change beyond the fix.

## How you verified

New `packages/core/components/AutoFrame/__tests__/copy-host-styles.spec.tsx`, driving the real component through `autoFrameContext` with a second document standing in for the frame:

- `re-mirrors an identical style element after it is removed and re-added` — **fails before, passes after.** With the previous `removeEl` it reads 0 mirrored styles where 1 is expected, which is the reported bug.
- `still dedupes a second, concurrently present identical style` — passes both before and after; this is the behaviour the fix must not break.

`jest components/AutoFrame`: 2 passed. Full `packages/core` suite before this change: 33 failed suites / 51 failed tests / 129 passed. After: 33 failed / 51 failed / **131 passed** — identical failure counts, +2 passing, no new failures. (Those 33 pre-existing failures are `jest is not defined` / ESM-config errors in my environment, unrelated to this change.)

`tsc --noEmit` on `packages/core`: no errors in `AutoFrame` or the new test; the 7 reported errors are pre-existing and in other files.

Fixes #1732

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*

> AGENT GENERATED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where host styles removed and later re-added were not mirrored into the frame.
  * Improved handling of duplicate styles so identical styles remain represented by a single mirrored style.
  * Ensured shared mirrored styles remain available while still referenced by other host styles.
  * Prevented stale style mappings after styles are removed, allowing subsequently added styles to be mirrored correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->