### PR TITLE
fix: add nested change tracking for component props

### DIFF
--- a/packages/core/lib/__tests__/get-changed.spec.ts
+++ b/packages/core/lib/__tests__/get-changed.spec.ts
@@ -1,0 +1,134 @@
+import { getChanged } from "../get-changed";
+
+describe("getChanged", () => {
+  it("returns empty object when newItem is undefined", () => {
+    expect(getChanged(undefined, undefined)).toEqual({});
+  });
+
+  it("returns correct diff when comparing identical items", () => {
+    const item1 = {
+      props: {
+        id: "comp-1",
+        title: "Hello",
+        nested: {
+          foo: "bar",
+        },
+      },
+    };
+    const item2 = {
+      props: {
+        id: "comp-1",
+        title: "Hello",
+        nested: {
+          foo: "bar",
+        },
+      },
+    };
+
+    expect(getChanged(item1, item2)).toEqual({});
+  });
+
+  it("returns nested dot-notation keys when nested object properties change", () => {
+    const oldItem = {
+      props: {
+        id: "comp-1",
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "original",
+              OtherString: "unchanged",
+            },
+          },
+        },
+      },
+    };
+
+    const newItem = {
+      props: {
+        id: "comp-1",
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "modified",
+              OtherString: "unchanged",
+            },
+          },
+        },
+      },
+    };
+
+    expect(getChanged(newItem, oldItem)).toEqual({
+      id: false,
+      FirstLevel: true,
+      "FirstLevel.SecondLevel": true,
+      "FirstLevel.SecondLevel.ThirdLevel": true,
+      "FirstLevel.SecondLevel.ThirdLevel.SomeString": true,
+      "FirstLevel.SecondLevel.ThirdLevel.OtherString": false,
+    });
+  });
+
+  it("returns nested keys for arrays of objects", () => {
+    const oldItem = {
+      props: {
+        id: "comp-1",
+        items: [
+          { id: "1", text: "one" },
+          { id: "2", text: "two" },
+        ],
+      },
+    };
+
+    const newItem = {
+      props: {
+        id: "comp-1",
+        items: [
+          { id: "1", text: "one modified" },
+          { id: "2", text: "two" },
+        ],
+      },
+    };
+
+    expect(getChanged(newItem, oldItem)).toEqual({
+      id: false,
+      items: true,
+      "items.[0]": true,
+      "items.[0].id": false,
+      "items.[0].text": true,
+      "items.[1]": false,
+    });
+  });
+
+  it("handles subfield at bar level matching the issue description", () => {
+    const oldItem = {
+      props: {
+        id: "comp-1",
+        foo: {
+          bar: {
+            id: "bar-1",
+            value: "original",
+          },
+        },
+      },
+    };
+
+    const newItem = {
+      props: {
+        id: "comp-1",
+        foo: {
+          bar: {
+            id: "bar-1",
+            value: "new-value",
+          },
+        },
+      },
+    };
+
+    expect(getChanged(newItem, oldItem)).toEqual({
+      id: false,
+      foo: true,
+      "foo.bar": true,
+      "foo.bar.id": false,
+      "foo.bar.value": true,
+    });
+  });
+});

--- a/packages/core/lib/__tests__/resolve-component-data.spec.tsx
+++ b/packages/core/lib/__tests__/resolve-component-data.spec.tsx
@@ -470,4 +470,162 @@ describe("resolveComponentData", () => {
     expect(movedResolution.node).toStrictEqual({});
     expect(movedResolution.didChange).toBe(false);
   });
