### PR TITLE
build: update import statement for package.json

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,4 +1,4 @@
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 import nextra from "nextra";
 
 const withNextra = nextra({


### PR DESCRIPTION
Build chore allows us to use Node 22+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package metadata imports to use the supported syntax, improving compatibility for the documentation site build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->