### PR TITLE
fix: clean up unmounted hotkey handlers

### DIFF
--- a/packages/core/lib/__tests__/use-hotkey.spec.tsx
+++ b/packages/core/lib/__tests__/use-hotkey.spec.tsx
@@ -32,8 +32,7 @@ describe("monitorHotkeys", () => {
 
   beforeEach(() => {
     // The store is a module singleton, so wipe held keys and registered
-    // triggers between tests for a clean slate. `useHotkey`'s effect never
-    // removes its trigger, so this is the only reliable reset for `triggers`.
+    // triggers between tests for a clean slate.
     useHotkeyStore.setState({ held: {}, triggers: {} });
   });
 
@@ -67,6 +66,20 @@ describe("monitorHotkeys", () => {
     keydown("KeyI", { ctrlKey: true });
 
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes its trigger when the component unmounts", () => {
+    const cb = jest.fn();
+    const { unmount } = renderHook(() => useHotkey({ meta: true, i: true }, cb));
+
+    expect(useHotkeyStore.getState().triggers["meta+i"]).toBeDefined();
+
+    unmount();
+
+    expect(useHotkeyStore.getState().triggers["meta+i"]).toBeUndefined();
+    keydown("MetaLeft", { metaKey: true });
+    keydown("KeyI", { metaKey: true });
+    expect(cb).not.toHaveBeenCalled();
   });
 
   it("does not fire a meta combo when 'i' is pressed alone after meta was left stuck", () => {

--- a/packages/core/lib/use-hotkey.ts
+++ b/packages/core/lib/use-hotkey.ts
@@ -216,14 +216,25 @@ export const useMonitorHotkeys = () => {
 };
 
 export const useHotkey = (combo: KeyMapStrict, cb: Function) => {
-  useEffect(
-    () =>
-      useHotkeyStore.setState((s) => ({
-        triggers: {
-          ...s.triggers,
-          [`${Object.keys(combo).join("+")}`]: { combo, cb },
-        },
-      })),
-    []
-  );
+  useEffect(() => {
+    const triggerId = Object.keys(combo).join("+");
+    const trigger = { combo, cb };
+
+    useHotkeyStore.setState((s) => ({
+      triggers: {
+        ...s.triggers,
+        [triggerId]: trigger,
+      },
+    }));
+
+    return () => {
+      useHotkeyStore.setState((s) => {
+        // Do not remove a newer registration for the same shortcut.
+        if (s.triggers[triggerId] !== trigger) return s;
+
+        const { [triggerId]: _removed, ...triggers } = s.triggers;
+        return { triggers };
+      });
+    };
+  }, []);
 };


### PR DESCRIPTION
## Bug
useHotkey retained callbacks from unmounted components in the global trigger store.

## Fix
The hook removes only its own registration during cleanup and preserves a newer handler for the same key combination.

## Validation
git diff HEAD^ HEAD --check passed. Added unmount regression test. Jest could not run because Yarn dependency installation stopped during package fetching and did not create node_modules.

Reviewed and reproduced by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hotkey registrations persisting after the associated component is unmounted.
  - Prevented hotkey callbacks from firing after unmount.
  - Preserved newer registrations when cleaning up older ones.

- **Tests**
  - Added coverage verifying hotkey cleanup and callback behavior after unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->