### PR TITLE
fix: Selected Item Gets Unselected When Switching Viewports

### DIFF
--- a/packages/core/components/Puck/components/Canvas/index.tsx
+++ b/packages/core/components/Puck/components/Canvas/index.tsx
@@ -247,7 +247,8 @@ export const Canvas = () => {
 
         if (
           !el.hasAttribute("data-puck-component") &&
-          !el.hasAttribute("data-puck-dropzone")
+          !el.hasAttribute("data-puck-dropzone") &&
+          !el.closest("[data-puck-viewport-controls]")
         ) {
           dispatch({
             type: "setUi",

--- a/packages/core/components/Puck/components/Preview/index.tsx
+++ b/packages/core/components/Puck/components/Preview/index.tsx
@@ -121,7 +121,8 @@ export const Preview = ({ id = "puck-preview" }: { id?: string }) => {
 
         if (
           !el.hasAttribute("data-puck-component") &&
-          !el.hasAttribute("data-puck-dropzone")
+          !el.hasAttribute("data-puck-dropzone") &&
+          !el.closest("[data-puck-viewport-controls]")
         ) {
           dispatch({ type: "setUi", ui: { itemSelector: null } });
         }

--- a/packages/core/components/ViewportControls/index.tsx
+++ b/packages/core/components/ViewportControls/index.tsx
@@ -153,6 +153,10 @@ export const ViewportControls = ({
     <div
       className={getClassName({ isExpanded, fullScreen })}
       suppressHydrationWarning // Suppress hydration warning as frame is not visible until after load
+      onClick={(e) => {
+        // Prevent clicks from propagating to the canvas and triggering a blur event
+        e.stopPropagation();
+      }}
     >
       <div className={getClassName("actions")}>
         <div className={getClassName("actionsInner")}>
@@ -160,9 +164,7 @@ export const ViewportControls = ({
             <ViewportButton
               key={i}
               viewport={viewport}
-              onClick={(e) => {
-                e.stopPropagation();
-
+              onClick={() => {
                 setActiveViewport(viewport.width);
                 onViewportChange(viewport);
               }}
@@ -173,8 +175,7 @@ export const ViewportControls = ({
           <ActionButton
             title={zoomOutLabel}
             disabled={zoom <= zoomOptions[0]?.value}
-            onClick={(e) => {
-              e.stopPropagation();
+            onClick={() => {
               onZoom(
                 zoomOptions[
                   Math.max(
@@ -191,9 +192,7 @@ export const ViewportControls = ({
           <ActionButton
             title={zoomInLabel}
             disabled={zoom >= zoomOptions[zoomOptions.length - 1]?.value}
-            onClick={(e) => {
-              e.stopPropagation();
-
+            onClick={() => {
               onZoom(
                 zoomOptions[
                   Math.min(
@@ -213,9 +212,6 @@ export const ViewportControls = ({
             <select
               className={getClassName("zoomSelect")}
               value={zoom.toString()}
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
               onChange={(e) => {
                 onZoom(parseFloat(e.currentTarget.value));
               }}

--- a/packages/core/components/ViewportControls/index.tsx
+++ b/packages/core/components/ViewportControls/index.tsx
@@ -160,7 +160,9 @@ export const ViewportControls = ({
             <ViewportButton
               key={i}
               viewport={viewport}
-              onClick={() => {
+              onClick={(e) => {
+                e.stopPropagation();
+
                 setActiveViewport(viewport.width);
                 onViewportChange(viewport);
               }}

--- a/packages/core/components/ViewportControls/index.tsx
+++ b/packages/core/components/ViewportControls/index.tsx
@@ -153,10 +153,7 @@ export const ViewportControls = ({
     <div
       className={getClassName({ isExpanded, fullScreen })}
       suppressHydrationWarning // Suppress hydration warning as frame is not visible until after load
-      onClick={(e) => {
-        // Prevent clicks from propagating to the canvas and triggering a blur event
-        e.stopPropagation();
-      }}
+      data-puck-viewport-controls
     >
       <div className={getClassName("actions")}>
         <div className={getClassName("actionsInner")}>


### PR DESCRIPTION
Closes #1170

## Changes made

Stop event propagation on viewport button click.

## How to test

Open puck editor, select item and select viewport using viewport buttons.