+
+  it("should pass nested keys in changed record to resolveData when nested object properties change", async () => {
+    const customResolveData = jest.fn((data) => data);
+    const customConfig: Config = {
+      components: {
+        TestChanged: {
+          fields: {},
+          resolveData: customResolveData,
+          render: () => <div />,
+        },
+      },
+    };
+
+    const initialItem = toComponent({
+      type: "TestChanged",
+      props: {
+        id: "test-changed-1",
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "original",
+              UnchangedString: "constant",
+            },
+          },
+        },
+      },
+    });
+
+    // First resolution (initial)
+    await resolveComponentData(initialItem, customConfig);
+    expect(customResolveData).toHaveBeenCalledTimes(1);
+
+    // Second resolution: update nested property SomeString
+    const updatedItem = {
+      ...initialItem,
+      props: {
+        ...initialItem.props,
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "modified",
+              UnchangedString: "constant",
+            },
+          },
+        },
+      },
+    };
+
+    await resolveComponentData(updatedItem, customConfig);
+    expect(customResolveData).toHaveBeenCalledTimes(2);
+    expect(customResolveData.mock.calls[1][1].changed).toEqual({
+      id: false,
+      FirstLevel: true,
+      "FirstLevel.SecondLevel": true,
+      "FirstLevel.SecondLevel.ThirdLevel": true,
+      "FirstLevel.SecondLevel.ThirdLevel.SomeString": true,
+      "FirstLevel.SecondLevel.ThirdLevel.UnchangedString": false,
+    });
+  });
+
+  it("should pass nested keys in changed record to resolveData when array items change", async () => {
+    const customResolveData = jest.fn((data) => data);
+    const customConfig: Config = {
+      components: {
+        TestChanged: {
+          fields: {},
+          resolveData: customResolveData,
+          render: () => <div />,
+        },
+      },
+    };
+
+    const initialItem = toComponent({
+      type: "TestChanged",
+      props: {
+        id: "test-changed-arr",
+        items: [
+          { id: "item-1", text: "original" },
+          { id: "item-2", text: "same" },
+        ],
+      },
+    });
+
+    await resolveComponentData(initialItem, customConfig);
+    expect(customResolveData).toHaveBeenCalledTimes(1);
+
+    const updatedItem = {
+      ...initialItem,
+      props: {
+        ...initialItem.props,
+        items: [
+          { id: "item-1", text: "updated" },
+          { id: "item-2", text: "same" },
+        ],
+      },
+    };
+
+    await resolveComponentData(updatedItem, customConfig);
+    expect(customResolveData).toHaveBeenCalledTimes(2);
+    expect(customResolveData.mock.calls[1][1].changed).toEqual({
+      id: false,
+      items: true,
+      "items.[0]": true,
+      "items.[0].id": false,
+      "items.[0].text": true,
+      "items.[1]": false,
+    });
+  });
+
+  it("should pass nested keys in changed record to root resolveData when nested root props change", async () => {
+    const rootResolve = jest.fn((rootData) => rootData);
+    const customConfig: Config = {
+      root: {
+        resolveData: rootResolve,
+        render: ({ children }) => <div>{children}</div>,
+      },
+      components: {},
+    };
+
+    const initialRoot = toComponent({
+      type: "root",
+      props: {
+        title: "Site",
+        header: {
+          navigation: {
+            links: "home",
+            stay: "same",
+          },
+        },
+      },
+    });
+
+    await resolveComponentData(initialRoot, customConfig);
+    expect(rootResolve).toHaveBeenCalledTimes(1);
+
+    const updatedRoot = {
+      ...initialRoot,
+      props: {
+        ...initialRoot.props,
+        header: {
+          navigation: {
+            links: "about",
+            stay: "same",
+          },
+        },
+      },
+    };
+
+    await resolveComponentData(updatedRoot, customConfig);
+    expect(rootResolve).toHaveBeenCalledTimes(2);
+    expect(rootResolve.mock.calls[1][1].changed).toEqual({
+      title: false,
+      header: true,
+      "header.navigation": true,
+      "header.navigation.links": true,
+      "header.navigation.stay": false,
+    });
+  });
 });

--- a/packages/core/lib/data/__tests__/get-nested-diff.spec.ts
+++ b/packages/core/lib/data/__tests__/get-nested-diff.spec.ts
@@ -1,0 +1,43 @@
+import { getNestedDiff } from "../get-nested-diff";
+
+describe("get-nested-diff", () => {
+  it("returns an empty object when both objects are equal", () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 2 } };
+    expect(getNestedDiff(obj1, obj2)).toEqual({});
+  });
+
+  it("returns the correct diff for nested objects", () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 3 } };
+    expect(getNestedDiff(obj1, obj2)).toEqual({
+      a: false,
+      b: true,
+      "b.c": true,
+    });
+  });
+
+  it("returns the correct diff for arrays", () => {
+    const obj1 = { a: [1, 2, 3] };
+    const obj2 = { a: [1, 2, 4] };
+    expect(getNestedDiff(obj1, obj2)).toEqual({
+      a: true,
+      "a.[0]": false,
+      "a.[1]": false,
+      "a.[2]": true,
+    });
+  });
+
+  it("returns the correct diff for mixed types", () => {
+    const obj1 = { a: 1, b: [1, 2], c: { d: 3 } };
+    const obj2 = { a: 2, b: [1, 3], c: { d: 4 } };
+    expect(getNestedDiff(obj1, obj2)).toEqual({
+      a: true,
+      b: true,
+      "b.[0]": false,
+      "b.[1]": true,
+      c: true,
+      "c.d": true,
+    });
+  });
+});

