### PR TITLE
fix: preserve aspect ratio for explicit viewport heights (#883)

### DIFF
--- a/packages/core/lib/__tests__/get-zoom-config.spec.ts
+++ b/packages/core/lib/__tests__/get-zoom-config.spec.ts
@@ -1,9 +1,9 @@
 import { getZoomConfig } from "../get-zoom-config";
 import type { AppState } from "../../types";
 
-// getZoomConfig reads the frame's rendered box; stub it to a fixed 800×600 preview area.
+// getZoomConfig reads the frame's rendered box; stub it to a fixed 960×800 preview area.
 jest.mock("css-box-model", () => ({
-  getBox: () => ({ contentBox: { width: 800, height: 600 } }),
+  getBox: () => ({ contentBox: { width: 960, height: 800 } }),
 }));
 
 const frame = {} as HTMLElement;
@@ -12,41 +12,96 @@ const vp = (width: Viewport["width"], height: Viewport["height"]): Viewport =>
   ({ width, height } as Viewport);
 
 describe("getZoomConfig", () => {
-  // #883: an explicit height is a concrete target, so render at actual size (both axes scroll),
-  // instead of fitting the width while the height overflows.
-  it("renders an explicit height at 1:1 with both axes scrollable (#883, Option A)", () => {
-    expect(getZoomConfig(vp(1920, 1080), frame, 1)).toEqual({
-      autoZoom: 1,
-      zoom: 1,
-      rootHeight: 1080,
+  describe("explicit height (#883)", () => {
+    // rootHeight is the unscaled height of the root, which is then multiplied by
+    // `transform: scale(zoom)`. For an explicit height it must stay at its real value so
+    // the rendered height scales by the same factor as the width (aspect ratio preserved).
+    it("fits the width and scales the height by the same factor when width is the constraint", () => {
+      const { zoom, autoZoom, rootHeight } = getZoomConfig(
+        vp(1920, 1080),
+        frame,
+        1
+      );
+
+      expect(zoom).toBeCloseTo(0.5); // 960 / 1920
+      expect(autoZoom).toBeCloseTo(0.5);
+      expect(rootHeight).toBe(1080); // renders at 1080 * 0.5 = 540px, keeping 16:9
+    });
+
+    it("fits the height and keeps the real height when height is the constraint", () => {
+      const { zoom, autoZoom, rootHeight } = getZoomConfig(
+        vp(800, 2000),
+        frame,
+        1
+      );
+
+      expect(zoom).toBeCloseTo(0.4); // 800 / 2000
+      expect(autoZoom).toBeCloseTo(0.4);
+      expect(rootHeight).toBe(2000); // renders at 2000 * 0.4 = 800px, keeping 2:5
+    });
+
+    it("fits the more constrained axis when both exceed the frame", () => {
+      const { zoom, rootHeight } = getZoomConfig(vp(1920, 3200), frame, 1);
+
+      // widthZoom = 0.5, heightZoom = 0.25 → height wins
+      expect(zoom).toBeCloseTo(0.25);
+      expect(rootHeight).toBe(3200);
+    });
+
+    it("renders 1:1 when the viewport fits within the frame", () => {
+      expect(getZoomConfig(vp(400, 300), frame, 1)).toEqual({
+        autoZoom: 1,
+        zoom: 1,
+        rootHeight: 300,
+      });
+    });
+
+    it("ignores the current zoom and recomputes from the viewport", () => {
+      // The `zoom` argument is the previous zoom; auto-fit must not depend on it.
+      const { zoom, rootHeight } = getZoomConfig(vp(1920, 1080), frame, 0.25);
+
+      expect(zoom).toBeCloseTo(0.5);
+      expect(rootHeight).toBe(1080);
+    });
+
+    it("does not auto-zoom a non-numeric width", () => {
+      expect(getZoomConfig(vp("100%", 1080), frame, 1)).toEqual({
+        autoZoom: 1,
+        zoom: 1,
+        rootHeight: 1080,
+      });
     });
   });
 
-  it("keeps an explicit height even when it is smaller than the frame", () => {
-    expect(getZoomConfig(vp(400, 300), frame, 1)).toEqual({
-      autoZoom: 1,
-      zoom: 1,
-      rootHeight: 300,
+  // Regression guard: auto-height viewports keep the existing behaviour, where the
+  // root is stretched so that it fills the frame at the auto-fitted zoom.
+  describe("auto height", () => {
+    it("auto-fits the width and stretches the root to fill the frame", () => {
+      const { zoom, autoZoom, rootHeight } = getZoomConfig(
+        vp(1920, "auto"),
+        frame,
+        1
+      );
+
+      expect(zoom).toBeCloseTo(0.5); // 960 / 1920
+      expect(autoZoom).toBeCloseTo(0.5);
+      expect(rootHeight).toBeCloseTo(1600); // frameHeight(800) / zoom(0.5)
     });
-  });
 
-  // Regression guard: auto-height viewports keep the existing auto-zoom-to-fit-width behaviour.
-  it("auto-fits the width for an auto-height viewport wider than the frame", () => {
-    const { zoom, autoZoom, rootHeight } = getZoomConfig(
-      vp(1600, "auto"),
-      frame,
-      1
-    );
-    expect(zoom).toBeCloseTo(0.5); // 800 / 1600
-    expect(autoZoom).toBeCloseTo(0.5);
-    expect(rootHeight).toBeCloseTo(1200); // viewportHeight(600) / zoom(0.5)
-  });
+    it("does not zoom a viewport that fits within the frame", () => {
+      expect(getZoomConfig(vp(400, "auto"), frame, 1)).toEqual({
+        autoZoom: 1,
+        zoom: 1,
+        rootHeight: 800,
+      });
+    });
 
-  it("does not zoom an auto-height viewport that fits within the frame", () => {
-    expect(getZoomConfig(vp(400, "auto"), frame, 1)).toEqual({
-      autoZoom: 1,
-      zoom: 1,
-      rootHeight: 600,
+    it("does not auto-zoom a non-numeric width", () => {
+      expect(getZoomConfig(vp("100%", "auto"), frame, 1)).toEqual({
+        autoZoom: 1,
+        zoom: 1,
+        rootHeight: 800,
+      });
     });
   });
 });

--- a/packages/core/lib/__tests__/get-zoom-config.spec.ts
+++ b/packages/core/lib/__tests__/get-zoom-config.spec.ts
@@ -32,7 +32,11 @@ describe("getZoomConfig", () => {
 
   // Regression guard: auto-height viewports keep the existing auto-zoom-to-fit-width behaviour.
   it("auto-fits the width for an auto-height viewport wider than the frame", () => {
-    const { zoom, autoZoom, rootHeight } = getZoomConfig(vp(1600, "auto"), frame, 1);
+    const { zoom, autoZoom, rootHeight } = getZoomConfig(
+      vp(1600, "auto"),
+      frame,
+      1
+    );
     expect(zoom).toBeCloseTo(0.5); // 800 / 1600
     expect(autoZoom).toBeCloseTo(0.5);
     expect(rootHeight).toBeCloseTo(1200); // viewportHeight(600) / zoom(0.5)

--- a/packages/core/lib/__tests__/get-zoom-config.spec.ts
+++ b/packages/core/lib/__tests__/get-zoom-config.spec.ts
@@ -1,0 +1,48 @@
+import { getZoomConfig } from "../get-zoom-config";
+import type { AppState } from "../../types";
+
+// getZoomConfig reads the frame's rendered box; stub it to a fixed 800×600 preview area.
+jest.mock("css-box-model", () => ({
+  getBox: () => ({ contentBox: { width: 800, height: 600 } }),
+}));
+
+const frame = {} as HTMLElement;
+type Viewport = AppState["ui"]["viewports"]["current"];
+const vp = (width: Viewport["width"], height: Viewport["height"]): Viewport =>
+  ({ width, height } as Viewport);
+
+describe("getZoomConfig", () => {
+  // #883: an explicit height is a concrete target, so render at actual size (both axes scroll),
+  // instead of fitting the width while the height overflows.
+  it("renders an explicit height at 1:1 with both axes scrollable (#883, Option A)", () => {
+    expect(getZoomConfig(vp(1920, 1080), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 1080,
+    });
+  });
+
+  it("keeps an explicit height even when it is smaller than the frame", () => {
+    expect(getZoomConfig(vp(400, 300), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 300,
+    });
+  });
+
+  // Regression guard: auto-height viewports keep the existing auto-zoom-to-fit-width behaviour.
+  it("auto-fits the width for an auto-height viewport wider than the frame", () => {
+    const { zoom, autoZoom, rootHeight } = getZoomConfig(vp(1600, "auto"), frame, 1);
+    expect(zoom).toBeCloseTo(0.5); // 800 / 1600
+    expect(autoZoom).toBeCloseTo(0.5);
+    expect(rootHeight).toBeCloseTo(1200); // viewportHeight(600) / zoom(0.5)
+  });
+
+  it("does not zoom an auto-height viewport that fits within the frame", () => {
+    expect(getZoomConfig(vp(400, "auto"), frame, 1)).toEqual({
+      autoZoom: 1,
+      zoom: 1,
+      rootHeight: 600,
+    });
+  });
+});

--- a/packages/core/lib/get-zoom-config.ts
+++ b/packages/core/lib/get-zoom-config.ts
@@ -15,15 +15,6 @@ export const getZoomConfig = (
   const viewportHeight =
     uiViewport.height === "auto" ? frameHeight : uiViewport.height;
 
-  // #883: When an explicit (non-"auto") height is set alongside the width, both dimensions have
-  // concrete target values (e.g. 1920×1080). Render the preview at its ACTUAL size and let the
-  // canvas scroll on both axes, instead of auto-fitting the width to the frame while the height
-  // overflows — the inconsistent mix reported in the issue. This is the reporter's preferred
-  // "Option A": explicit width + height → 1:1, both scrollable.
-  if (uiViewport.height !== "auto") {
-    return { autoZoom: 1, zoom: 1, rootHeight: viewportHeight };
-  }
-
   let rootHeight = 0;
   let autoZoom = 1;
 
@@ -37,7 +28,11 @@ export const getZoomConfig = (
     zoom = widthZoom;
 
     if (widthZoom < heightZoom) {
-      rootHeight = viewportHeight / zoom;
+      // An auto height fills the frame at any zoom. An explicit height is a
+      // target resolution, so keep its real value and let it scale with the
+      // width to preserve the aspect ratio (#883).
+      rootHeight =
+        uiViewport.height === "auto" ? viewportHeight / zoom : viewportHeight;
     } else {
       rootHeight = viewportHeight;
       zoom = heightZoom;

--- a/packages/core/lib/get-zoom-config.ts
+++ b/packages/core/lib/get-zoom-config.ts
@@ -15,6 +15,15 @@ export const getZoomConfig = (
   const viewportHeight =
     uiViewport.height === "auto" ? frameHeight : uiViewport.height;
 
+  // #883: When an explicit (non-"auto") height is set alongside the width, both dimensions have
+  // concrete target values (e.g. 1920×1080). Render the preview at its ACTUAL size and let the
+  // canvas scroll on both axes, instead of auto-fitting the width to the frame while the height
+  // overflows — the inconsistent mix reported in the issue. This is the reporter's preferred
+  // "Option A": explicit width + height → 1:1, both scrollable.
+  if (uiViewport.height !== "auto") {
+    return { autoZoom: 1, zoom: 1, rootHeight: viewportHeight };
+  }
+
   let rootHeight = 0;
   let autoZoom = 1;
 


### PR DESCRIPTION
Supersedes #1776, which was closed for inactivity and can't be reopened by the author. Addresses @FedericoBonel's review there by switching from Option A to **Option B**.

## Problem

Fixes #883.

When a custom viewport has both an explicit **width and height**, the preview scales inconsistently: the width is auto-fitted to the frame, but the height is rendered at its physical pixel value and overflows the preview. The same happens with manual zoom: zooming out shrinks the width but not the height, so the preview never reflects the target resolution.

## Fix (Option B)

`rootHeight` is the *unscaled* height of the canvas root, which is then multiplied by `transform: scale(zoom)`. Dividing it by `zoom` is correct for `height: "auto"` (the root must fill the frame at any zoom), but for an explicit height it pinned the rendered height while the width was scaled down.

An explicit height now keeps its real value, so it scales by the same factor as the width and the aspect ratio is preserved — e.g. a 1920×1080 viewport renders as 16:9 at any zoom level:

```ts
if (widthZoom < heightZoom) {
  rootHeight =
    uiViewport.height === "auto" ? viewportHeight / zoom : viewportHeight;
}
```

The existing fit-to-width auto-zoom is untouched, so there's no zoom-in behaviour, no horizontal overflow, and drag-and-drop is unaffected. Auto-height viewports are unchanged.

> Earlier revisions of this PR implemented Option A (render at actual size, both axes scrollable). That was switched to Option B per review feedback.

## Verification

Measured in the demo (frame 1484×753):

| Viewport | zoom | Rendered | Aspect | Overflow |
|---|---|---|---|---|
| 1920×1080 | 0.697 | 1339×753 | 1.778 | none |
| 4000×2000 | 0.371 | 1484×742 | 2.000 | none, both edges visible |
| 800×2000 | 0.377 | 301×753 | 0.400 | none |
| 1920×1080, manual zoom 50% / 25% | 0.5 / 0.25 | 960×540 / 480×270 | 1.778 | none |
| `auto` height (Small / Large / Full) | unchanged | unchanged | — | none |
| `auto` height, manual zoom 75% | 0.75 | 960×753 | — | "Constrain height" effect intact |

## Tests

Adds `get-zoom-config.spec.ts` (this helper was previously untested):

- explicit height, width is the constraint → fits width, `rootHeight` stays real (the fixed branch)
- explicit height, height is the constraint → fits height
- explicit height, both exceed the frame → most constrained axis wins
- explicit height within the frame → 1:1
- auto-fit ignores the previous zoom
- non-numeric width (`"100%"`) → no auto-zoom
- auto-height regression guards (fit width + stretch to frame, fits, `"100%"`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected zoom configuration for viewports with an explicitly defined height.
  - Preserved aspect-ratio scaling when zoom is limited by width.
  - Improved handling of viewport-fit behavior and invalid widths.
  - Maintained existing automatic-height behavior while ensuring zoom calculations remain independent of prior zoom settings.

- **Tests**
  - Added comprehensive coverage for zoom scaling, axis constraints, viewport fitting, invalid dimensions, and automatic-height scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->