### PR TITLE
feat: add inline field placeholders

### DIFF
--- a/apps/demo/config/blocks/Card/index.tsx
+++ b/apps/demo/config/blocks/Card/index.tsx
@@ -37,10 +37,12 @@ const CardInner: ComponentConfig<CardProps> = {
     title: {
       type: "text",
       contentEditable: true,
+      placeholder: "Enter a title",
     },
     description: {
       type: "textarea",
       contentEditable: true,
+      placeholder: "Enter a title",
     },
     icon: {
       type: "select",
@@ -55,8 +57,8 @@ const CardInner: ComponentConfig<CardProps> = {
     },
   },
   defaultProps: {
-    title: "Title",
-    description: "Description",
+    title: "",
+    description: "",
     icon: "Feather",
     mode: "flat",
   },

--- a/apps/demo/config/blocks/Card/index.tsx
+++ b/apps/demo/config/blocks/Card/index.tsx
@@ -42,7 +42,7 @@ const CardInner: ComponentConfig<CardProps> = {
     description: {
       type: "textarea",
       contentEditable: true,
-      placeholder: "Enter a title",
+      placeholder: "Enter a description",
     },
     icon: {
       type: "select",

--- a/apps/demo/config/blocks/Hero/client.tsx
+++ b/apps/demo/config/blocks/Hero/client.tsx
@@ -81,7 +81,11 @@ export const Hero: ComponentConfig<{
       },
       getItemSummary: (item) => item.label,
     },
-    title: { type: "text", contentEditable: true },
+    title: {
+      type: "text",
+      contentEditable: true,
+      placeholder: "Enter a title",
+    },
     description: {
       ...heroRenderFields.description,
       contentEditable: true,
@@ -174,7 +178,7 @@ export const Hero: ComponentConfig<{
     padding: { type: "userField", option: true },
   },
   defaultProps: {
-    title: "Hero",
+    title: "",
     align: "left",
     description: "<p>Description</p>",
     buttons: [{ label: "Learn more", href: "#" }],

--- a/packages/core/components/InlineTextField/__tests__/index.spec.tsx
+++ b/packages/core/components/InlineTextField/__tests__/index.spec.tsx
@@ -30,19 +30,21 @@ jest.mock("../../../lib/overlay-portal", () => ({
 jest.mock("../styles.module.css");
 
 describe("InlineTextField", () => {
-  it("renders empty when value is null instead of the literal string 'null'", () => {
+  it("renders the placeholder as an attribute when value is empty", () => {
     const { container } = render(
       <InlineTextField
         propPath="subtitle"
         componentId="comp-1"
         value={null}
         isReadOnly={false}
+        placeholder="Enter a subtitle"
       />
     );
 
     const span = container.querySelector("span");
     expect(span).not.toBeNull();
     expect(span?.innerText ?? span?.textContent ?? "").toBe("");
+    expect(span).toHaveAttribute("data-placeholder", "Enter a subtitle");
   });
 
   it("renders empty when value is undefined instead of the literal string 'undefined'", () => {
@@ -52,6 +54,7 @@ describe("InlineTextField", () => {
         componentId="comp-1"
         value={undefined}
         isReadOnly={false}
+        placeholder="Enter a subtitle"
       />
     );
 
@@ -67,6 +70,7 @@ describe("InlineTextField", () => {
         componentId="comp-1"
         value="Hello world"
         isReadOnly={false}
+        placeholder="Enter a subtitle"
       />
     );
 

--- a/packages/core/components/InlineTextField/__tests__/index.spec.tsx
+++ b/packages/core/components/InlineTextField/__tests__/index.spec.tsx
@@ -77,4 +77,42 @@ describe("InlineTextField", () => {
     const span = container.querySelector("span");
     expect(span?.textContent).toBe("Hello world");
   });
+
+  it("normalizes empty state and shows placeholder even when filler <br> is retained", () => {
+    const { container, rerender } = render(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value="Initial"
+        isReadOnly={false}
+        placeholder="Enter a subtitle"
+      />
+    );
+
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+
+    // Simulate browser retaining a <br> filler when field is emptied by user
+    if (span) {
+      span.innerHTML = "<br>";
+    }
+
+    // Re-render with empty value to trigger normalization
+    rerender(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value=""
+        isReadOnly={false}
+        placeholder="Enter a subtitle"
+      />
+    );
+
+    // After normalization, the <br> should be removed and element should be empty
+    expect(span?.innerHTML).toBe("");
+    expect(span?.textContent ?? "").toBe("");
+    // :empty pseudo-class should now match (though we can't directly test this,
+    // the data-placeholder attribute presence confirms placeholder will render)
+    expect(span).toHaveAttribute("data-placeholder", "Enter a subtitle");
+  });
 });

--- a/packages/core/components/InlineTextField/__tests__/index.spec.tsx
+++ b/packages/core/components/InlineTextField/__tests__/index.spec.tsx
@@ -30,7 +30,7 @@ jest.mock("../../../lib/overlay-portal", () => ({
 jest.mock("../styles.module.css");
 
 describe("InlineTextField", () => {
-  it("renders the placeholder as an attribute when value is empty", () => {
+  it("renders empty when value is null instead of the literal string 'null'", () => {
     const { container } = render(
       <InlineTextField
         propPath="subtitle"
@@ -44,7 +44,6 @@ describe("InlineTextField", () => {
     const span = container.querySelector("span");
     expect(span).not.toBeNull();
     expect(span?.innerText ?? span?.textContent ?? "").toBe("");
-    expect(span).toHaveAttribute("data-placeholder", "Enter a subtitle");
   });
 
   it("renders empty when value is undefined instead of the literal string 'undefined'", () => {
@@ -61,6 +60,23 @@ describe("InlineTextField", () => {
     const span = container.querySelector("span");
     expect(span).not.toBeNull();
     expect(span?.innerText ?? span?.textContent ?? "").toBe("");
+  });
+
+  it("renders the placeholder as an attribute when value is empty", () => {
+    const { container } = render(
+      <InlineTextField
+        propPath="subtitle"
+        componentId="comp-1"
+        value={""}
+        isReadOnly={false}
+        placeholder="Enter a subtitle"
+      />
+    );
+
+    const span = container.querySelector("span");
+    expect(span).not.toBeNull();
+    expect(span?.innerText ?? span?.textContent ?? "").toBe("");
+    expect(span).toHaveAttribute("data-placeholder", "Enter a subtitle");
   });
 
   it("renders the value when it is a non-empty string", () => {

--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -49,9 +49,9 @@ const InlineTextFieldInternal = ({
       // args, so passing null/undefined renders the literal text "null"/"undefined".
       const safeValue = value ?? "";
 
-      // Normalize empty contenteditable spans to remove filler <br> nodes that
-      // browsers insert for editability (which prevent :empty from matching).
-      // Always replaceChildren when empty, not just when innerText differs.
+      // Replace when the user has edited the value or when the value is empty to
+      // remove any elements inserted by the browser that would break placeholder
+      // styling (e.g. <br>).
       if (!safeValue || safeValue !== ref.current.innerText) {
         ref.current.replaceChildren(safeValue);
       }

--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -15,12 +15,14 @@ import styles from "./styles.module.css";
 const getClassName = getClassNameFactory("InlineTextField", styles);
 
 const InlineTextFieldInternal = ({
+  placeholder,
   propPath,
   componentId,
   value,
   isReadOnly,
   opts = {},
 }: {
+  placeholder?: string;
   propPath: string;
   value: string | null | undefined;
   componentId: string;
@@ -92,6 +94,7 @@ const InlineTextFieldInternal = ({
   return (
     <span
       className={getClassName()}
+      data-placeholder={placeholder}
       ref={ref}
       contentEditable={isHovering || isFocused ? "plaintext-only" : "false"}
       onClick={(e) => {

--- a/packages/core/components/InlineTextField/index.tsx
+++ b/packages/core/components/InlineTextField/index.tsx
@@ -49,7 +49,10 @@ const InlineTextFieldInternal = ({
       // args, so passing null/undefined renders the literal text "null"/"undefined".
       const safeValue = value ?? "";
 
-      if (safeValue !== ref.current.innerText) {
+      // Normalize empty contenteditable spans to remove filler <br> nodes that
+      // browsers insert for editability (which prevent :empty from matching).
+      // Always replaceChildren when empty, not just when innerText differs.
+      if (!safeValue || safeValue !== ref.current.innerText) {
         ref.current.replaceChildren(safeValue);
       }
 

--- a/packages/core/components/InlineTextField/styles.module.css
+++ b/packages/core/components/InlineTextField/styles.module.css
@@ -18,3 +18,9 @@
 [data-dnd-dragging] .InlineTextField::selection {
   display: none;
 }
+
+.InlineTextField:empty::before {
+  content: attr(data-placeholder);
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/packages/core/lib/field-transforms/default-transforms/inline-text-transform.tsx
+++ b/packages/core/lib/field-transforms/default-transforms/inline-text-transform.tsx
@@ -11,6 +11,7 @@ export const getInlineTextTransform = (): FieldTransforms => ({
           value={value}
           opts={{ disableLineBreaks: true }}
           isReadOnly={isReadOnly}
+          placeholder={field.placeholder}
         />
       );
     }
@@ -25,6 +26,7 @@ export const getInlineTextTransform = (): FieldTransforms => ({
           componentId={componentId}
           value={value}
           isReadOnly={isReadOnly}
+          placeholder={field.placeholder}
         />
       );
     }


### PR DESCRIPTION
Closes #1795

## Description

Adds inline placeholder display for `text` and `textarea` fields when `contentEditable` is enabled. Placeholders now appear directly in the editor, using a reduced opacity to distinguish them from actual content. The placeholder is purely visual and is not saved to the component data payload.

**Approach:**
- Passes `field.placeholder` to `InlineTextField` component from the text and textarea transforms
- Uses `data-placeholder` attribute and CSS `::before` pseudo-element with `attr()` to render the placeholder text
- Applies reduced opacity (0.5) to visually indicate the placeholder is not actual content
- Inherits the current text color from the component for style consistency

## Changes made

- **InlineTextField component** (`packages/core/components/InlineTextField/index.tsx`):
  - Added optional `placeholder?: string` prop to component signature
  - Set `data-placeholder` attribute on the editable span

- **Inline text transform** (`packages/core/lib/field-transforms/default-transforms/inline-text-transform.tsx`):
  - Pass `placeholder={field.placeholder}` to `InlineTextField` in both `text` and `textarea` transforms

- **Inline text styles** (`packages/core/components/InlineTextField/styles.module.css`):
  - Added `.InlineTextField:empty::before` rule to display placeholder text with reduced opacity when the field is empty

- **InlineTextField tests** (`packages/core/components/InlineTextField/__tests__/index.spec.tsx`):
  - Updated test to verify `data-placeholder` attribute is correctly set when value is empty
  - Confirmed placeholder does not appear in the actual text content

## How to test
  - ``` yarn workspace @puckeditor/core test --runInBand components/InlineTextField/__tests__/index.spec.tsx```


##visual evidences
https://github.com/user-attachments/assets/e802e2a0-57b5-4d70-9212-355c82bc6c76


1. **Update the demo Card component** temporarily to include placeholders and empty default values:
   ```tsx
   // In apps/demo/config/blocks/Card/index.tsx
   title: {
     type: "text",
     contentEditable: true,
     placeholder: "Enter a title",
   },
   description: {
     type: "textarea",
     contentEditable: true,
     placeholder: "Enter a description",
   },
   defaultProps: {
     title: "",
     description: "",
     icon: "Feather",
     mode: "flat",
   },

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline text fields now display configured placeholder text when empty.
  * Placeholder text uses subdued styling and does not interfere with interaction.
  * Demo Card and Hero fields now provide guidance such as “Enter a title” when blank.

* **Bug Fixes**
  * Empty inline fields no longer retain browser-inserted filler content.
  * Placeholder behavior is consistent across text and textarea fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->