--- a/packages/core/lib/data/get-nested-diff.ts
+++ b/packages/core/lib/data/get-nested-diff.ts
@@ -1,0 +1,60 @@
+import { deepEqual } from "fast-equals";
+import { isPlainObject } from "../is-plain-object";
+
+type NestedDiff = Record<string, boolean>;
+
+export const getNestedDiff = (
+  obj1: Record<string, any> | undefined,
+  obj2: Record<string, any> | undefined,
+  path: string = ""
+): NestedDiff => {
+  const result: NestedDiff = {};
+
+  // 1. Fast-path: Entire subtree/value is identical
+  if (deepEqual(obj1, obj2)) {
+    if (path !== "") {
+      result[path] = false;
+    }
+
+    return result;
+  }
+
+  // 2. Both are arrays (and known to be unequal)
+  if (Array.isArray(obj1) && Array.isArray(obj2)) {
+    const maxLen = Math.max(obj1.length, obj2.length);
+
+    for (let i = 0; i < maxLen; i++) {
+      const fullPath = path !== "" ? `${path}.[${i}]` : `[${i}]`;
+      Object.assign(result, getNestedDiff(obj1[i], obj2[i], fullPath));
+    }
+
+    if (path !== "") {
+      result[path] = true;
+    }
+
+    return result;
+  }
+
+  // 3. Both are plain objects (and known to be unequal)
+  if (isPlainObject(obj1) && isPlainObject(obj2)) {
+    const keys = new Set([...Object.keys(obj1), ...Object.keys(obj2)]);
+
+    for (const key of keys) {
+      const fullPath = path !== "" ? `${path}.${key}` : key;
+      Object.assign(result, getNestedDiff(obj1[key], obj2[key], fullPath));
+    }
+
+    if (path !== "") {
+      result[path] = true;
+    }
+
+    return result;
+  }
+
+  // 4. Primitive change or type mismatch (e.g., string vs number, array vs object)
+  if (path !== "") {
+    result[path] = true;
+  }
+
+  return result;
+};

--- a/packages/core/lib/get-changed.ts
+++ b/packages/core/lib/get-changed.ts
@@ -1,19 +1,16 @@
 import { ComponentData } from "../types";
-import { deepEqual } from "fast-equals";
+import { getNestedDiff } from "./data/get-nested-diff";
 
 export const getChanged = (
   newItem: Omit<Partial<ComponentData<any>>, "type"> | undefined,
   oldItem: Omit<Partial<ComponentData<any>>, "type"> | null | undefined
 ) => {
-  return newItem
-    ? Object.keys(newItem.props || {}).reduce((acc, item) => {
-        const newItemProps = newItem?.props || {};
-        const oldItemProps = oldItem?.props || {};
+  if (!newItem) {
+    return {};
+  }
 
-        return {
-          ...acc,
-          [item]: !deepEqual(oldItemProps[item], newItemProps[item]),
-        };
-      }, {})
-    : {};
+  const newItemProps = newItem?.props || {};
+  const oldItemProps = oldItem?.props || {};
+
+  return getNestedDiff(newItemProps, oldItemProps);
 };

--- a/packages/core/store/slices/__tests__/fields.spec.tsx
+++ b/packages/core/store/slices/__tests__/fields.spec.tsx
@@ -414,4 +414,120 @@ describe("fields slice", () => {
       expect(mockResolveFields).toHaveBeenCalledTimes(2);
     });
   });
