### PR TITLE
fix(core): populate ids for content items on initial data ingestion

### DIFF
--- a/packages/core/components/Puck/index.tsx
+++ b/packages/core/components/Puck/index.tsx
@@ -52,6 +52,7 @@ import { PrivateAppState } from "../../types/Internal";
 import { deepEqual } from "fast-equals";
 import { FieldTransforms } from "../../types/API/FieldTransforms";
 import { populateIds } from "../../lib/data/populate-ids";
+import { generateId } from "../../lib/generate-id";
 import { toComponent } from "../../lib/data/to-component";
 import { Layout } from "./components/Layout";
 import { useSafeId } from "../../lib/use-safe-id";
@@ -166,12 +167,21 @@ function PuckProvider<
       config
     );
 
+    // Content items may arrive without `props.id` (it is optional per
+    // ComponentDataOptionalId). Populate them so the node index doesn't
+    // collapse every item into a single `undefined` key, which corrupts the
+    // canvas and layer tree (every item renders as the last component).
+    const content = (initialData.content || []).map((item) => {
+      const id = item.props?.id || generateId(item.type);
+      return { ...item, props: { id, ...item.props } };
+    }) as G["UserData"]["content"];
+
     const newAppState = {
       ...defaultAppState,
       data: {
         ...initialData,
         root: { ...initialData?.root, props: root.props },
-        content: initialData.content || [],
+        content,
       },
       ui: {
         ...initial,


### PR DESCRIPTION
## Summary
Fixes https://github.com/puckeditor/puck/issues/1822 — the editor canvas renders every content item as the **last registered component** when a document is loaded with more than one item.

## Root cause
On initial data ingestion (`generateAppStore` in `components/Puck/index.tsx`), only the document **root** goes through `populateIds`. Content items may legitimately arrive without `props.id` (`ComponentDataOptionalId.props.id` is optional), and in that case every item collapses into a single `nodes["undefined"]` index entry — the last item processed wins, so the canvas renders it for every content slot. The layer tree is corrupted the same way (each item duplicated as the last type).

This does not affect documents whose items already carry `props.id`, nor the `<Render>` path (which reads `data.content` directly, not the node index).

## Fix
Populate a `props.id` for every top-level content item during initial state creation, mirroring what the `insert` action already does via `populateIds`:

```ts
const content = (initialData.content || []).map((item) => {
  const id = item.props?.id || generateId(item.type);
  return { ...item, props: { id, ...item.props } };
}) as G["UserData"]["content"];
```

Items that already have `props.id` are untouched (`...item.props` spreads after the generated id).

## Reproduction
1. Use the official `recipes/next` starter with a config of 5 components (A–E), each rendering distinct content.
2. Load a page with 5 content items `{ type: "A" ... "E", props: {} }` (no `props.id`).
3. Open the editor: the canvas renders E five times (before fix) / A,B,C,D,E (after).

Verified on `@puckeditor/core` 0.21.3, 0.22.2 and 0.23.0 with the recipe.

## Test plan
Manual repro above; `pnpm test`/lint pass locally (no test file added — happy to add a regression test if maintainers point me at the right harness for the Puck component/store).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where initial content items without IDs could cause duplicate or missing node keys.
  * Existing content IDs are now preserved, while missing IDs are generated automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->