+
+  it("provides correct nested keys in changed record to resolveFields when nested properties change", async () => {
+    const mockResolveFields = jest.fn().mockResolvedValue({
+      FirstLevel: {
+        type: "object",
+        objectFields: {
+          SecondLevel: {
+            type: "object",
+            objectFields: {
+              ThirdLevel: {
+                type: "object",
+                objectFields: {
+                  SomeString: { type: "text" },
+                  UnchangedString: { type: "text" },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const config: Config = {
+      components: {
+        TestChanged: {
+          fields: {},
+          render: () => <div />,
+          resolveFields: mockResolveFields,
+        },
+      },
+    };
+
+    const initialItem: ComponentData = {
+      type: "TestChanged",
+      props: {
+        id: "test-nested-1",
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "original",
+              UnchangedString: "constant",
+            },
+          },
+        },
+      },
+    };
+
+    appStore.setState({
+      ...appStore.getState(),
+      config,
+      selectedItem: initialItem,
+      state: walkAppState(
+        {
+          ...defaultAppState,
+          data: {
+            content: [initialItem],
+            root: {},
+            zones: {},
+          },
+          ui: {
+            ...defaultAppState.ui,
+            itemSelector: { index: 0 },
+          },
+        },
+        config
+      ),
+    });
+
+    renderHook(() => useRegisterFieldsSlice(appStore, "test-nested-1"));
+
+    await waitFor(() => {
+      expect(mockResolveFields).toHaveBeenCalledTimes(1);
+    });
+
+    const updatedItem: ComponentData = {
+      ...initialItem,
+      props: {
+        ...initialItem.props,
+        FirstLevel: {
+          SecondLevel: {
+            ThirdLevel: {
+              SomeString: "modified",
+              UnchangedString: "constant",
+            },
+          },
+        },
+      },
+    };
+
+    act(() => {
+      appStore.getState().dispatch({
+        type: "replace",
+        data: updatedItem,
+        destinationIndex: 0,
+        destinationZone: "root:default-zone",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockResolveFields).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockResolveFields).toHaveBeenLastCalledWith(
+      updatedItem,
+      expect.objectContaining({
+        changed: {
+          id: false,
+          FirstLevel: true,
+          "FirstLevel.SecondLevel": true,
+          "FirstLevel.SecondLevel.ThirdLevel": true,
+          "FirstLevel.SecondLevel.ThirdLevel.SomeString": true,
+          "FirstLevel.SecondLevel.ThirdLevel.UnchangedString": false,
+        },
+      })
+    );
+  });
 });

--- a/packages/core/store/slices/__tests__/permissions.spec.tsx
+++ b/packages/core/store/slices/__tests__/permissions.spec.tsx
@@ -370,6 +370,224 @@ describe("permissions slice", () => {
       expect(perms.globalTest).toBe(true);
     });
 
+    it("provides correct nested keys in changed record to component.resolvePermissions on nested changes", async () => {
+      const resolvePermissions = jest.fn().mockReturnValue({
+        resolved: true,
+      });
+
+      const config = {
+        components: {
+          MyComponent: {
+            render: () => <div />,
+            permissions: { base: true },
+            resolvePermissions,
+          },
+        },
+      };
+
+      appStore.setState({
+        config,
+        state: walkAppState(
+          {
+            ...defaultAppState,
+            data: {
+              ...defaultAppState.data,
+              content: [
+                {
+                  type: "MyComponent",
+                  props: {
+                    id: "comp-nested",
+                    FirstLevel: {
+                      SecondLevel: {
+                        ThirdLevel: {
+                          SomeString: "original",
+                          OtherString: "unchanged",
+                        },
+                      },
+                    },
+                    foo: {
+                      bar: {
+                        id: "bar-1",
+                        value: "initial",
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          config
+        ),
+      });
+
+      renderHook(() =>
+        useRegisterPermissionsSlice(appStore, { globalTest: true })
+      );
+
+      await act(async () => {
+        await appStore.getState().permissions.resolvePermissions();
+
+        const { dispatch } = appStore.getState();
+
+        dispatch({
+          type: "replace",
+          data: {
+            props: {
+              id: "comp-nested",
+              FirstLevel: {
+                SecondLevel: {
+                  ThirdLevel: {
+                    SomeString: "modified",
+                    OtherString: "unchanged",
+                  },
+                },
+              },
+              foo: {
+                bar: {
+                  id: "bar-1",
+                  value: "updated",
+                },
+              },
+            },
+            type: "MyComponent",
+          },
+          destinationIndex: 0,
+          destinationZone: rootDroppableId,
+        });
+      });
+
+      expect(resolvePermissions).toHaveBeenLastCalledWith(
+        {
+          props: {
+            id: "comp-nested",
+            FirstLevel: {
+              SecondLevel: {
+                ThirdLevel: {
+                  SomeString: "modified",
+                  OtherString: "unchanged",
+                },
+              },
+            },
+            foo: {
+              bar: {
+                id: "bar-1",
+                value: "updated",
+              },
+            },
+          },
+          type: "MyComponent",
+        },
+        expect.objectContaining({
+          changed: {
+            id: false,
+            FirstLevel: true,
+            "FirstLevel.SecondLevel": true,
+            "FirstLevel.SecondLevel.ThirdLevel": true,
+            "FirstLevel.SecondLevel.ThirdLevel.SomeString": true,
+            "FirstLevel.SecondLevel.ThirdLevel.OtherString": false,
+            foo: true,
+            "foo.bar": true,
+            "foo.bar.id": false,
+            "foo.bar.value": true,
+          },
+        })
+      );
+    });
+
+    it("provides correct nested keys in changed record to root.resolvePermissions on nested changes", async () => {
+      const mockResolvePermissions = jest.fn().mockReturnValue({
+        rootResolved: true,
+      });
+
+      const config: Config = {
+        root: {
+          render: () => <div />,
+          resolvePermissions: mockResolvePermissions,
+        },
+        components: {},
+      };
+
+      appStore.setState({
+        config,
+        state: {
+          ...defaultAppState,
+          data: {
+            content: [],
+            root: {
+              props: {
+                title: "Site",
+                nav: {
+                  item: {
+                    label: "Home",
+                    visible: true,
+                  },
+                },
+              },
+            },
+            zones: {},
+          },
+        },
+      });
+
+      renderHook(() => useRegisterPermissionsSlice(appStore, {}));
+
+      await waitFor(() => {
+        expect(mockResolvePermissions).toHaveBeenCalledTimes(1);
+        expect(appStore.getState().permissions.cache["root"]).toBeDefined();
+      });
+
+      // Update root data - auto-resolves via state.data subscription
+      appStore.setState({
+        ...appStore.getState(),
+        state: {
+          ...appStore.getState().state,
+          data: {
+            ...appStore.getState().state.data,
+            root: {
+              props: {
+                title: "Site",
+                nav: {
+                  item: {
+                    label: "Dashboard",
+                    visible: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      await waitFor(() => {
+        expect(mockResolvePermissions).toHaveBeenCalledTimes(2);
+      });
+      expect(mockResolvePermissions).toHaveBeenLastCalledWith(
+        {
+          type: "root",
+          props: {
+            id: "root",
+            title: "Site",
+            nav: {
+              item: {
+                label: "Dashboard",
+                visible: true,
+              },
+            },
+          },
+        },
+        expect.objectContaining({
+          changed: {
+            id: false,
+            title: false,
+            nav: true,
+            "nav.item": true,
+            "nav.item.label": true,
+            "nav.item.visible": false,
+          },
+        })
+      );
+    });
+
     it("updates if item changes or if force = true", async () => {
       let resolveCalls = 0;
       appStore.setState({

--- a/packages/core/types/Config.tsx
+++ b/packages/core/types/Config.tsx
@@ -7,7 +7,7 @@ import { BaseField, Field, Fields } from "./Fields";
 import { AsFieldProps, WithChildren, WithId, WithPuckProps } from "./Utils";
 import { AppState } from "./AppState";
 import { DefaultComponentProps, WithDefaultRootFieldProps } from "./Props";
-import { Permissions } from "./API";
+import { Permissions, Slot } from "./API";
 import {
   AssertHasValue,
   FieldsExtension,
@@ -43,6 +43,18 @@ type WithPartialProps<T, Props extends DefaultComponentProps> = Omit<
 
 export interface ComponentConfigExtensions {}
 
+type NestedKeyOf<T> =
+  // Skip going through Slot and ReactNode types
+  T extends Slot | ReactNode
+    ? never
+    : T extends readonly (infer ElementType)[]
+    ? `[${number}]` | `[${number}].${NestedKeyOf<ElementType>}`
+    : T extends object
+    ? {
+        [K in keyof T & string]: `${K}` | `${K}.${NestedKeyOf<T[K]>}`;
+      }[keyof T & string]
+    : never;
+
 type ComponentConfigInternal<
   RenderProps extends DefaultComponentProps,
   FieldProps extends DefaultComponentProps,
@@ -58,7 +70,9 @@ type ComponentConfigInternal<
   resolveFields?: (
     data: DataShape,
     params: {
-      changed: Partial<Record<keyof FieldProps, boolean> & { id: string }>;
+      changed: Partial<
+        Record<NestedKeyOf<FieldProps>, boolean> & { id: string }
+      >;
       fields: Fields<FieldProps>;
       lastFields: Fields<FieldProps>;
       lastData: DataShape | null;
@@ -70,7 +84,9 @@ type ComponentConfigInternal<
   resolveData?: (
     data: DataShape,
     params: {
-      changed: Partial<Record<keyof FieldProps, boolean> & { id: string }>;
+      changed: Partial<
+        Record<NestedKeyOf<FieldProps>, boolean> & { id: string }
+      >;
       lastData: DataShape | null;
       metadata: ComponentMetadata;
       trigger: ResolveDataTrigger;
@@ -83,7 +99,9 @@ type ComponentConfigInternal<
   resolvePermissions?: (
     data: DataShape,
     params: {
-      changed: Partial<Record<keyof FieldProps, boolean> & { id: string }>;
+      changed: Partial<
+        Record<NestedKeyOf<FieldProps>, boolean> & { id: string }
+      >;
       lastPermissions: Partial<Permissions>;
       permissions: Partial<Permissions>;
       appState: AppState;


### PR DESCRIPTION
Closes #629 

## Description

Previously, the `changed` record provided in `resolveData`, `resolveFields`, and `resolvePermissions` only tracked diffs at the top-level property keys. When updating subfields within nested objects or array items (such as `object` fields or custom subfields), `changed` would only indicate that the root object field had changed (e.g. `{ FirstLevel: true }`), without giving granular visibility into which subfield actually changed.

This PR introduces deep diffing via `getNestedDiff` so that nested properties and array item changes are represented with dot-notation keys (e.g., `"FirstLevel.SecondLevel.ThirdLevel.SomeString": true` or `"items.[0].value": true`), while unchanged subfields are explicitly set to `false`. TypeScript types have also been updated using a `NestedKeyOf` utility type to provide accurate types for nested keys in `changed` field param.

## Changes made

- Implemented a recursive diffing algorithm (`packages/core/lib/data/get-nested-diff.ts`) that traverses nested objects and arrays, generating dot-notation keys for changed properties and preserving `false` flags for unchanged sibling properties.
- Replaced shallow object key diffing with `getNestedDiff` in `getChanged` utility function.
- Updated `ComponentConfigInternal` in `packages/core/types/Config.tsx` so that `changed` in `resolveData`, `resolveFields`, and `resolvePermissions` includes typed dot-notation paths for nested fields.
- Added test cases for those changes in:
  - `get-nested-diff.spec.ts`
  - `get-changed.spec.ts`
  - `resolve-component-data.spec.tsx`
  - `fields.spec.tsx`
  - `permissions.spec.tsx`

## How to test

You can run `yarn test` with new test cases or manually verify.

Example setup for manual verification
```tsx
const config = {
  components: {
    TestChanged: {
      fields: {
        FirstLevel: {
          type: "object",
          objectFields: {
            SecondLevel: {
              type: "object",
              objectFields: {
                ThirdLevel: {
                  type: "object",
                  objectFields: {
                    SomeString: { type: "text" },
                    OtherString: { type: "text" },
                  },
                },
              },
            },
          },
        },
      },
      resolveData: (data, { changed }) => {
        console.log("resolveData changed:", changed);
        return data;
      },
      render: () => <p>Test</p>,
    },
  },
};
```




